### PR TITLE
make examples/nginx/uwsgi.service more systemd'ish

### DIFF
--- a/examples/nginx/uwsgi.service
+++ b/examples/nginx/uwsgi.service
@@ -2,11 +2,12 @@
 Description=uWSGI instance to serve acme2certifier
 
 [Service]
-ExecStartPre=-/usr/bin/bash -c 'mkdir -p /run/uwsgi; chown nginx /run/uwsgi'
+RuntimeDirectory=uwsgi
 ExecStart=/usr/bin/bash -c 'cd /opt/acme2certifier; uwsgi --ini acme2certifier.ini'
 Restart=always
 Type=notify
 NotifyAccess=all
+User=nginx
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Use `RuntimeDirectory=` and `User=` directives instead of creating the runtime directory manually.
This automatically takes care of the cleanup on service-shutdown, too.

P.S.: At least on arch linux, `nginx` runs under the user `http`, not `nginx`.