### PR TITLE
fix base64-parsing of dns challenge

### DIFF
--- a/acme/helper.py
+++ b/acme/helper.py
@@ -54,7 +54,7 @@ def b64_url_encode(logger, string):
     """ encode a bytestream in base64 url and remove padding """
     logger.debug('b64_url_encode()')
     encoded = base64.urlsafe_b64encode(string)
-    return encoded.rstrip("=")
+    return encoded.rstrip(b"=")
 
 def b64_url_recode(logger, string):
     """ recode base64_url to base64 """


### PR DESCRIPTION
Previous error on dns challenge (maybe a python2 vs python3 issue?):
```
  File "./acme/helper.py", line 57, in b64_url_encode
    return encoded.rstrip("=")
TypeError: a bytes-like object is required, not 'str'
```
... so we give it, what it requests for:
`return encoded.rstrip(b"=")`