### PR TITLE
redirect apache error-log to /dev/stderr

### DIFF
--- a/examples/Docker/django/Dockerfile
+++ b/examples/Docker/django/Dockerfile
@@ -32,6 +32,8 @@ RUN mkdir -p /var/www/acme2certifier/volume && \
     chown -R www-data.www-data /var/www/acme2certifier/ && \
     rm -rf /tmp/acme2certifier
 
+RUN sed -i "s/\${APACHE_LOG_DIR}\/error.log/\/dev\/stderr/g" /etc/apache2/apache2.conf
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /var/www/acme2certifier/

--- a/examples/Docker/wsgi/Dockerfile
+++ b/examples/Docker/wsgi/Dockerfile
@@ -30,6 +30,8 @@ RUN mkdir -p /var/www/acme2certifier/volume && \
     chown -R www-data.www-data /var/www/acme2certifier/ && \
     rm -rf /tmp/acme2certifier
 
+RUN sed -i "s/\${APACHE_LOG_DIR}\/error.log/\/dev\/stderr/g" /etc/apache2/apache2.conf
+
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
 WORKDIR /var/www/acme2certifier/


### PR DESCRIPTION
 error.log appear in docke logs <container>