### PR TITLE
respect RFC608 hostname in email addr verification

### DIFF
--- a/acme/helper.py
+++ b/acme/helper.py
@@ -585,7 +585,7 @@ def validate_email(logger, contact_list):
     """ validate contact against RFC608"""
     logger.debug('validate_email()')
     result = True
-    pattern = r"^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$"
+    pattern = r"^[A-Za-z0-9\.\+_-]+@[A-Za-z]+[A-Za-z0-9\._-]+[A-Za-z0-9]+\.[a-zA-Z\.]+[a-zA-Z]+$"
     # check if we got a list or single address
     if isinstance(contact_list, list):
         for contact in contact_list:


### PR DESCRIPTION
additional checks:
- the first character is a letter
- the last character is NOT a minus sign

DOES NOT check:
- max lenght of hostname (48 char) 
- length of hostname + domain/subdomain