### PR TITLE
Docker-entrypoint: minor changes

### DIFF
--- a/examples/Docker/apache2/django/docker-entrypoint.sh
+++ b/examples/Docker/apache2/django/docker-entrypoint.sh
@@ -14,8 +14,14 @@ then
     cp  /var/www/acme2certifier/examples/apache_django_ssl.conf /etc/apache2/sites-enabled/acme2certifier_ssl.conf
 fi
 
-# create ca_handler if not existing
-if [ ! -f /var/www/acme2certifier/volume/ca_handler.py ]
+# create ca_handler if:
+# - ca_handler.py does not exists in volume AND
+# - no entry hanlder_file: exists in acme_srv.cfg
+# - define ca_handler defined under handler_file does not exists
+if ( [ ! -f /var/www/acme2certifier/volume/ca_handler.py ] && \
+     ! ( grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg &> /dev/null && \
+         [ -f $(grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg | awk -F":" '{print $2}') ] \
+        ))
 then
     echo "no ca_handler.py found! creating from skeleton_ca_handler.py"
     cp /var/www/acme2certifier/examples/ca_handler/skeleton_ca_handler.py /var/www/acme2certifier/volume/ca_handler.py

--- a/examples/Docker/apache2/django/docker-entrypoint.sh
+++ b/examples/Docker/apache2/django/docker-entrypoint.sh
@@ -66,7 +66,7 @@ else
     ln -s /var/www/acme2certifier/volume/settings.py /var/www/acme2certifier/acme2certifier/settings.py
 fi
 
-chown -R www-data.www-data /var/www/acme2certifier/volume
+chown -R www-data /var/www/acme2certifier/volume
 chmod u+s /var/www/acme2certifier/volume/
 
 exec "$@"

--- a/examples/Docker/apache2/wsgi/docker-entrypoint.sh
+++ b/examples/Docker/apache2/wsgi/docker-entrypoint.sh
@@ -40,7 +40,7 @@ then
     ln -s /var/www/acme2certifier/volume/ca_handler.py /var/www/acme2certifier/acme/ca_handler.py
 fi
 
-chown -R www-data.www-data /var/www/acme2certifier/volume
+chown -R www-data /var/www/acme2certifier/volume
 chmod u+s /var/www/acme2certifier/volume/
 exec "$@"
 

--- a/examples/Docker/apache2/wsgi/docker-entrypoint.sh
+++ b/examples/Docker/apache2/wsgi/docker-entrypoint.sh
@@ -12,9 +12,16 @@ then
    cp  /var/www/acme2certifier/examples/apache_wsgi_ssl.conf /etc/apache2/sites-enabled/acme2certifier_ssl.conf
 fi 
 
-# create ca_handler if not existing
-if [ ! -f /var/www/acme2certifier/volume/ca_handler.py ] 
-then 
+# create ca_handler if:
+# - ca_handler.py does not exists in volume AND
+# - no entry hanlder_file: exists in acme_srv.cfg
+# - define ca_handler defined under handler_file does not exists
+if ( [ ! -f /var/www/acme2certifier/volume/ca_handler.py ] && \
+     ! ( grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg &> /dev/null && \
+         [ -f $(grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg | awk -F":" '{print $2}') ] \
+        ))
+then
+    echo "no ca_handler.py found! creating from skeleton_ca_handler.py"
     cp /var/www/acme2certifier/examples/ca_handler/skeleton_ca_handler.py /var/www/acme2certifier/volume/ca_handler.py
 fi
 

--- a/examples/Docker/nginx/django/docker-entrypoint.sh
+++ b/examples/Docker/nginx/django/docker-entrypoint.sh
@@ -8,17 +8,22 @@ then
 fi
 
 # enable ssl if acme2certifier_cert.pem and acme2certifier_key.pem exist on volume
-if [ -f /var/www/acme2certifier/volume/acme2certifier_cert.pem ] && [ -f /var/www/acme2certifier/volume/acme2certifier_key.pem ]
+if  [ -f /var/www/acme2certifier/volume/acme2certifier_cert.pem ] && \
+    [ -f /var/www/acme2certifier/volume/acme2certifier_key.pem ] && \
+    [ ! -f /etc/nginx/sites-available/acme_ssl.conf ]
 then
-    if [ ! -f /etc/nginx/sites-available/acme_ssl.conf ]
-    then
-        cp  /var/www/acme2certifier/examples/nginx/nginx_acme_ssl.conf /etc/nginx/sites-available/acme_ssl.conf
-        ln -s /etc/nginx/sites-available/acme_ssl.conf /etc/nginx/sites-enabled/acme_ssl.conf
-    fi
+    cp  /var/www/acme2certifier/examples/nginx/nginx_acme_ssl.conf /etc/nginx/sites-available/acme_ssl.conf
+    ln -s /etc/nginx/sites-available/acme_ssl.conf /etc/nginx/sites-enabled/acme_ssl.conf
 fi
 
-# create ca_handler if not existing
-if [ ! -f /var/www/acme2certifier/volume/ca_handler.py ]
+# create ca_handler if:
+# - ca_handler.py does not exists in volume AND
+# - no entry hanlder_file: exists in acme_srv.cfg
+# - define ca_handler defined under handler_file does not exists
+if ( [ ! -f /var/www/acme2certifier/volume/ca_handler.py ] && \
+     ! ( grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg &> /dev/null && \
+         [ -f $(grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg | awk -F":" '{print $2}') ] \
+        ))
 then
     echo "no ca_handler.py found! creating from skeleton_ca_handler.py"
     cp /var/www/acme2certifier/examples/ca_handler/skeleton_ca_handler.py /var/www/acme2certifier/volume/ca_handler.py

--- a/examples/Docker/nginx/django/docker-entrypoint.sh
+++ b/examples/Docker/nginx/django/docker-entrypoint.sh
@@ -69,7 +69,7 @@ else
     ln -s /var/www/acme2certifier/volume/settings.py /var/www/acme2certifier/acme2certifier/settings.py
 fi
 
-chown -R www-data.www-data /var/www/acme2certifier/volume
+chown -R www-data /var/www/acme2certifier/volume
 chmod u+s /var/www/acme2certifier/volume/
 
 exec "$@"

--- a/examples/Docker/nginx/wsgi/docker-entrypoint.sh
+++ b/examples/Docker/nginx/wsgi/docker-entrypoint.sh
@@ -44,6 +44,6 @@ then
     ln -s /var/www/acme2certifier/volume/ca_handler.py /var/www/acme2certifier/acme/ca_handler.py
 fi
 
-chown -R www-data.www-data /var/www/acme2certifier/volume
+chown -R www-data /var/www/acme2certifier/volume
 chmod u+s /var/www/acme2certifier/volume/
 exec "$@"

--- a/examples/Docker/nginx/wsgi/docker-entrypoint.sh
+++ b/examples/Docker/nginx/wsgi/docker-entrypoint.sh
@@ -3,22 +3,29 @@
 # create acme-srv.cfg if not existing
 if [ ! -f /var/www/acme2certifier/volume/acme_srv.cfg ]
 then
+    echo "no acme_srv.cfg found! creating acme_srv.cfg"
     cp /var/www/acme2certifier/examples/acme_srv.cfg /var/www/acme2certifier/volume/
 fi
 
 # enable ssl if acme2certifier_cert.pem and acme2certifier_key.pem exist on volume
-if [ -f /var/www/acme2certifier/volume/acme2certifier_cert.pem ] && [ -f /var/www/acme2certifier/volume/acme2certifier_key.pem ]
+if  [ -f /var/www/acme2certifier/volume/acme2certifier_cert.pem ] && \
+    [ -f /var/www/acme2certifier/volume/acme2certifier_key.pem ] && \
+    [ ! -f /etc/nginx/sites-available/acme_ssl.conf ]
 then
-   if [ ! -f /etc/nginx/sites-available/acme_ssl.conf ]
-   then
-     cp  /var/www/acme2certifier/examples/nginx/nginx_acme_ssl.conf /etc/nginx/sites-available/acme_ssl.conf
-     ln -s /etc/nginx/sites-available/acme_ssl.conf /etc/nginx/sites-enabled/acme_ssl.conf
-   fi
+    cp  /var/www/acme2certifier/examples/nginx/nginx_acme_ssl.conf /etc/nginx/sites-available/acme_ssl.conf
+    ln -s /etc/nginx/sites-available/acme_ssl.conf /etc/nginx/sites-enabled/acme_ssl.conf
 fi
 
-# create ca_handler if not existing
-if [ ! -f /var/www/acme2certifier/volume/ca_handler.py ]
+# create ca_handler if:
+# - ca_handler.py does not exists in volume AND
+# - no entry hanlder_file: exists in acme_srv.cfg
+# - define ca_handler defined under handler_file does not exists
+if ( [ ! -f /var/www/acme2certifier/volume/ca_handler.py ] && \
+     ! ( grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg &> /dev/null && \
+         [ -f $(grep -E '^handler_file:' /var/www/acme2certifier/volume/acme_srv.cfg | awk -F":" '{print $2}') ] \
+        ))
 then
+    echo "no ca_handler.py found! creating from skeleton_ca_handler.py"
     cp /var/www/acme2certifier/examples/ca_handler/skeleton_ca_handler.py /var/www/acme2certifier/volume/ca_handler.py
 fi
 


### PR DESCRIPTION
- don't overwrite group ownership for volume folder
- don't copy ca_handler file if a valid ca_handler was defined under handler_file in acme_srv.cfg