### PR TITLE
Allow setting config file location with environment variable

### DIFF
--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -375,8 +375,13 @@ def get_url(environ, include_path=False):
         result = '{0}://{1}'.format(proto, server_name)
     return result
 
-def load_config(logger=None, mfilter=None, cfg_file=os.path.dirname(__file__)+'/'+'acme_srv.cfg'):
+def load_config(logger=None, mfilter=None, cfg_file=None):
     """ small configparser wrappter to load a config file """
+    if not cfg_file:
+        if 'ACME_SRV_CONFIGFILE' in os.environ:
+            cfg_file = os.environ['ACME_SRV_CONFIGFILE']
+        else:
+            cfg_file = os.path.dirname(__file__) + '/' + 'acme_srv.cfg'
     if logger:
         logger.debug('load_config({1}:{0})'.format(mfilter, cfg_file))
     config = configparser.RawConfigParser()


### PR DESCRIPTION
Me again :-)

As there is currently no way to specify a config file location to the whole package, I propose this small change to allow reading the config file location from an environment variable. If the environment variable is not present, it reverts to the previous behavior.