### PR TITLE
Implement new Hooks feature

### DIFF
--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -163,6 +163,29 @@ def eab_handler_load(logger, config_dic):
     return eab_handler_module
 
 
+def hooks_load(logger, config_dic):
+    """ load and return hooks """
+    logger.debug('Helper.hooks_load()')
+
+    hooks_module = None
+    if 'Hooks' in config_dic and 'hooks_file' in config_dic['Hooks']:
+        # try to load hooks from file
+        try:
+            spec = importlib.util.spec_from_file_location('Hooks', config_dic['Hooks']['hooks_file'])
+            hooks_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(hooks_module)
+        except Exception as err_:
+            logger.critical('Helper.hooks_load(): loading Hooks configured in cfg failed with err: {0}'.format(err_))
+
+    if hooks_module is None:
+        try:
+            hooks_module = importlib.import_module('acme_srv.hooks')
+        except Exception as err_:
+            logger.critical('Helper.hooks_load(): loading default Hooks failed with err: {0}'.format(err_))
+
+    return hooks_module
+
+
 def cert_dates_get(logger, certificate):
     """ get serial number form certificate """
     logger.debug('cert_dates_get()')

--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -101,16 +101,6 @@ def build_pem_file(logger, existing, certificate, wrap, csr=False):
     return pem_file
 
 
-def ca_handler_get(logger, ca_handler_name):
-    """ turn handler-filename into a python path """
-    logger.debug('Certificate._ca_handler_get({0})'.format(ca_handler_name))
-    ca_handler_name = ca_handler_name.rstrip('.py')
-    ca_handler_name = ca_handler_name.replace('/', '.')
-    ca_handler_name = ca_handler_name.replace('\\', '.')
-    logger.debug('Certificate._ca_handler_get() ended with: {0}'.format(ca_handler_name))
-    return ca_handler_name
-
-
 def ca_handler_load(logger, config_dic):
     """ load and return ca_handler """
     logger.debug('Helper.ca_handler_load()')

--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -105,29 +105,26 @@ def ca_handler_load(logger, config_dic):
     """ load and return ca_handler """
     logger.debug('Helper.ca_handler_load()')
 
-    if 'CAhandler' in config_dic and 'handler_file' in config_dic['CAhandler']:
+    if 'CAhandler' not in config_dic:
+        logger.error('Helper.ca_handler_load(): CAhandler configuration missing in config file')
+        return None
+
+    if 'handler_file' in config_dic['CAhandler']:
         # try to load handler from file
         try:
             spec = importlib.util.spec_from_file_location('CAhandler', config_dic['CAhandler']['handler_file'])
             ca_handler_module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(ca_handler_module)
+            return ca_handler_module
         except Exception as err_:
             logger.critical('Helper.ca_handler_load(): loading CAhandler configured in cfg failed with err: {0}'.format(err_))
-            try:
-                ca_handler_module = importlib.import_module('acme_srv.ca_handler')
-            except Exception as err_:
-                ca_handler_module = None
-                logger.critical('Helper.ca_handler_load(): loading default CAhandler failed with err: {0}'.format(err_))
-    else:
-        if 'CAhandler' in config_dic:
-            try:
-                ca_handler_module = importlib.import_module('acme_srv.ca_handler')
-            except Exception as err_:
-                logger.critical('Helper.ca_handler_load(): loading default CAhandler failed with err: {0}'.format(err_))
-                ca_handler_module = None
-        else:
-            logger.error('Helper.ca_handler_load(): CAhandler configuration missing in config file')
-            ca_handler_module = None
+
+    # if no 'handler_file' provided or loading was unsuccessful, try to load default handler
+    try:
+        ca_handler_module = importlib.import_module('acme_srv.ca_handler')
+    except Exception as err_:
+        logger.critical('Helper.ca_handler_load(): loading default CAhandler failed with err: {0}'.format(err_))
+        ca_handler_module = None
 
     return ca_handler_module
 

--- a/acme_srv/hooks.py
+++ b/acme_srv/hooks.py
@@ -1,0 +1,44 @@
+class Hooks:
+    """
+    This class provides three different methods:
+    - pre_hook (run before obtaining any certificates)
+    - post_hook (run after *attempting* to obtain/renew certificates; runs regardless of whether
+      obtain/renew succeeded or failed)
+    - success_hook (run after each successfully renewed certificate)
+
+    Each method should throw an Exception if an unrecoverable error occurs.
+
+    This class contains dummy implementations of these hooks. To actually use hooks, create a
+    subclass and overwrite one or multiple of the methods.
+    """
+
+    def __init__(self, logger) -> None:
+        self.logger = logger
+
+    def pre_hook(
+        self,
+        certificate_name,
+        order_name,
+        csr,
+    ):
+        pass
+
+    def post_hook(
+        self,
+        certificate_name,
+        order_name,
+        csr,
+        error,
+    ):
+        pass
+
+    def success_hook(
+        self,
+        certificate_name,
+        order_name,
+        csr,
+        certificate,
+        certificate_raw,
+        poll_identifier,
+    ):
+        pass

--- a/acme_srv/trigger.py
+++ b/acme_srv/trigger.py
@@ -3,10 +3,9 @@
 """ Challenge class """
 from __future__ import print_function
 import json
-import importlib
 from acme_srv.certificate import Certificate
 from acme_srv.db_handler import DBstore
-from acme_srv.helper import convert_byte_to_string, cert_pubkey_get, csr_pubkey_get, cert_der2pem, b64_decode, load_config, ca_handler_get
+from acme_srv.helper import convert_byte_to_string, cert_pubkey_get, csr_pubkey_get, cert_der2pem, b64_decode, load_config, ca_handler_load
 
 
 class Trigger(object):
@@ -56,23 +55,8 @@ class Trigger(object):
         config_dic = load_config()
         if 'Order' in config_dic:
             self.tnauthlist_support = config_dic.getboolean('Order', 'tnauthlist_support', fallback=False)
-        if 'CAhandler' in config_dic and 'handler_file' in config_dic['CAhandler']:
-            try:
-                ca_handler_module = importlib.import_module(ca_handler_get(self.logger, config_dic['CAhandler']['handler_file']))
-            except Exception as err_:
-                self.logger.critical('Certificate._config_load(): loading CAhandler configured in cfg failed with err: {0}'.format(err_))
-                try:
-                    ca_handler_module = importlib.import_module('acme_srv.ca_handler')
-                except Exception as err_:
-                    ca_handler_module = None
-                    self.logger.critical('Certificate._config_load(): loading default CAhandler failed with err: {0}'.format(err_))
-        else:
-            if 'CAhandler' in config_dic:
-                ca_handler_module = importlib.import_module('acme_srv.ca_handler')
-            else:
-                self.logger.error('Trigger._config_load(): CAhandler configuration missing in config file')
-                ca_handler_module = None
 
+        ca_handler_module = ca_handler_load(self.logger, config_dic)
         if ca_handler_module:
             # store handler in variable
             try:

--- a/docs/acme_srv.md
+++ b/docs/acme_srv.md
@@ -24,6 +24,7 @@
 | `Directory` | `tos_url` | Terms of Service URL | URL | None|
 | `Directory` | `url_prefix` | url prefix for acme2certifier resources | '/foo' | None|
 | `Helper` | `log_format` | Format of logging information | check the 'LogRecord attributes' Section of the [python logging module](https://docs.python.org/3/library/logging.html)| `%(message)s`|
+| `Hooks` | `hooks_file` | path and name of hooks (for pre- and post-enrollment hooks) file to be loaded; if not specified, `acme_srv/hooks.py` will be loaded |  | `acme_srv/hooks.py`|
 | `Message`| `signature_check_disable` | disable signature check of incoming JWS messages. THIS IS A SEVERE SECURITY ISSUE bypassing security checks and allowing message manipulations during transit. Please enable for testing/debugging purposes only. | True/False | False|
 | `Nonce`| `nonce_check_disable` | disable nonce check. THIS IS A SECURITY ISSUE as it exposes the API for replay attacks! Should be enabled for testing/debugging purposes only. | True/False | False|
 | `Order` | `expiry_check_disable` | Disable order expiration  | True/False | False|
@@ -32,6 +33,8 @@
 | `Order` | `validity` | Order validity in seconds | Integer |86400|
 
 The options for the `CAhandler` section depend on the CA handler.
+
+Further options for the `Hooks` section depend on the concrete hooks class.
 
 Instructions for [Insta Certifier](certifier.md)
 

--- a/docs/acme_srv.md
+++ b/docs/acme_srv.md
@@ -13,25 +13,25 @@
 | `Account` | `tos_check_disable` | turn off "Terms of Service" acceptance check  | True/False | False|
 | `Authorization` | `expiry_check_disable` | Disable authorization expiration  | True/False | False|
 | `Authorization` | `validity` | authorization validity in seconds  | Integer |86400|
-| `CAhandler` | `handler_file` | path and name of ca_handler file to be loaded. If not specified `acme_srv/ca_handler.py` will be loaded | examples/ca_handler/openssl_hander.py | `acme_srv/ca_handler.py`|
-| `DBhandler` | `dbfile` | path and name of dabase file. If not specified `acme_srv/acme_srv.db` will be used. Parameter is only available for a wsgi handler and will be ignored if django handler is getting used | 'acme/databse.db' | `acme_srv/acme_srv.db`|
+| `CAhandler` | `handler_file` | path and name of ca_handler file to be loaded. If not specified `acme_srv/ca_handler.py` will be loaded | examples/ca_handler/openssl_handler.py | `acme_srv/ca_handler.py`|
 | `Certificate` | `revocation_reason_check_disable` | disable the check of revocation reason | True/False | False|
 | `Certificate` | `cert_reusage_timeframe` | in case a csr will be resend within this timeframe (in seconds) the  certificate already stored in the database will be returned and no enrollment will be triggered| Integer |0 (disabled)|
 | `Certificate` | `enrollment_timeout` | timeout in second for asynchronous ca_handler threat| Integer |5|
 | `Challenge` | `challenge_validation_disable` | disable challenge validation via http or dns. THIS IS A SEVERE SECURITY ISSUE! Please enable for testing/debugging purposes only. | True/False | False|
 | `Challenge` | `dns_server_list` | Use own dns servers for name resolution during challenge verification| ["ip1", "ip2"] | []|
+| `DBhandler` | `dbfile` | path and name of database file. If not specified `acme_srv/acme_srv.db` will be used. Parameter is only available for a wsgi handler and will be ignored if django handler is getting used | 'acme/database.db' | `acme_srv/acme_srv.db`|
 | `Directory` | `supress_version` | Do not show version information when fetching the directory resource | True/False | False|
 | `Directory` | `tos_url` | Terms of Service URL | URL | None|
-| `Directory` | `url_prefix` | url prefix for acme2certifier ressources | '/foo' | None|
+| `Directory` | `url_prefix` | url prefix for acme2certifier resources | '/foo' | None|
 | `Helper` | `log_format` | Format of logging information | check the 'LogRecord attributes' Section of the [python logging module](https://docs.python.org/3/library/logging.html)| `%(message)s`|
-| `Message`| `signature_check_disable` | disable signature check of incoming JWS messages. THIS IS A SEVERE SECURTIY ISSUE bypassing security checks and allowing message manipulations during transit. Please enable for testing/debugging purposes only. | True/False | False|
-| `Nonce`| `nonce_check_disable` | disable nonce check. THIS IS A SECURTIY ISSUE as it exposes the API for replay attacks! Should be enabled for testing/debugging purposes only. | True/False | False|
+| `Message`| `signature_check_disable` | disable signature check of incoming JWS messages. THIS IS A SEVERE SECURITY ISSUE bypassing security checks and allowing message manipulations during transit. Please enable for testing/debugging purposes only. | True/False | False|
+| `Nonce`| `nonce_check_disable` | disable nonce check. THIS IS A SECURITY ISSUE as it exposes the API for replay attacks! Should be enabled for testing/debugging purposes only. | True/False | False|
 | `Order` | `expiry_check_disable` | Disable order expiration  | True/False | False|
 | `Order` | `retry_after_timeout` | Retry-After value to be send to client in case a certificate enrollment request gets pending on CA server  | Integer |120|
 | `Order` | [`tnauthlist_support`](tnauthlist.md) | accept [TNAuthList identifiers](https://tools.ietf.org/html/draft-ietf-acme-authority-token-tnauthlist-03) and challenges containing [tkauth-01 type](https://tools.ietf.org/html/draft-ietf-acme-authority-token-03) | True/False | False|
 | `Order` | `validity` | Order validity in seconds | Integer |86400|
 
-The options for the `CAHandler` section depend on the CA handler.
+The options for the `CAhandler` section depend on the CA handler.
 
 Instructions for [Insta Certifier](certifier.md)
 

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -34,6 +34,8 @@ class TestACMEHandler(unittest.TestCase):
         from acme_srv.certificate import Certificate
         self.account = Account(False, 'http://tester.local', self.logger)
         self.certificate = Certificate(False, 'http://tester.local', self.logger)
+        hooks_module = importlib.import_module('acme_srv.hooks')
+        self.certificate.hooks = hooks_module.Hooks(self.logger)
 
     @patch('acme_srv.certificate.generate_random_string')
     def test_001_certificate_store_csr(self, mock_name):

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -29,7 +29,7 @@ class TestACMEHandler(unittest.TestCase):
         patch.dict('sys.modules', modules).start()
         import logging
         logging.basicConfig(level=logging.CRITICAL)
-        from acme_srv.helper import b64decode_pad, b64_decode, b64_encode, b64_url_encode, b64_url_recode, ca_handler_get, convert_string_to_byte, convert_byte_to_string, decode_message, decode_deserialize, get_url, generate_random_string, signature_check, validate_email, uts_to_date_utc, date_to_uts_utc, load_config, cert_serial_get, cert_san_get, cert_dates_get, build_pem_file, date_to_datestr, datestr_to_date, dkeys_lower, csr_cn_get, cert_pubkey_get, csr_pubkey_get, url_get, url_get_with_own_dns,  dns_server_list_load, csr_san_get, csr_extensions_get, fqdn_resolve, fqdn_in_san_check, sha256_hash, sha256_hash_hex, cert_der2pem, cert_pem2der, cert_extensions_get, csr_dn_get, logger_setup, logger_info, print_debug, jwk_thumbprint_get, allowed_gai_family, patched_create_connection, validate_csr, servercert_get, txt_get, proxystring_convert, proxy_check, handle_exception, ca_handler_load, eab_handler_load
+        from acme_srv.helper import b64decode_pad, b64_decode, b64_encode, b64_url_encode, b64_url_recode, convert_string_to_byte, convert_byte_to_string, decode_message, decode_deserialize, get_url, generate_random_string, signature_check, validate_email, uts_to_date_utc, date_to_uts_utc, load_config, cert_serial_get, cert_san_get, cert_dates_get, build_pem_file, date_to_datestr, datestr_to_date, dkeys_lower, csr_cn_get, cert_pubkey_get, csr_pubkey_get, url_get, url_get_with_own_dns,  dns_server_list_load, csr_san_get, csr_extensions_get, fqdn_resolve, fqdn_in_san_check, sha256_hash, sha256_hash_hex, cert_der2pem, cert_pem2der, cert_extensions_get, csr_dn_get, logger_setup, logger_info, print_debug, jwk_thumbprint_get, allowed_gai_family, patched_create_connection, validate_csr, servercert_get, txt_get, proxystring_convert, proxy_check, handle_exception, ca_handler_load, eab_handler_load
         self.logger = logging.getLogger('test_a2c')
         self.allowed_gai_family = allowed_gai_family
         self.b64_decode = b64_decode
@@ -38,7 +38,6 @@ class TestACMEHandler(unittest.TestCase):
         self.b64_url_recode = b64_url_recode
         self.b64decode_pad = b64decode_pad
         self.build_pem_file = build_pem_file
-        self.ca_handler_get = ca_handler_get
         self.ca_handler_load = ca_handler_load
         self.cert_dates_get = cert_dates_get
         self.cert_extensions_get = cert_extensions_get
@@ -877,26 +876,6 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         """ get issuing and expiration date ecc certificate """
         cert = 'MIIDozCCAYugAwIBAgIIMMxkE7mRR+YwDQYJKoZIhvcNAQELBQAwKjEXMBUGA1UECxMOYWNtZTJjZXJ0aWZpZXIxDzANBgNVBAMTBnN1Yi1jYTAeFw0yMDA3MTEwNDUzMTFaFw0yMTA3MTEwNDUzMTFaMBkxFzAVBgNVBAMMDmZvbzEuYmFyLmxvY2FsMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER/KMoV5+zQgegqYue2ztPK2nZVpK2vxb02UzwyHw4ebhJ2gBobI23lSBRa1so1ug0kej7U+ohm5aGFdNxLM0G6OBqDCBpTALBgNVHQ8EBAMCBeAwGQYDVR0RBBIwEIIOZm9vMS5iYXIubG9jYWwwHQYDVR0OBBYEFCSaU743wU8jMETIO381r13tVLdMMA4GA1UdDwEB/wQEAwIFoDAfBgNVHSMEGDAWgBS/3o6OBiIiq61DyN3UT6irSEE+1TAMBgNVHRMBAf8EAjAAMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATANBgkqhkiG9w0BAQsFAAOCAgEAmmhHuBhXNM2Azv53rCKY72yTQIoDVHjYrAvTmS6NsJzYflEOMkI7FCes64dWp54BerSD736Yax67b4XmLXc/+T41d7QAcnhY5xvLJiMpSsW37icHcLZpjlOrYDoRmny2U7n6t1aQ03nwgV+BgdaUQYLkUZuczs4kdqH1c9Ot9CCRTHpqSWlmWzGeRgt2uT4gKhFESP9lzx37YwKBHulBGthv1kcAaz8w8iPXBg01OEDiraXCBZFoYDEpDi2w2Y6ChCr7sNsY7aJ3a+2iHGYlktXEntk78S+g00HW61G9oLoRgeqEH3L6qVIpnswPAU/joub0YhNBIUFenCj8c3HMBgMcczzdZL+qStdymhpVkZetzXtMTKtgmxhkRzAOQUBBcHFc+wM97FqC0S4HJAuoHQ4EJ46MxwZH0jBVqcqCPMSaJ88uV902+VGGXrnxMR8RbGWLoCmsYb1ISmBUt+31PjMCYbXKwLmzvbRpO7XAQimvtOqoufl5yeRUJRLcUS6Let0QzU196/nZ789d7Etep7RjDYQm7/QhiWH197yKZ5/mUxqfyHDQ3hk5iX7S/gbo1jQXElEv5tB8Ozs+zVQmB2bXpN8c+8XUaZnwvYC2y+0LAQN4z7xilReCaasxQSsEOLCrlsannkGV704HYnnaKBS2tI948QotHnADHdfHl3o'
         self.assertEqual((1594443191, 1625979191), self.cert_dates_get(self.logger, cert))
-
-    def test_121_helper_ca_handler_get(self):
-        """ identifier check none input"""
-        file_name = 'foo'
-        self.assertEqual('foo', self.ca_handler_get(self.logger, file_name))
-
-    def test_122_helper_ca_handler_get(self):
-        """ identifier check none input"""
-        file_name = 'foo.py'
-        self.assertEqual('foo', self.ca_handler_get(self.logger, file_name))
-
-    def test_123_helper_ca_handler_get(self):
-        """ identifier check none input"""
-        file_name = 'foo/foo.py'
-        self.assertEqual('foo.foo', self.ca_handler_get(self.logger, file_name))
-
-    def test_124_helper_ca_handler_get(self):
-        """ identifier check none input"""
-        file_name = 'foo\\foo.py'
-        self.assertEqual('foo.foo', self.ca_handler_get(self.logger, file_name))
 
     @patch('dns.resolver.Resolver')
     def test_125_helper_fqdn_resolve(self, mock_resolve):

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -277,7 +277,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_load_cfg.return_value = {}
         with self.assertLogs('test_a2c', level='INFO') as lcm:
             self.trigger._config_load()
-        self.assertIn('ERROR:test_a2c:Trigger._config_load(): CAhandler configuration missing in config file', lcm.output)
+        self.assertIn('ERROR:test_a2c:Helper.ca_handler_load(): CAhandler configuration missing in config file', lcm.output)
 
     @patch('acme_srv.trigger.Trigger._config_load')
     def test_023__enter__(self, mock_cfg):
@@ -295,7 +295,7 @@ class TestACMEHandler(unittest.TestCase):
         with self.assertLogs('test_a2c', level='INFO') as lcm:
             self.trigger._config_load()
         self.assertFalse(self.trigger.tnauthlist_support)
-        self.assertIn('ERROR:test_a2c:Trigger._config_load(): CAhandler configuration missing in config file', lcm.output)
+        self.assertIn('ERROR:test_a2c:Helper.ca_handler_load(): CAhandler configuration missing in config file', lcm.output)
 
     @patch('acme_srv.trigger.load_config')
     def test_025_config_load(self, mock_load_cfg):
@@ -305,7 +305,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_load_cfg.return_value = parser
         with self.assertLogs('test_a2c', level='INFO') as lcm:
             self.trigger._config_load()
-        self.assertIn("CRITICAL:test_a2c:Certificate._config_load(): loading CAhandler configured in cfg failed with err: No module named 'foo'", lcm.output)
+        self.assertIn("CRITICAL:test_a2c:Helper.ca_handler_load(): loading CAhandler configured in cfg failed with err: 'NoneType' object has no attribute 'loader'", lcm.output)
 
     @patch('importlib.import_module')
     @patch('acme_srv.trigger.load_config')


### PR DESCRIPTION
Add a `Hooks` class, which provides three different methods:
- pre_hook (run before obtaining any certificates)
- post_hook (run after *attempting* to obtain/renew certificates; runs regardless of whether
  obtain/renew succeeded or failed)
- success_hook (run after each successfully renewed certificate)

Each method should throw an Exception if an unrecoverable error occurs.

This class contains dummy implementations of these hooks. To actually use hooks, one should create a
subclass and overwrite one or multiple of the methods. The class file can be configured through the `Hooks`
section with parameter `hooks_file` in the config file.

I'm not 100% sure about the intended behavior if one of the hooks fails, please let me know what you think about that, @grindsa.

Closes #87 

/cc @grindsa @flphrrr