### PR TITLE
Rate-limiting and identifier sanitizing

### DIFF
--- a/.github/workflows/upgrade_tests..yml
+++ b/.github/workflows/upgrade_tests..yml
@@ -713,6 +713,7 @@ jobs:
         docker exec acme-srv tar cvfz /tmp/acme2certifier/a2c.tgz /opt/acme2certifier
         docker exec acme-srv tar cvfz /tmp/acme2certifier/nginx.tgz /etc/nginx
         sudo cp -rp data/ ${{ github.workspace }}/artifact/data/
+        sudo rm ${{ github.workspace }}/artifact/data/*.rpm
         sudo cp -rp acme-sh/ ${{ github.workspace }}/artifact/acme-sh/
         docker exec acme-srv cat /var/log/messages > ${{ github.workspace }}/artifact/acme-srv.log
         sudo tar -C ${{ github.workspace }}/artifact/ -cvzf ${{ github.workspace }}/artifact/upload/artifact.tar.gz data acme-srv.log acme-sh
@@ -896,6 +897,7 @@ jobs:
         docker exec acme-srv tar cvfz /tmp/acme2certifier/a2c.tgz /opt/acme2certifier
         docker exec acme-srv tar cvfz /tmp/acme2certifier/nginx.tgz /etc/nginx
         sudo cp -rp data/ ${{ github.workspace }}/artifact/data/
+        sudo rm ${{ github.workspace }}/artifact/data/*.rpm
         sudo cp -rp acme-sh/ ${{ github.workspace }}/artifact/acme-sh/
         docker exec acme-srv cat /var/log/messages > ${{ github.workspace }}/artifact/acme-srv.log
         sudo tar -C ${{ github.workspace }}/artifact/ -cvzf ${{ github.workspace }}/artifact/upload/artifact.tar.gz data acme-srv.log acme-sh
@@ -1061,6 +1063,7 @@ jobs:
         docker exec acme-srv tar cvfz /tmp/acme2certifier/a2c.tgz /opt/acme2certifier
         docker exec acme-srv tar cvfz /tmp/acme2certifier/nginx.tgz /etc/nginx
         sudo cp -rp data/ ${{ github.workspace }}/artifact/data/
+        sudo rm ${{ github.workspace }}/artifact/data/*.rpm
         sudo cp -rp acme-sh/ ${{ github.workspace }}/artifact/acme-sh/
         docker exec acme-srv cat /var/log/messages > ${{ github.workspace }}/artifact/acme-srv.log
         sudo tar -C ${{ github.workspace }}/artifact/ -cvzf ${{ github.workspace }}/artifact/upload/artifact.tar.gz data acme-srv.log acme-sh
@@ -1254,6 +1257,7 @@ jobs:
         docker exec acme-srv tar cvfz /tmp/acme2certifier/a2c.tgz /opt/acme2certifier
         docker exec acme-srv tar cvfz /tmp/acme2certifier/nginx.tgz /etc/nginx
         sudo cp -rp data/ ${{ github.workspace }}/artifact/data/
+        sudo rm ${{ github.workspace }}/artifact/data/*.rpm
         sudo cp -rp acme-sh/ ${{ github.workspace }}/artifact/acme-sh/
         docker exec acme-srv cat /var/log/messages > ${{ github.workspace }}/artifact/acme-srv.log
         sudo tar -C ${{ github.workspace }}/artifact/ -cvzf ${{ github.workspace }}/artifact/upload/artifact.tar.gz data acme-srv.log acme-sh

--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -1265,6 +1265,7 @@ def validate_identifier(logger: logging.Logger, type: str, identifier: str, tnau
     """ validate identifier """
     logger.debug('validate_identifier()')
 
+    result = False
     if identifier:
         if type == 'dns':
             result = validate_fqdn(logger, identifier)
@@ -1272,8 +1273,6 @@ def validate_identifier(logger: logging.Logger, type: str, identifier: str, tnau
             result = validate_ip(logger, identifier)
         elif type == 'tnauthlist' and tnauthlist_support:
             result = True
-        else:
-            result = False
 
     logger.debug('validate_identifier() ended with: %s', result)
     return result

--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -1204,7 +1204,7 @@ def servercert_get(logger: logging.Logger, hostname: str, port: int = 443, proxy
     try:
         # this does not work on RH8
         context.minimum_version = ssl.TLSVersion.TLSv1_2
-    except Exception: # pragma: no cover
+    except Exception:  # pragma: no cover
         pass
     context.options |= ssl.OP_NO_SSLv3
     context.options |= ssl.OP_NO_TLSv1
@@ -1261,6 +1261,7 @@ def validate_email(logger: logging.Logger, contact_list: List[str]) -> bool:
         logger.debug('# validate: %s result: %s', contact_list, result)
     return result
 
+
 def validate_identifier(logger: logging.Logger, type: str, identifier: str, tnauthlist_support: bool = False) -> bool:
     """ validate identifier """
     logger.debug('validate_identifier()')
@@ -1277,6 +1278,7 @@ def validate_identifier(logger: logging.Logger, type: str, identifier: str, tnau
     logger.debug('validate_identifier() ended with: %s', result)
     return result
 
+
 def validate_ip(logger: logging.Logger, ip: str) -> bool:
     """ validate ip address """
     logger.debug('validate_ip()')
@@ -1288,6 +1290,7 @@ def validate_ip(logger: logging.Logger, ip: str) -> bool:
     logger.debug('validate_ip() ended with: %s', result)
     return result
 
+
 def validate_fqdn(logger: logging.Logger, fqdn: str) -> bool:
     """ validate fqdn """
     logger.debug('validate_fqdn()')
@@ -1295,11 +1298,12 @@ def validate_fqdn(logger: logging.Logger, fqdn: str) -> bool:
     result = False
     regex = r"^(([a-z0-9]\-*[a-z0-9]*){1,63}\.?){1,255}$"
     p = re.compile(regex)
-    if(re.search(p, fqdn)):
+    if re.search(p, fqdn):
         result = True
 
     logger.debug('validate_fqdn() ended with: %s', result)
     return result
+
 
 def handle_exception(exc_type, exc_value, exc_traceback):  # pragma: no cover
     """ exception handler """

--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -1301,6 +1301,13 @@ def validate_fqdn(logger: logging.Logger, fqdn: str) -> bool:
     if re.search(p, fqdn):
         result = True
 
+    if not result:
+        logger.debug('validate_fqdn(): invalid fqdn. Check for wildcard : %s', fqdn)
+        regex = r"^\*\.[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        p = re.compile(regex)
+        if re.search(p, fqdn):
+            result = True
+
     logger.debug('validate_fqdn() ended with: %s', result)
     return result
 

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -26,6 +26,7 @@ class Order(object):
         self.retry_after = 600
         self.tnauthlist_support = False
         self.sectigo_sim = False
+        self.identifier_limit = 20
         self.header_info_list = []
 
     def __enter__(self):
@@ -136,6 +137,10 @@ class Order(object):
                     self.validity = int(config_dic['Order']['validity'])
                 except Exception:
                     self.logger.warning('Order._config_load(): failed to parse validity: %s', config_dic['Order']['validity'])
+            try:
+                self.identifier_limit = int(config_dic.get('Order', 'identifier_limit', fallback=20))
+            except Exception:
+                self.logger.warning('Order._config_load(): failed to parse identifier_limit: %s', config_dic['Order']['identifier_limit'])
 
         self.logger.debug('Order._config_orderconfig_load() ended')
 
@@ -171,9 +176,9 @@ class Order(object):
         self.logger.debug('Order._name_get() ended')
         return order_name
 
-    def _identifiers_check(self, identifiers_list: List[str]) -> str:
-        """ check validity of identifers in order """
-        self.logger.debug('Order._identifiers_check(%s)', identifiers_list)
+    def _identifiers_allowed(self, identifiers_list: List[str]) -> bool:
+        """ check if identifiers are allowed """
+        self.logger.debug('Order._identifiers_allowed()')
 
         error = None
         allowed_identifers = ['dns', 'ip']
@@ -182,18 +187,31 @@ class Order(object):
         if self.tnauthlist_support:
             allowed_identifers.append('tnauthlist')
 
-        if identifiers_list and isinstance(identifiers_list, list):
-            for identifier in identifiers_list:
-                if 'type' in identifier:
-                    if identifier['type'].lower() not in allowed_identifers:
-                        error = self.error_msg_dic['unsupportedidentifier']
-                        break
-                    else:
-                        if not validate_identifier(self.logger, identifier['type'].lower(), identifier['value'], self.tnauthlist_support):
-                            error = self.error_msg_dic['rejectedidentifier']
-                            break
+        for identifier in identifiers_list:
+            if 'type' in identifier:
+                # pylint: disable=R1723
+                if identifier['type'].lower() not in allowed_identifers:
+                    error = self.error_msg_dic['unsupportedidentifier']
+                    break
                 else:
-                    error = self.error_msg_dic['malformed']
+                    if not validate_identifier(self.logger, identifier['type'].lower(), identifier['value'], self.tnauthlist_support):
+                        error = self.error_msg_dic['rejectedidentifier']
+                        break
+            else:
+                error = self.error_msg_dic['malformed']
+
+        self.logger.debug('Order._identifiers_allowed() ended with: %s', error)
+        return error
+
+    def _identifiers_check(self, identifiers_list: List[str]) -> str:
+        """ check validity of identifers in order """
+        self.logger.debug('Order._identifiers_check(%s)', identifiers_list)
+
+        if identifiers_list and isinstance(identifiers_list, list):
+            if len(identifiers_list) > self.identifier_limit:
+                error = self.error_msg_dic['rejectedidentifier']
+            else:
+                error = self._identifiers_allowed(identifiers_list)
         else:
             error = self.error_msg_dic['malformed']
 

--- a/docs/acme_srv.md
+++ b/docs/acme_srv.md
@@ -36,6 +36,7 @@
 | `Order` | `expiry_check_disable` | Disable order expiration  | True/False | False|
 | `Order` | `header_info_list` | HTTP header fields to be passed to ca handler  | ["HTTP_USER_AGENT", "FOO_BAR"] |[]|
 | `Order` | `retry_after_timeout` | Retry-After value to be send to client in case a certificate enrollment request gets pending on CA server  | Integer |120|
+| `Order` | `identifier_limit` | Maximum number of identifiers submitted in a single order request which translate later into SANs per certificate | Integer |20|
 | `Order` | [`tnauthlist_support`](tnauthlist.md) | accept [TNAuthList identifiers](https://tools.ietf.org/html/draft-ietf-acme-authority-token-tnauthlist-03) and challenges containing [tkauth-01 type](https://tools.ietf.org/html/draft-ietf-acme-authority-token-03) | True/False | False|
 | `Order` | `validity` | Order validity in seconds | Integer |86400|
 

--- a/examples/nginx/nginx_acme_srv.conf
+++ b/examples/nginx/nginx_acme_srv.conf
@@ -1,6 +1,13 @@
+# zone with 10mb memory which is 160k/s - 5requests per client per second
+limit_req_zone $binary_remote_addr zone=ip:10m rate=5r/s;
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
+
+    # first 5 requests go trough instantly 5more requests evey 100ms
+    limit_req zone=ip burst=10 delay=5;
+
     server_name _;
     location = favicon.ico { access_log off; log_not_found off; }
     location / {

--- a/examples/nginx/nginx_acme_srv.conf
+++ b/examples/nginx/nginx_acme_srv.conf
@@ -6,7 +6,7 @@ server {
     listen [::]:80 default_server;
 
     # first 5 requests go trough instantly 5more requests evey 100ms
-    limit_req zone=ip burst=10 delay=5;
+    limit_req zone=ip burst=10; # delay=5;
 
     server_name _;
     location = favicon.ico { access_log off; log_not_found off; }

--- a/examples/nginx/nginx_acme_srv_ssl.conf
+++ b/examples/nginx/nginx_acme_srv_ssl.conf
@@ -1,5 +1,5 @@
 # zone with 10mb memory which is 160k/s - 5requests per client per second
-limit_req_zone $binary_remote_addr zone=ip:10m rate=5r/s;
+# limit_req_zone $binary_remote_addr zone=ip:10m rate=5r/s;
 server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;

--- a/examples/nginx/nginx_acme_srv_ssl.conf
+++ b/examples/nginx/nginx_acme_srv_ssl.conf
@@ -1,6 +1,12 @@
+# zone with 10mb memory which is 160k/s - 5requests per client per second
+limit_req_zone $binary_remote_addr zone=ip:10m rate=5r/s;
 server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
+
+    # first 5 requests go trough instantly 5more requests evey 100ms
+    limit_req zone=ip burst=10 delay=5;
+
     server_name _;
     location = favicon.ico { access_log off; log_not_found off; }
     location / {

--- a/examples/nginx/nginx_acme_srv_ssl.conf
+++ b/examples/nginx/nginx_acme_srv_ssl.conf
@@ -5,7 +5,7 @@ server {
     listen [::]:443 ssl default_server;
 
     # first 5 requests go trough instantly 5more requests evey 100ms
-    limit_req zone=ip burst=10 delay=5;
+    limit_req zone=ip burst=10; # delay=5;
 
     server_name _;
     location = favicon.ico { access_log off; log_not_found off; }

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -2226,6 +2226,10 @@ jX1vlY35Ofonc4+6dRVamBiF9A==
         """ test validate_fqdn() """
         self.assertFalse(self.validate_fqdn(self.logger, 'foo@bar.local'))
 
+    def test_294_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertTrue(self.validate_fqdn(self.logger, '*.bar.local'))
+
     def test_294_validate_ip(self):
         """ test validate_ip() """
         self.assertTrue(self.validate_ip(self.logger, '10.0.0.1'))

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -26,7 +26,7 @@ class TestACMEHandler(unittest.TestCase):
         """ setup unittest """
         import logging
         logging.basicConfig(level=logging.CRITICAL)
-        from acme_srv.helper import b64decode_pad, b64_decode, b64_encode, b64_url_encode, b64_url_recode, convert_string_to_byte, convert_byte_to_string, decode_message, decode_deserialize, get_url, generate_random_string, signature_check, validate_email, uts_to_date_utc, date_to_uts_utc, load_config, cert_serial_get, cert_san_get, cert_san_pyopenssl_get, cert_dates_get, build_pem_file, date_to_datestr, datestr_to_date, dkeys_lower, csr_cn_get, cert_pubkey_get, csr_pubkey_get, url_get, url_get_with_own_dns,  dns_server_list_load, csr_san_get, csr_san_byte_get, csr_extensions_get, fqdn_resolve, fqdn_in_san_check, sha256_hash, sha256_hash_hex, cert_der2pem, cert_pem2der, cert_extensions_get, csr_dn_get, logger_setup, logger_info, print_debug, jwk_thumbprint_get, allowed_gai_family, patched_create_connection, validate_csr, servercert_get, txt_get, proxystring_convert, proxy_check, handle_exception, ca_handler_load, eab_handler_load, hooks_load, error_dic_get, _logger_nonce_modify, _logger_certificate_modify, _logger_token_modify, _logger_challenges_modify, config_check, cert_issuer_get, cert_cn_get, string_sanitize, pembundle_to_list, certid_asn1_get, certid_check, certid_hex_get, v6_adjust, ipv6_chk, ip_validate, header_info_get, encode_url, uts_now, cert_ski_get, cert_ski_pyopenssl_get, cert_aki_get, cert_aki_pyopenssl_get
+        from acme_srv.helper import b64decode_pad, b64_decode, b64_encode, b64_url_encode, b64_url_recode, convert_string_to_byte, convert_byte_to_string, decode_message, decode_deserialize, get_url, generate_random_string, signature_check, validate_email, uts_to_date_utc, date_to_uts_utc, load_config, cert_serial_get, cert_san_get, cert_san_pyopenssl_get, cert_dates_get, build_pem_file, date_to_datestr, datestr_to_date, dkeys_lower, csr_cn_get, cert_pubkey_get, csr_pubkey_get, url_get, url_get_with_own_dns,  dns_server_list_load, csr_san_get, csr_san_byte_get, csr_extensions_get, fqdn_resolve, fqdn_in_san_check, sha256_hash, sha256_hash_hex, cert_der2pem, cert_pem2der, cert_extensions_get, csr_dn_get, logger_setup, logger_info, print_debug, jwk_thumbprint_get, allowed_gai_family, patched_create_connection, validate_csr, servercert_get, txt_get, proxystring_convert, proxy_check, handle_exception, ca_handler_load, eab_handler_load, hooks_load, error_dic_get, _logger_nonce_modify, _logger_certificate_modify, _logger_token_modify, _logger_challenges_modify, config_check, cert_issuer_get, cert_cn_get, string_sanitize, pembundle_to_list, certid_asn1_get, certid_check, certid_hex_get, v6_adjust, ipv6_chk, ip_validate, header_info_get, encode_url, uts_now, cert_ski_get, cert_ski_pyopenssl_get, cert_aki_get, cert_aki_pyopenssl_get, validate_fqdn, validate_ip, validate_identifier
         self.logger = logging.getLogger('test_a2c')
         self.allowed_gai_family = allowed_gai_family
         self.b64_decode = b64_decode
@@ -95,6 +95,9 @@ class TestACMEHandler(unittest.TestCase):
         self.url_get_with_own_dns = url_get_with_own_dns
         self.uts_to_date_utc = uts_to_date_utc
         self.validate_email = validate_email
+        self.validate_ip = validate_ip
+        self.validate_fqdn = validate_fqdn
+        self.validate_identifier = validate_identifier
         self.validate_csr = validate_csr
         self.sha256_hash = sha256_hash
         self.sha256_hash_hex = sha256_hash_hex
@@ -1814,7 +1817,8 @@ klGUNHG98CtsmlhrivhSTJWqSIOfyKGF
             'unsupportedidentifier': 'urn:ietf:params:acme:error:unsupportedIdentifier',
             'ordernotready': 'urn:ietf:params:acme:error:orderNotReady',
             'ratelimited': 'urn:ietf:params:acme:error:rateLimited',
-            'badrevocationreason': 'urn:ietf:params:acme:error:badRevocationReason'}
+            'badrevocationreason': 'urn:ietf:params:acme:error:badRevocationReason',
+            'rejectedidentifier': 'urn:ietf:params:acme:error:rejectedIdentifier'}
         self.assertEqual(result, self.error_dic_get(self.logger))
 
     def test_238_logger_nonce_modify(self):
@@ -2190,6 +2194,107 @@ jX1vlY35Ofonc4+6dRVamBiF9A==
             self.assertFalse(self.cert_aki_pyopenssl_get(self.logger, cert))
         self.assertIn('ERROR:test_a2c:cert_ski_pyopenssl_get(): No AKI found in certificate', lcm.output)
 
+    def test_286_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertTrue(self.validate_fqdn(self.logger, 'foo.bar.com'))
+
+    def test_287_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, '-foo.bar.com'))
+
+    def test_288_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, 'foo.bar.com/foo'))
+
+    def test_289_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, 'foo.bar.com#foo'))
+
+    def test_290_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, 'foo.bar.com?foo=foo'))
+
+    def test_291_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, '2a01:c22:b0cf:600:74be:80a7:4feb:bfe8'))
+
+    def test_292_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, 'foo.bar.com:8080'))
+
+    def test_293_validate_fqdn(self):
+        """ test validate_fqdn() """
+        self.assertFalse(self.validate_fqdn(self.logger, 'foo@bar.local'))
+
+    def test_294_validate_ip(self):
+        """ test validate_ip() """
+        self.assertTrue(self.validate_ip(self.logger, '10.0.0.1'))
+
+    def test_295_validate_ip(self):
+        """ test validate_ip() """
+        self.assertTrue(self.validate_ip(self.logger, '2a01:c22:b0cf:600:74be:80a7:4feb:bfe8'))
+
+    def test_296_validate_ip(self):
+        """ test validate_ip() """
+        self.assertFalse(self.validate_ip(self.logger, 'foo.bar.local'))
+
+    def test_297_validate_ip(self):
+        """ test validate_ip() """
+        self.assertFalse(self.validate_ip(self.logger, 'foo@bar.local'))
+
+    def test_298_validate_ip(self):
+        """ test validate_ip() """
+        self.assertFalse(self.validate_ip(self.logger, '301.0.0.1'))
+
+    @patch('acme_srv.helper.validate_fqdn')
+    @patch('acme_srv.helper.validate_ip')
+    def test_299_validate_identifier(self, mock_ip, mock_fqdn):
+        """ test validate_identifier """
+        mock_fqdn.return_value = 'dns'
+        mock_ip.return_value = 'ip'
+        self.assertEqual('dns', self.validate_identifier(self.logger, 'dns', 'foo.bar.com'))
+        self.assertTrue(mock_fqdn.called)
+        self.assertFalse(mock_ip.called)
+
+    @patch('acme_srv.helper.validate_fqdn')
+    @patch('acme_srv.helper.validate_ip')
+    def test_300_validate_identifier(self, mock_ip, mock_fqdn):
+        """ test validate_identifier """
+        mock_fqdn.return_value = 'dns'
+        mock_ip.return_value = 'ip'
+        self.assertEqual('ip', self.validate_identifier(self.logger, 'ip', 'ip'))
+        self.assertFalse(mock_fqdn.called)
+        self.assertTrue(mock_ip.called)
+
+    @patch('acme_srv.helper.validate_fqdn')
+    @patch('acme_srv.helper.validate_ip')
+    def test_301_validate_identifier(self, mock_ip, mock_fqdn):
+        """ test validate_identifier """
+        mock_fqdn.return_value = 'dns'
+        mock_ip.return_value = 'ip'
+        self.assertFalse(self.validate_identifier(self.logger, 'unk', 'ip'))
+        self.assertFalse(mock_fqdn.called)
+        self.assertFalse(mock_ip.called)
+
+    @patch('acme_srv.helper.validate_fqdn')
+    @patch('acme_srv.helper.validate_ip')
+    def test_302_validate_identifier(self, mock_ip, mock_fqdn):
+        """ test validate_identifier """
+        mock_fqdn.return_value = 'dns'
+        mock_ip.return_value = 'ip'
+        self.assertFalse(self.validate_identifier(self.logger, 'tnauthlist', 'ip'))
+        self.assertFalse(mock_fqdn.called)
+        self.assertFalse(mock_ip.called)
+
+    @patch('acme_srv.helper.validate_fqdn')
+    @patch('acme_srv.helper.validate_ip')
+    def test_303_validate_identifier(self, mock_ip, mock_fqdn):
+        """ test validate_identifier """
+        mock_fqdn.return_value = 'dns'
+        mock_ip.return_value = 'ip'
+        self.assertTrue(self.validate_identifier(self.logger, 'tnauthlist', 'ip', True))
+        self.assertFalse(mock_fqdn.called)
+        self.assertFalse(mock_ip.called)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -150,34 +150,34 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(mock_nnonce.called)
 
     @patch('acme_srv.order.Order._info')
-    def test_010_order__lookup(self, mock_oinfo):
+    def test_011_order__lookup(self, mock_oinfo):
         """ test order lookup with empty hash """
         mock_oinfo.return_value = {}
         self.assertEqual({}, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_011_order__lookup(self, mock_oinfo):
+    def test_012_order__lookup(self, mock_oinfo):
         """ test order lookup with wrong hash and wrong authorization hash"""
         self.order.dbstore.authorization_lookup.return_value = [{'identifier_key' : 'identifier_value'}]
         mock_oinfo.return_value = {'status_key' : 'status_value'}
         self.assertEqual({'authorizations': []}, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_012_order__lookup(self, mock_oinfo):
+    def test_013_order__lookup(self, mock_oinfo):
         """ test order lookup with wrong hash and correct authorization hash"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}]
         mock_oinfo.return_value = {'status_key' : 'status_value'}
         self.assertEqual({'authorizations': ['http://tester.local/acme/authz/name']}, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_013_order__lookup(self, mock_oinfo):
+    def test_014_order__lookup(self, mock_oinfo):
         """ test order lookup with wrong hash and authorization hash having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status_key' : 'status_value'}
         self.assertEqual({'authorizations': ['http://tester.local/acme/authz/name', 'http://tester.local/acme/authz/name2']}, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_014_order__lookup(self, mock_oinfo):
+    def test_015_order__lookup(self, mock_oinfo):
         """ test order lookup status in dict and authorization dict having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status' : 'status_value'}
@@ -185,7 +185,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_015_order__lookup(self, mock_oinfo):
+    def test_016_order__lookup(self, mock_oinfo):
         """ test order lookup status, expires in dict and authorization dict having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400}
@@ -193,7 +193,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_016_order__lookup(self, mock_oinfo):
+    def test_017_order__lookup(self, mock_oinfo):
         """ test order lookup status, expires, notbefore (0) in dict and authorization dict having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 0}
@@ -201,7 +201,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_017_order__lookup(self, mock_oinfo):
+    def test_018_order__lookup(self, mock_oinfo):
         """ test order lookup status, expires, notbefore and notafter (0) in dict and authorization dict having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 0, 'notafter' : 0}
@@ -209,7 +209,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_018_order__lookup(self, mock_oinfo):
+    def test_019_order__lookup(self, mock_oinfo):
         """ test order lookup status, expires, notbefore and notafter (valid) in dict and authorization dict having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400}
@@ -217,7 +217,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_019_order__lookup(self, mock_oinfo):
+    def test_020_order__lookup(self, mock_oinfo):
         """ test order lookup status, expires, notbefore and notafter (valid), identifier, in dict and authorization dict having multiple entries"""
         self.order.dbstore.authorization_lookup.return_value = [{'name' : 'name', 'identifier_key' : 'identifier_value'}, {'name' : 'name2', 'identifier_key' : 'identifier_value2'}]
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifier': '"{"foo" : "bar"}"'}
@@ -225,7 +225,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_020_order__lookup(self, mock_oinfo):
+    def test_021_order__lookup(self, mock_oinfo):
         """ test order lookup status, expires, notbefore and notafter (valid), identifier, in dict and worng authorization"""
         self.order.dbstore.authorization_lookup.return_value = 'foo'
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifier': '"{"foo" : "bar"}"'}
@@ -233,7 +233,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_021_order__lookup(self, mock_oinfo):
+    def test_022_order__lookup(self, mock_oinfo):
         """ test order lookup correct identifier for oder info"""
         self.order.dbstore.authorization_lookup.return_value = 'foo'
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifiers': '{"foo": "bar"}'}
@@ -241,7 +241,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(e_result, self.order._lookup('foo'))
 
     @patch('acme_srv.order.Order._info')
-    def test_022_order__lookup(self, mock_oinfo):
+    def test_023_order__lookup(self, mock_oinfo):
         """ test order lookup incorrect identifier for oder info"""
         self.order.dbstore.authorization_lookup.return_value = 'foo'
         mock_oinfo.return_value = {'status' : 'status_value', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifiers': 'wrongvalue'}
@@ -252,7 +252,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('acme_srv.order.Order._update')
     @patch('acme_srv.order.Order._info')
-    def test_023_order__lookup(self, mock_oinfo, mock_update):
+    def test_024_order__lookup(self, mock_oinfo, mock_update):
         """ test order lookup correct identifier for oder info status - pending order-update """
         self.order.dbstore.authorization_lookup.return_value = [{'name': 'name', 'status__name': 'valid'}]
         mock_oinfo.return_value = {'status' : 'pending', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifiers': '{"foo": "bar"}'}
@@ -262,7 +262,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('acme_srv.order.Order._update')
     @patch('acme_srv.order.Order._info')
-    def test_024_order__lookup(self, mock_oinfo, mock_update):
+    def test_025_order__lookup(self, mock_oinfo, mock_update):
         """ test order lookup correct identifier for oder info status - pending order-update """
         self.order.dbstore.authorization_lookup.return_value = [{'name': 'name', 'status__name': 'valid'}]
         mock_oinfo.return_value = {'status' : 'notpending', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifiers': '{"foo": "bar"}'}
@@ -272,7 +272,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('acme_srv.order.Order._update')
     @patch('acme_srv.order.Order._info')
-    def test_025_order__lookup(self, mock_oinfo, mock_update):
+    def test_026_order__lookup(self, mock_oinfo, mock_update):
         """ test order lookup correct identifier for oder info status - invalid statusname """
         self.order.dbstore.authorization_lookup.return_value = [{'name': 'name', 'status__name': 'invalid'}]
         mock_oinfo.return_value = {'status' : 'pending', 'expires' : 1543640400, 'notbefore' : 1543640400, 'notafter' : 1543640400, 'identifiers': '{"foo": "bar"}'}
@@ -281,7 +281,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(mock_update.called)
 
     @patch('acme_srv.order.Order._info')
-    def test_026_order__csr_process(self, mock_oinfo):
+    def test_027_order__csr_process(self, mock_oinfo):
         """ test order prcoess_csr with empty order_dic """
         mock_oinfo.return_value = {}
         self.assertEqual((400, 'urn:ietf:params:acme:error:unauthorized', 'order: order_name not found'), self.order._csr_process('order_name', 'csr', 'header_info'))
@@ -289,7 +289,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('importlib.import_module')
     @patch('acme_srv.certificate.Certificate.store_csr')
     @patch('acme_srv.order.Order._info')
-    def test_027_order__csr_process(self, mock_oinfo, mock_certname, mock_import):
+    def test_028_order__csr_process(self, mock_oinfo, mock_certname, mock_import):
         """ test order prcoess_csr with failed csr dbsave"""
         mock_oinfo.return_value = {'foo', 'bar'}
         mock_certname.return_value = None
@@ -300,7 +300,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.certificate.Certificate.enroll_and_store')
     @patch('acme_srv.certificate.Certificate.store_csr')
     @patch('acme_srv.order.Order._info')
-    def test_028_order__csr_process(self, mock_oinfo, mock_certname, mock_enroll, mock_import):
+    def test_029_order__csr_process(self, mock_oinfo, mock_certname, mock_enroll, mock_import):
         """ test order prcoess_csr with failed cert enrollment"""
         mock_oinfo.return_value = {'foo', 'bar'}
         mock_certname.return_value = 'foo'
@@ -312,7 +312,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.certificate.Certificate.enroll_and_store')
     @patch('acme_srv.certificate.Certificate.store_csr')
     @patch('acme_srv.order.Order._info')
-    def test_029_order__csr_process(self, mock_oinfo, mock_certname, mock_enroll, mock_import):
+    def test_030_order__csr_process(self, mock_oinfo, mock_certname, mock_enroll, mock_import):
         """ test order prcoess_csr with successful cert enrollment"""
         mock_oinfo.return_value = {'foo', 'bar'}
         mock_certname.return_value = 'foo'
@@ -320,29 +320,29 @@ class TestACMEHandler(unittest.TestCase):
         mock_import.return_value = importlib.import_module('examples.ca_handler.skeleton_ca_handler')
         self.assertEqual((200, 'foo', None), self.order._csr_process('order_name', 'csr', 'header_info'))
 
-    def test_030_order__name_get(self):
+    def test_031_order__name_get(self):
         """ Order.name_get() http"""
         self.assertEqual('foo', self.order._name_get('http://tester.local/acme/order/foo'))
 
-    def test_031_order__name_get(self):
+    def test_032_order__name_get(self):
         """ Order.name_get() http with further path (finalize)"""
         self.assertEqual('foo', self.order._name_get('http://tester.local/acme/order/foo/bar'))
 
-    def test_032_order__name_get(self):
+    def test_033_order__name_get(self):
         """ Order.name_get() http with parameters"""
         self.assertEqual('foo', self.order._name_get('http://tester.local/acme/order/foo?bar'))
 
-    def test_033_order__name_get(self):
+    def test_034_order__name_get(self):
         """ Order.name_get() http with key/value parameters"""
         self.assertEqual('foo', self.order._name_get('http://tester.local/acme/order/foo?key=value'))
 
-    def test_034_order__name_get(self):
+    def test_035_order__name_get(self):
         """ Order.name_get() https with key/value parameters"""
         self.assertEqual('foo', self.order._name_get('https://tester.local/acme/order/foo?key=value'))
 
     @patch('acme_srv.nonce.Nonce.generate_and_add')
     @patch('acme_srv.message.Message.check')
-    def test_035_order_parse(self, mock_mcheck, mock_nnonce):
+    def test_036_order_parse(self, mock_mcheck, mock_nnonce):
         """ Order.parse() failed bcs. of failed message check """
         mock_mcheck.return_value = (400, 'message', 'detail', None, None, 'account_name')
         message = '{"foo" : "bar"}'
@@ -352,7 +352,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('acme_srv.nonce.Nonce.generate_and_add')
     @patch('acme_srv.message.Message.check')
-    def test_036_order_parse(self, mock_mcheck, mock_nnonce):
+    def test_037_order_parse(self, mock_mcheck, mock_nnonce):
         """ Order.parse() failed bcs. no url key in protected """
         mock_mcheck.return_value = (200, None, None, {'foo_protected' : 'bar_protected'}, {"foo_payload" : "bar_payload"}, 'account_name')
         message = '{"foo" : "bar"}'
@@ -363,7 +363,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.nonce.Nonce.generate_and_add')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_037_order_parse(self, mock_mcheck, mock_oname, mock_nnonce):
+    def test_038_order_parse(self, mock_mcheck, mock_oname, mock_nnonce):
         """ Order.parse() name_get failed """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = None
@@ -376,7 +376,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_038_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_nnonce):
+    def test_039_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_nnonce):
         """ Order.parse() failed as order lookup failed """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -391,7 +391,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_039_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_040_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned non 200 """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -407,7 +407,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_040_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_041_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned 200 and no certname """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -422,7 +422,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_041_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_042_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned 200 and certname and valid status """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -437,7 +437,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_042_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_043_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned 200 and certname without status """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -452,7 +452,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_043_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_044_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned 200 and certname and non-valid status """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -462,104 +462,118 @@ class TestACMEHandler(unittest.TestCase):
         message = '{"foo" : "bar"}'
         self.assertEqual({'code': 200, 'data': {'finalize': 'http://tester.local/acme/order/foo/finalize', 'foo': 'bar', 'status': 'foobar'}, 'header': {'Location': 'http://tester.local/acme/order/foo', 'Replay-Nonce': 'nonce'}}, self.order.parse(message))
 
-    def test_044_order__identifiers_check(self):
+    def test_045_order__identifiers_check(self):
         """ order identifers check with empty identifer list"""
         self.assertEqual('urn:ietf:params:acme:error:malformed', self.order._identifiers_check([]))
 
-    def test_045_order__identifiers_check(self):
+    def test_046_order__identifiers_check(self):
         """ order identifers check with string identifier """
         self.assertEqual('urn:ietf:params:acme:error:malformed', self.order._identifiers_check('foo'))
 
-    def test_046_order__identifiers_check(self):
+    def test_047_order__identifiers_check(self):
         """ order identifers check with dictionary identifier """
         self.assertEqual('urn:ietf:params:acme:error:malformed', self.order._identifiers_check({'type': 'dns', 'value': 'foo.bar'}))
 
-    def test_047_order__identifiers_check(self):
+    def test_048_order__identifiers_check(self):
         """ order identifers check with correct identifer but case-insensitive """
         self.assertEqual('urn:ietf:params:acme:error:malformed', self.order._identifiers_check([{'Type': 'dns', 'value': 'value'}]))
 
-    def test_048_order__identifiers_check(self):
+    def test_049_order__identifiers_check(self):
         """ order identifers check with wrong identifer in list"""
         self.assertEqual('urn:ietf:params:acme:error:unsupportedIdentifier', self.order._identifiers_check([{'type': 'foo', 'value': 'value'}]))
 
-    def test_049_order__identifiers_check(self):
+    def test_050_order__identifiers_check(self):
         """ order identifers check with correct identifer in list"""
         self.assertEqual(None, self.order._identifiers_check([{'type': 'dns', 'value': 'value'}]))
 
-    def test_050_order__identifiers_check(self):
+    def test_051_order__identifiers_check(self):
         """ order identifers check with two identifers in list (one wrong) """
         self.assertEqual('urn:ietf:params:acme:error:unsupportedIdentifier', self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'foo', 'value': 'value'}]))
 
-    def test_051_order__identifiers_check(self):
+    def test_052_order__identifiers_check(self):
         """ order identifers check with two identifers in list (one wrong) """
         self.assertEqual('urn:ietf:params:acme:error:unsupportedIdentifier', self.order._identifiers_check([{'type': 'foo', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
 
-    def test_052_order__identifiers_check(self):
+    def test_053_order__identifiers_check(self):
         """ order identifers check with two identifers in list (one wrong) """
         self.assertEqual(None, self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
 
-    def test_053_order__identifiers_check(self):
+    def test_054_order__identifiers_check(self):
         """ order identifers check with tnauthlist identifier and support false """
         self.order.tnauthlist_support = False
         self.assertEqual('urn:ietf:params:acme:error:unsupportedIdentifier', self.order._identifiers_check([{'type': 'TNAuthList', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
 
-    def test_054_order__identifiers_check(self):
+    def test_055_order__identifiers_check(self):
         """ order identifers check with tnauthlist identifier and support True """
         self.order.tnauthlist_support = True
         self.assertEqual(None, self.order._identifiers_check([{'type': 'TNAuthList', 'value': 'value'}, {'type': 'dns', 'value': 'foo.bar.local'}]))
 
-    def test_055_order__identifiers_check(self):
+    def test_056_order__identifiers_check(self):
         """ order identifers check with tnauthlist identifier and support True """
         self.order.tnauthlist_support = True
         self.assertEqual(None, self.order._identifiers_check([{'type': 'TNAuthList', 'value': 'value'}]))
 
-    def test_056_order__identifiers_check(self):
+    def test_057_order__identifiers_check(self):
         """ order identifers check with tnauthlist identifier a wrong identifer and support True """
         self.order.tnauthlist_support = True
         self.assertEqual('urn:ietf:params:acme:error:unsupportedIdentifier', self.order._identifiers_check([{'type': 'TNAuthList', 'value': 'value'}, {'type': 'type', 'value': 'value'}]))
 
-    def test_057_order__identifiers_check(self):
+    def test_058_order__identifiers_check(self):
         """ order identifers check with wrong identifer in list and tnauthsupport true"""
         self.order.tnauthlist_support = True
         self.assertEqual('urn:ietf:params:acme:error:unsupportedIdentifier', self.order._identifiers_check([{'type': 'foo', 'value': 'value'}]))
 
-    def test_058_order__identifiers_check(self):
+    def test_059_order__identifiers_check(self):
         """ order identifers check with correct identifer in list and tnauthsupport true"""
         self.order.tnauthlist_support = True
         self.assertEqual(None, self.order._identifiers_check([{'type': 'dns', 'value': 'value'}]))
 
+    def test_060_order__identifiers_check(self):
+        """ order identifers check with 3 identifiers and no indentifier limit """
+        self.assertEqual(None, self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
+
+    def test_061_order__identifiers_check(self):
+        """ order identifers check with 3 identifiers and identifier limit of 3 """
+        self.order.identifier_limit = 3
+        self.assertEqual(None, self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
+
+    def test_062_order__identifiers_check(self):
+        """ order identifers check with 3 identifiers and identifier limit of 2 """
+        self.order.identifier_limit = 2
+        self.assertEqual('urn:ietf:params:acme:error:rejectedIdentifier', self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
+
     @patch('acme_srv.order.validate_identifier')
-    def test_059_order__identifiers_check(self, mock_vali):
+    def test_063_order__identifiers_check(self, mock_vali):
         """ order identifers check with correct identifer """
         mock_vali.side_effect = [True]
         self.assertEqual(None, self.order._identifiers_check([{'type': 'dns', 'value': 'value'}]))
 
     @patch('acme_srv.order.validate_identifier')
-    def test_060_order__identifiers_check(self, mock_vali):
+    def test_064_order__identifiers_check(self, mock_vali):
         """ order identifers check with correct identifer """
         mock_vali.side_effect = [False]
         self.assertEqual('urn:ietf:params:acme:error:rejectedIdentifier', self.order._identifiers_check([{'type': 'dns', 'value': 'value'}]))
 
     @patch('acme_srv.order.validate_identifier')
-    def test_060_order__identifiers_check(self, mock_vali):
+    def test_065_order__identifiers_check(self, mock_vali):
         """ order identifers check with correct identifer """
         mock_vali.side_effect = [True, False]
         self.assertEqual('urn:ietf:params:acme:error:rejectedIdentifier', self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
 
     @patch('acme_srv.order.validate_identifier')
-    def test_061_order__identifiers_check(self, mock_vali):
+    def test_066_order__identifiers_check(self, mock_vali):
         """ order identifers check with correct identifer """
         mock_vali.side_effect = [False, True]
         self.assertEqual('urn:ietf:params:acme:error:rejectedIdentifier', self.order._identifiers_check([{'type': 'dns', 'value': 'value'}, {'type': 'dns', 'value': 'value'}]))
 
-    def test_059_order__process(self):
+    def test_067_order__process(self):
         """ Order.prcoess() without url in protected header """
         order_name = 'order_name'
         protected = 'protected'
         payload = 'payload'
         self.assertEqual((400, 'urn:ietf:params:acme:error:malformed', 'url is missing in protected', None), self.order._process(order_name, protected, payload))
 
-    def test_060_order__process(self):
+    def test_068_order__process(self):
         """ Order.prcoess() polling request with failed certificate lookup """
         order_name = 'order_name'
         protected = {'url': 'foo'}
@@ -567,7 +581,7 @@ class TestACMEHandler(unittest.TestCase):
         self.order.dbstore.certificate_lookup.return_value = {}
         self.assertEqual((200, None, None, None), self.order._process(order_name, protected, payload))
 
-    def test_061_order__process(self):
+    def test_069_order__process(self):
         """ Order.prcoess() polling request with successful certificate lookup """
         order_name = 'order_name'
         protected = {'url': 'foo'}
@@ -576,7 +590,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((200, None, None, 'cert_name'), self.order._process(order_name, protected, payload))
 
     @patch('acme_srv.order.Order._info')
-    def test_062_order__process(self, mock_info):
+    def test_070_order__process(self, mock_info):
         """ Order.prcoess() finalize request with empty orderinfo """
         mock_info.return_value = {}
         order_name = 'order_name'
@@ -585,7 +599,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((403, 'urn:ietf:params:acme:error:orderNotReady', 'Order is not ready', None), self.order._process(order_name, protected, payload))
 
     @patch('acme_srv.order.Order._info')
-    def test_063_order__process(self, mock_info):
+    def test_071_order__process(self, mock_info):
         """ Order.prcoess() finalize request with orderinfo without status"""
         mock_info.return_value = {'foo': 'bar'}
         order_name = 'order_name'
@@ -594,7 +608,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((403, 'urn:ietf:params:acme:error:orderNotReady', 'Order is not ready', None), self.order._process(order_name, protected, payload))
 
     @patch('acme_srv.order.Order._info')
-    def test_064_order__process(self, mock_info):
+    def test_072_order__process(self, mock_info):
         """ Order.prcoess() finalize request with orderinfo with wrong status"""
         mock_info.return_value = {'status': 'bar'}
         order_name = 'order_name'
@@ -603,7 +617,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((403, 'urn:ietf:params:acme:error:orderNotReady', 'Order is not ready', None), self.order._process(order_name, protected, payload))
 
     @patch('acme_srv.order.Order._info')
-    def test_065_order__process(self, mock_info):
+    def test_073_order__process(self, mock_info):
         """ Order.prcoess() finalize request without CSR """
         mock_info.return_value = {'status': 'ready'}
         order_name = 'order_name'
@@ -613,7 +627,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('acme_srv.order.Order._csr_process')
     @patch('acme_srv.order.Order._info')
-    def test_066_order__process(self, mock_info, mock_process_csr):
+    def test_074_order__process(self, mock_info, mock_process_csr):
         """ Order.prcoess() finalize request with CSR but csr_process failed """
         mock_info.return_value = {'status': 'ready'}
         order_name = 'order_name'
@@ -625,7 +639,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._update')
     @patch('acme_srv.order.Order._csr_process')
     @patch('acme_srv.order.Order._info')
-    def test_067_order__process(self, mock_info, mock_process_csr, mock_update):
+    def test_075_order__process(self, mock_info, mock_process_csr, mock_update):
         """ Order.prcoess() finalize request with CSR but all good """
         mock_info.return_value = {'status': 'ready'}
         order_name = 'order_name'
@@ -639,7 +653,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._update')
     @patch('acme_srv.order.Order._csr_process')
     @patch('acme_srv.order.Order._info')
-    def test_068_order__process(self, mock_info, mock_process_csr, mock_update):
+    def test_076_order__process(self, mock_info, mock_process_csr, mock_update):
         """ Order.prcoess() timeout in csr processing """
         mock_info.return_value = {'status': 'ready'}
         order_name = 'order_name'
@@ -653,7 +667,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._update')
     @patch('acme_srv.order.Order._csr_process')
     @patch('acme_srv.order.Order._info')
-    def test_069_order__process(self, mock_info, mock_process_csr, mock_update):
+    def test_077_order__process(self, mock_info, mock_process_csr, mock_update):
         """ Order.prcoess() finalize request with detail none """
         mock_info.return_value = {'status': 'ready'}
         order_name = 'order_name'
@@ -668,7 +682,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.certificate.Certificate.enroll_and_store')
     @patch('acme_srv.certificate.Certificate.store_csr')
     @patch('acme_srv.order.Order._info')
-    def test_070_order__csr_process(self, mock_oinfo, mock_certname, mock_enroll, mock_import):
+    def test_078_order__csr_process(self, mock_oinfo, mock_certname, mock_enroll, mock_import):
         """ test order prcoess_csr with failed cert enrollment with internal error (response code must be corrected by 500)"""
         mock_oinfo.return_value = {'foo', 'bar'}
         mock_certname.return_value = 'foo'
@@ -681,7 +695,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_071_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_079_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned 200 and certname processing status default retry after-header """
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
         mock_oname.return_value = 'foo'
@@ -696,7 +710,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('acme_srv.order.Order._lookup')
     @patch('acme_srv.order.Order._name_get')
     @patch('acme_srv.message.Message.check')
-    def test_072_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
+    def test_080_order_parse(self, mock_mcheck, mock_oname, mock_lookup, mock_process, mock_nnonce):
         """ Order.parse() succ, oder process returned 200 and certname processing status configurable retry after-header """
         self.order.retry_after = 60
         mock_mcheck.return_value = (200, None, None, {'url' : 'bar_url/finalize'}, {"foo_payload" : "bar_payload"}, 'account_name')
@@ -707,38 +721,38 @@ class TestACMEHandler(unittest.TestCase):
         message = '{"foo" : "bar"}'
         self.assertEqual({'code': 200, 'data': {'finalize': 'http://tester.local/acme/order/foo/finalize', 'foo': 'bar', 'status': 'processing'}, 'header': {'Location': 'http://tester.local/acme/order/foo', 'Replay-Nonce': 'nonce', 'Retry-After': '60'}}, self.order.parse(message))
 
-    def test_073_order_invalidate(self):
+    def test_081_order_invalidate(self):
         """ test Order.invalidate() empty order list """
         self.order.dbstore.orders_invalid_search.return_value = []
         self.assertEqual((['id', 'name', 'expires', 'identifiers', 'created_at', 'status__id', 'status__name', 'account__id', 'account__name', 'account__contact'], []), self.order.invalidate())
 
-    def test_074_order_invalidate(self):
+    def test_082_order_invalidate(self):
         """ test Certificate._fieldlist_normalize() - wrong return list (no status__name included) """
         self.order.dbstore.orders_invalid_search.return_value = [{'foo': 'bar'}]
         self.assertEqual((['id', 'name', 'expires', 'identifiers', 'created_at', 'status__id', 'status__name', 'account__id', 'account__name', 'account__contact'], []), self.order.invalidate())
 
-    def test_075_order_invalidate(self):
+    def test_083_order_invalidate(self):
         """ test Certificate._fieldlist_normalize() - no name but status__name """
         self.order.dbstore.orders_invalid_search.return_value = [{'foo': 'bar', 'status__name': 'foo'}]
         self.assertEqual((['id', 'name', 'expires', 'identifiers', 'created_at', 'status__id', 'status__name', 'account__id', 'account__name', 'account__contact'], []), self.order.invalidate())
 
-    def test_076_order_invalidate(self):
+    def test_084_order_invalidate(self):
         """ test Certificate._fieldlist_normalize() - name but no status__name """
         self.order.dbstore.orders_invalid_search.return_value = [{'foo': 'bar', 'name': 'foo'}]
         self.assertEqual((['id', 'name', 'expires', 'identifiers', 'created_at', 'status__id', 'status__name', 'account__id', 'account__name', 'account__contact'], []), self.order.invalidate())
 
-    def test_077_order_invalidate(self):
+    def test_085_order_invalidate(self):
         """ test Certificate._fieldlist_normalize() - name and status__name but invalid """
         self.order.dbstore.orders_invalid_search.return_value = [{'foo': 'bar', 'name': 'foo', 'status__name': 'invalid'}]
         self.assertEqual((['id', 'name', 'expires', 'identifiers', 'created_at', 'status__id', 'status__name', 'account__id', 'account__name', 'account__contact'], []), self.order.invalidate())
 
-    def test_078_order_invalidate(self):
+    def test_086_order_invalidate(self):
         """ test Certificate._fieldlist_normalize() - name and status__name but invalid """
         self.order.dbstore.orders_invalid_search.return_value = [{'foo': 'bar', 'name': 'foo', 'status__name': 'foobar'}]
         self.assertEqual((['id', 'name', 'expires', 'identifiers', 'created_at', 'status__id', 'status__name', 'account__id', 'account__name', 'account__contact'], [{'foo': 'bar', 'name': 'foo', 'status__name': 'foobar'}]), self.order.invalidate())
 
     @patch('acme_srv.order.Order._identifiers_check')
-    def test_079_order__add(self, mock_idchk):
+    def test_087_order__add(self, mock_idchk):
         """ test Order._add - dbstore.authorization_add() raises an exception  """
         self.order.dbstore.authorization_add.side_effect = Exception('exc_order_add')
         self.order.dbstore.order_add.return_value = 'oid'
@@ -748,7 +762,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._add() authz: exc_order_add', lcm.output)
 
     @patch('acme_srv.order.Order._identifiers_check')
-    def test_080_order__add(self, mock_idchk):
+    def test_088_order__add(self, mock_idchk):
         """ test Order._add - dbstore.order_add() raises an exception  """
         self.order.dbstore.order_add.side_effect = Exception('exc_order_add')
         mock_idchk.return_value = False
@@ -756,21 +770,21 @@ class TestACMEHandler(unittest.TestCase):
             self.order._add({'foo': 'bar', 'identifiers': 'identifiers'}, 'aname')
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._add() order: exc_order_add', lcm.output)
 
-    def test_081_order__info(self):
+    def test_089_order__info(self):
         """ test Order._info - dbstore.order_lookup() raises an exception  """
         self.order.dbstore.order_lookup.side_effect = Exception('exc_order_info')
         with self.assertLogs('test_a2c', level='INFO') as lcm:
             self.order._info('oname')
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._info(): exc_order_info', lcm.output)
 
-    def test_082_order__process(self):
+    def test_090_order__process(self):
         """ test Order._process - dbstore.order_lookup() raises an exception  """
         self.order.dbstore.certificate_lookup.side_effect = Exception('exc_order_process')
         with self.assertLogs('test_a2c', level='INFO') as lcm:
             self.order._process('oname', {'url': 'url'}, 'payload')
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._process(): exc_order_process', lcm.output)
 
-    def test_083_order__update(self):
+    def test_091_order__update(self):
         """ test Order._update - dbstore.order_update() raises an exception  """
         self.order.dbstore.order_update.side_effect = Exception('exc_order_upd')
         with self.assertLogs('test_a2c', level='INFO') as lcm:
@@ -778,7 +792,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._update(): exc_order_upd', lcm.output)
 
     @patch('acme_srv.order.Order._info')
-    def test_084_order__lookup(self, mock_info):
+    def test_092_order__lookup(self, mock_info):
         """ test Order._lookup - dbstore.authorization_lookup() raises an exception  """
         self.order.dbstore.authorization_lookup.side_effect = Exception('exc_authz_lookup')
         mock_info.return_value = {'status': 'valid'}
@@ -786,7 +800,7 @@ class TestACMEHandler(unittest.TestCase):
             self.order._lookup('oname')
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._authz_list_lookup(): exc_authz_lookup', lcm.output)
 
-    def test_085_order_invalidate(self):
+    def test_093_order_invalidate(self):
         """ test Order.invalidate - dbstore.order_update() raises an exception  """
         self.order.dbstore.order_update.side_effect = Exception('exc_order_upd')
         self.order.dbstore.order_invalid_search.return_value = ['foo']
@@ -795,7 +809,7 @@ class TestACMEHandler(unittest.TestCase):
             self.order.invalidate(timestamp)
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._invalidate() upd: exc_order_upd', lcm.output)
 
-    def test_086_order_invalidate(self):
+    def test_094_order_invalidate(self):
         """ test Order.invalidate - dbstore.order_update() raises an exception  """
         self.order.dbstore.orders_invalid_search.side_effect = Exception('exc_order_search')
         timestamp = 1543640400
@@ -804,14 +818,14 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('CRITICAL:test_a2c:acme2certifier database error in Order._invalidate() search: exc_order_search', lcm.output)
 
     @patch('acme_srv.order.Order._config_load')
-    def test_087__enter__(self, mock_cfg):
+    def test_095__enter__(self, mock_cfg):
         """ test enter """
         mock_cfg.return_value = True
         self.order.__enter__()
         self.assertTrue(mock_cfg.called)
 
     @patch('acme_srv.order.load_config')
-    def test_088_config_load(self, mock_load_cfg):
+    def test_096_config_load(self, mock_load_cfg):
         """ test _config_load empty config """
         parser = configparser.ConfigParser()
         mock_load_cfg.return_value = parser
@@ -820,7 +834,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.order.header_info_list)
 
     @patch('acme_srv.order.load_config')
-    def test_089_config_load(self, mock_load_cfg):
+    def test_097_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'foo': 'bar'}
@@ -830,7 +844,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.order.header_info_list)
 
     @patch('acme_srv.order.load_config')
-    def test_090_config_load(self, mock_load_cfg):
+    def test_098_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'tnauthlist_support': False}
@@ -840,7 +854,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.order.header_info_list)
 
     @patch('acme_srv.order.load_config')
-    def test_091_config_load(self, mock_load_cfg):
+    def test_099_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'tnauthlist_support': True}
@@ -854,7 +868,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.order.header_info_list)
 
     @patch('acme_srv.order.load_config')
-    def test_092_config_load(self, mock_load_cfg):
+    def test_100_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'expiry_check_disable': False}
@@ -867,9 +881,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_093_config_load(self, mock_load_cfg):
+    def test_101_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'expiry_check_disable': True}
@@ -882,9 +897,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_094_config_load(self, mock_load_cfg):
+    def test_102_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'retry_after_timeout': 1200}
@@ -897,9 +913,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_095_config_load(self, mock_load_cfg):
+    def test_103_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'retry_after_timeout': '1200'}
@@ -912,9 +929,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_096_config_load(self, mock_load_cfg):
+    def test_104_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'retry_after_timeout': 'foo'}
@@ -929,9 +947,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.authz_validity)
         self.assertIn('WARNING:test_a2c:Order._config_load(): failed to parse retry_after: foo', lcm.output)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_097_config_load(self, mock_load_cfg):
+    def test_105_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'validity': 1200}
@@ -944,9 +963,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(1200, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_098_config_load(self, mock_load_cfg):
+    def test_106_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'validity': '1200'}
@@ -959,9 +979,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(1200, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_099_config_load(self, mock_load_cfg):
+    def test_107_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'validity': 'foo'}
@@ -976,9 +997,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.authz_validity)
         self.assertIn('WARNING:test_a2c:Order._config_load(): failed to parse validity: foo', lcm.output)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_100_config_load(self, mock_load_cfg):
+    def test_108_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Authorization'] = {'validity': 1200}
@@ -991,9 +1013,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(1200, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_101_config_load(self, mock_load_cfg):
+    def test_109_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Authorization'] = {'validity': '1200'}
@@ -1006,9 +1029,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(1200, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_102_config_load(self, mock_load_cfg):
+    def test_110_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Authorization'] = {'validity': 'foo'}
@@ -1023,9 +1047,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.authz_validity)
         self.assertIn('WARNING:test_a2c:Order._config_load(): failed to parse authz validity: foo', lcm.output)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_103_config_load(self, mock_load_cfg):
+    def test_111_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Directory'] = {'url_prefix': 'url_prefix'}
@@ -1034,9 +1059,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.order.tnauthlist_support)
         self.assertEqual({'authz_path': 'url_prefix/acme/authz/', 'cert_path': 'url_prefix/acme/cert/', 'order_path': 'url_prefix/acme/order/'}, self.order.path_dic)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_104_config_load(self, mock_load_cfg):
+    def test_112_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Challenge'] = {'sectigo_sim': True}
@@ -1049,9 +1075,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_105_config_load(self, mock_load_cfg):
+    def test_113_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Challenge'] = {'sectigo_sim': False}
@@ -1064,9 +1091,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_106_config_load(self, mock_load_cfg):
+    def test_114_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'header_info_list': '["foo", "bar"]'}
@@ -1079,9 +1107,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.validity)
         self.assertEqual(86400, self.order.authz_validity)
         self.assertEqual(['foo', 'bar'], self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
 
     @patch('acme_srv.order.load_config')
-    def test_107_config_load(self, mock_load_cfg):
+    def test_115_config_load(self, mock_load_cfg):
         """ test _config_load """
         parser = configparser.ConfigParser()
         parser['Order'] = {'header_info_list': 'foo'}
@@ -1096,10 +1125,77 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(86400, self.order.authz_validity)
         self.assertFalse(self.order.header_info_list)
         self.assertIn('WARNING:test_a2c:Order._config_orderconfig_load() header_info_list failed with error: Expecting value: line 1 column 1 (char 0)', lcm.output)
+        self.assertEqual(20, self.order.identifier_limit)
+
+    @patch('acme_srv.order.load_config')
+    def test_116_config_load(self, mock_load_cfg):
+        """ test _config_load """
+        parser = configparser.ConfigParser()
+        parser['Challenge'] = {'sectigo_sim': False}
+        mock_load_cfg.return_value = parser
+        self.order._config_load()
+        self.assertFalse(self.order.tnauthlist_support)
+        self.assertFalse(self.order.sectigo_sim)
+        self.assertFalse(self.order.expiry_check_disable)
+        self.assertEqual(600, self.order.retry_after)
+        self.assertEqual(86400, self.order.validity)
+        self.assertEqual(86400, self.order.authz_validity)
+        self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
+
+    @patch('acme_srv.order.load_config')
+    def test_117_config_load(self, mock_load_cfg):
+        """ test _config_load """
+        parser = configparser.ConfigParser()
+        parser['Order'] = {'identifier_limit': 40}
+        mock_load_cfg.return_value = parser
+        self.order._config_load()
+        self.assertFalse(self.order.tnauthlist_support)
+        self.assertFalse(self.order.sectigo_sim)
+        self.assertFalse(self.order.expiry_check_disable)
+        self.assertEqual(600, self.order.retry_after)
+        self.assertEqual(86400, self.order.validity)
+        self.assertEqual(86400, self.order.authz_validity)
+        self.assertFalse(self.order.header_info_list)
+        self.assertEqual(40, self.order.identifier_limit)
+
+    @patch('acme_srv.order.load_config')
+    def test_118_config_load(self, mock_load_cfg):
+        """ test _config_load """
+        parser = configparser.ConfigParser()
+        parser['Order'] = {'identifier_limit': '40'}
+        mock_load_cfg.return_value = parser
+        self.order._config_load()
+        self.assertFalse(self.order.tnauthlist_support)
+        self.assertFalse(self.order.sectigo_sim)
+        self.assertFalse(self.order.expiry_check_disable)
+        self.assertEqual(600, self.order.retry_after)
+        self.assertEqual(86400, self.order.validity)
+        self.assertEqual(86400, self.order.authz_validity)
+        self.assertFalse(self.order.header_info_list)
+        self.assertEqual(40, self.order.identifier_limit)
+
+    @patch('acme_srv.order.load_config')
+    def test_119_config_load(self, mock_load_cfg):
+        """ test _config_load """
+        parser = configparser.ConfigParser()
+        parser['Order'] = {'identifier_limit': 'aa'}
+        mock_load_cfg.return_value = parser
+        with self.assertLogs('test_a2c', level='INFO') as lcm:
+            self.order._config_load()
+        self.assertFalse(self.order.tnauthlist_support)
+        self.assertFalse(self.order.sectigo_sim)
+        self.assertFalse(self.order.expiry_check_disable)
+        self.assertEqual(600, self.order.retry_after)
+        self.assertEqual(86400, self.order.validity)
+        self.assertEqual(86400, self.order.authz_validity)
+        self.assertFalse(self.order.header_info_list)
+        self.assertEqual(20, self.order.identifier_limit)
+        self.assertIn('WARNING:test_a2c:Order._config_load(): failed to parse identifier_limit: aa', lcm.output)
 
     @patch('acme_srv.order.DBstore.authorization_add')
     @patch('acme_srv.order.generate_random_string')
-    def test_108__auth_add(self, mock_name, mock_order_add):
+    def test_120__auth_add(self, mock_name, mock_order_add):
         """ test _auth_add() """
         mock_name.return_value = 'name'
         auth_dic = {}
@@ -1108,7 +1204,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(mock_order_add.called)
 
     @patch('acme_srv.order.generate_random_string')
-    def test_109__auth_add(self, mock_name):
+    def test_121__auth_add(self, mock_name):
         """ test _auth_add() """
         mock_name.return_value = 'name'
         auth_dic = {}
@@ -1119,7 +1215,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.order.dbstore.authorization_update.called)
 
     @patch('acme_srv.order.generate_random_string')
-    def test_110__auth_add(self, mock_name):
+    def test_122__auth_add(self, mock_name):
         """ test _auth_add() """
         mock_name.return_value = 'name'
         auth_dic = {}
@@ -1130,37 +1226,37 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(self.order.dbstore.authorization_add.called)
         self.assertTrue(self.order.dbstore.authorization_update.called)
 
-    def test_111__header_info_lookup(self):
+    def test_123__header_info_lookup(self):
         """ test _header_info_lookup() """
         header = {'foo1': 'bar1', 'foo2': 'bar2'}
         self.order.header_info_list = ['foo1', 'foo2']
         self.assertEqual('{"foo1": "bar1", "foo2": "bar2"}', self.order._header_info_lookup(header))
 
-    def test_112__header_info_lookup(self):
+    def test_124__header_info_lookup(self):
         """ test _header_info_lookup() """
         header = {'foo1': 'bar1', 'foo2': 'bar2'}
         self.order.header_info_list = ['foo2']
         self.assertEqual('{"foo2": "bar2"}', self.order._header_info_lookup(header))
 
-    def test_113__header_info_lookup(self):
+    def test_125__header_info_lookup(self):
         """ test _header_info_lookup() """
         header = {'foo1': 'bar1', 'foo2': 'bar2'}
         self.order.header_info_list = ['foo1']
         self.assertEqual('{"foo1": "bar1"}', self.order._header_info_lookup(header))
 
-    def test_114__header_info_lookup(self):
+    def test_126__header_info_lookup(self):
         """ test _header_info_lookup() """
         header = {'foo1': 'bar1', 'foo2': 'bar2'}
         self.order.header_info_list = ['foo1', 'foo3']
         self.assertEqual('{"foo1": "bar1"}', self.order._header_info_lookup(header))
 
-    def test_115__header_info_lookup(self):
+    def test_127__header_info_lookup(self):
         """ test _header_info_lookup() """
         header = None
         self.order.header_info_list = ['foo1', 'foo3']
         self.assertFalse(self.order._header_info_lookup(header))
 
-    def test_116__header_info_lookup(self):
+    def test_128__header_info_lookup(self):
         """ test _header_info_lookup() """
         header = {'foo1': 'bar1', 'foo2': 'bar2'}
         self.order.header_info_list = False


### PR DESCRIPTION
This PR introduces:

- request rate limiting in ngnix to 10 requests per second
- better dns/ip identifier sanitizing
- a configurable threshold to limit the number of identifiers in a single request (default 20)