### PR TITLE
Update a2c_response.py problem_json content type

### DIFF
--- a/examples/django/acme_srv/a2c_response.py
+++ b/examples/django/acme_srv/a2c_response.py
@@ -23,7 +23,7 @@ class JsonResponse(HttpResponse):
             json_dumps_params = {}
 
         if 'status' in kwargs and kwargs['status'] > 201:
-            kwargs.setdefault('content_type', 'problem+json')
+            kwargs.setdefault('content_type', 'application/problem+json')
         else:
             kwargs.setdefault('content_type', 'application/json')
 


### PR DESCRIPTION
While trying out the nginx-django docker image with https://certifytheweb.com the New Account registration was failing with an invalid [anti-replay] nonce but the content type was slightly off so it wasn't recognized as a problem json response Content Type by the dotnet HttpClient.