### PR TITLE
[feat] log enrollment config 

### DIFF
--- a/docs/acme_ca.md
+++ b/docs/acme_ca.md
@@ -51,7 +51,9 @@ The handler must be configured via `acme_srv`.
 | acme_account_email | email address used to register a new account | no | None |
 | allowed_domainlist | list of domain-names allowed for enrollment in json format example: ["bar.local$, bar.foo.local] | no | [] |
 | directory_path | path to directory ressource on ca server | no | '/directory' |
-| eab_profiling |  enable eab-profiling  | None |  False |
+| eab_profiling |  enable eab-profiling  | no |  False |
+| enrollment_config_log | log enrollment parameters | no  | False |
+| enrollment_config_log_skip_list | list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] | no | [] |
 | ssl_verify | verify certificates on SSL connections | no | True |
 
 - modify the server configuration (`acme_srv/acme_srv.cfg`) and add at least the following parameters.

--- a/docs/asa.md
+++ b/docs/asa.md
@@ -36,6 +36,9 @@ cert_validity_days: <days>
 - ca_name - name of the CA used to enroll certificates
 - profile_name - profile name
 - cert_validity_days - optional - polling timeout (default: 60s)
+- eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 
 It is also recommended to increase the enrollment timeout to avoid that acme2certifier is closing the connection to early.
 

--- a/docs/certifier.md
+++ b/docs/certifier.md
@@ -31,9 +31,11 @@ eab_profiling: <True|False>
 - api_password_variable - *optional* - name of the environment variable containing the password for the REST user (a configured `api_password` parameter in acme_srv.cfg takes precedence)
 - ca_bundle - optional - certificate bundle needed to validate the server certificate - can be True/False or a filename (default: True)
 - ca_name - name of the CA used to enroll certificates
+- eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 - profile_id - optional - profileId
 - polling_timeout - optional - polling timeout (default: 60s)
-- eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
 
 Depending on CA policy configuration a CSR may require approval. In such a situation acme2certfier will poll the CA server to check the CSR status. The polling interval can be configured in acme.server.cfg.
 

--- a/docs/digicert.md
+++ b/docs/digicert.md
@@ -42,6 +42,8 @@ eab_profiling: <True|False>
 - order_validity - optional - oder validity (default: 1 year)
 - request_timeout - optional - requests timeout in seconds for requests (default: 5s)
 - eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 
 Use your favorite acme client for certificate enrollment. A list of clients used in our regression can be found in the [disclaimer section of our README file](../README.md)
 

--- a/docs/ejbca.md
+++ b/docs/ejbca.md
@@ -45,8 +45,10 @@ eab_profiling: <True|False>
 - cert_profile_name - name of the certificate profile
 - ee_profile_name - name of the end entity profile
 - ca_name - name of the CA used to enroll certificates
-- request_timeout - optional - requests timeout in seconds for requests (default: 5s)
 - eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
+- request_timeout - optional - requests timeout in seconds for requests (default: 5s)
 
 You can test the connection by running the following curl command against your EJBCA server.
 

--- a/docs/entrust.md
+++ b/docs/entrust.md
@@ -42,6 +42,8 @@ eab_profiling: <True|False>
 - allowed_domainlist: list of domain-names allowed for enrollment in json format (example: ["bar.local$, bar.foo.local])
 - request_timeout - optional - requests timeout in seconds for requests (default: 5s)
 - eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 
 Use your favorite acme client for certificate enrollment. A list of clients used in our regression can be found in the [disclaimer section of our README file](../README.md)
 

--- a/docs/mscertsrv.md
+++ b/docs/mscertsrv.md
@@ -95,6 +95,8 @@ eab_profiling: False
 - template - certificate template used for enrollment
 - allowed_domainlist - *optional* - list of domain-names allowed for enrollment in json format example: ["bar.local$, bar.foo.local]
 - eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 
 ## Passing a template from client to server
 

--- a/docs/mswcce.md
+++ b/docs/mswcce.md
@@ -87,6 +87,8 @@ eab_profiling: False
 - use_kerberos - use kerboros for authentication; if set to `False` authentication will be done via NTLM. Considering a [Microsoft accouncement from October 2023](https://techcommunity.microsoft.com/t5/windows-it-pro-blog/the-evolution-of-windows-authentication/ba-p/3926848) the usage of Kerberos should be preferred. Nevertheless, for backwards compatibility reasons the default setting is `False`
 - allowed_domainlist - *optional* - list of domain-names allowed for enrollment in json format example: ["bar.local$, bar.foo.local]
 - eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 
 ## Passing a template from client to server
 

--- a/docs/nclm.md
+++ b/docs/nclm.md
@@ -34,3 +34,6 @@ template_name: <template_name>
 - ca_name - name of the CA used to enroll certificates
 - tsg_name - name of the target system group to store the certificates
 - template_name - optional - name of the template to be applied to CSR
+- eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])

--- a/docs/xca.md
+++ b/docs/xca.md
@@ -42,6 +42,8 @@ template_name: XCA template to be applied to CSRs
 - `ca_cert_chain_list` - *optional* - List of root and intermediate CA certificates to be added to the bundle return to an ACME-client (the issuing CA cert must not be included)
 - `template_name` - *optional* - name of the XCA template to be applied during certificate issuance
 - eab_profiling - optional - [activate eab profiling](eab_profiling.md) (default: False)
+- enrollment_config_log - optional - log enrollment parameters (default False)
+- enrollment_config_log_skip_list - optional - list enrollment parameters not to be logged in json format example: [ "parameter1", "parameter2" ] (default: [])
 
 Template support has been introduced starting from v0.13. Support is limited to the below parameters which can be applied during certificate issuance:
 

--- a/examples/ca_handler/asa_ca_handler.py
+++ b/examples/ca_handler/asa_ca_handler.py
@@ -6,7 +6,7 @@ import os
 import requests
 from requests.auth import HTTPBasicAuth
 # pylint: disable=e0401
-from acme_srv.helper import load_config, encode_url, csr_pubkey_get, csr_cn_get, csr_san_get, uts_now, uts_to_date_utc, b64_decode, cert_der2pem, convert_byte_to_string, cert_ski_get, csr_san_byte_get, header_info_field_validate, header_info_lookup, config_eab_profile_load, config_headerinfo_load, eab_profile_header_info_check
+from acme_srv.helper import load_config, encode_url, csr_pubkey_get, csr_cn_get, csr_san_get, uts_now, uts_to_date_utc, b64_decode, cert_der2pem, convert_byte_to_string, cert_ski_get, config_eab_profile_load, config_headerinfo_load, eab_profile_header_info_check,  config_enroll_config_log_load, enrollment_config_log
 
 
 class CAhandler(object):
@@ -28,6 +28,8 @@ class CAhandler(object):
         self.header_info_field = False
         self.eab_handler = None
         self.eab_profiling = False
+        self.enrollment_config_log = False
+        self.enrollment_config_log_skip_list = []
 
     def __enter__(self):
         """ Makes CAhandler a Context Manager """
@@ -205,12 +207,16 @@ class CAhandler(object):
             if not getattr(self, ele):
                 self.logger.error('CAhandler._config_load(): %s not set', ele)
 
-        self._auth_set()
-
         # load profiling
         self.eab_profiling, self.eab_handler = config_eab_profile_load(self.logger, config_dic)
+
+        self._auth_set()
+
         # load header info
         self.header_info_field = config_headerinfo_load(self.logger, config_dic)
+
+        # load enrollment config log
+        self.enrollment_config_log, self.enrollment_config_log_skip_list = config_enroll_config_log_load(self.logger, config_dic)
 
         self.logger.debug('CAhandler._config_load() ended')
 
@@ -392,6 +398,10 @@ class CAhandler(object):
 
         # check for eab profiling and header_info
         error = eab_profile_header_info_check(self.logger, self, csr, 'profile_name')
+
+        if self.enrollment_config_log:
+            self.enrollment_config_log_skip_list.extend(['api_password', 'auth'])
+            enrollment_config_log(self.logger, self, self.enrollment_config_log_skip_list)
 
         if not error:
             # verify issuer

--- a/examples/ca_handler/certifier_ca_handler.py
+++ b/examples/ca_handler/certifier_ca_handler.py
@@ -10,7 +10,7 @@ from typing import List, Tuple, Dict
 import requests
 from requests.auth import HTTPBasicAuth
 # pylint: disable=e0401
-from acme_srv.helper import load_config, cert_serial_get, uts_now, uts_to_date_utc, b64_decode, b64_encode, cert_pem2der, parse_url, proxy_check, error_dic_get, config_eab_profile_load, config_headerinfo_load, eab_profile_header_info_check
+from acme_srv.helper import load_config, cert_serial_get, uts_now, uts_to_date_utc, b64_decode, b64_encode, cert_pem2der, parse_url, proxy_check, error_dic_get, config_eab_profile_load, config_headerinfo_load, eab_profile_header_info_check, config_enroll_config_log_load, enrollment_config_log
 
 
 class CAhandler(object):
@@ -32,6 +32,8 @@ class CAhandler(object):
         self.header_info_field = False
         self.eab_handler = None
         self.eab_profiling = False
+        self.enrollment_config_log = False
+        self.enrollment_config_log_skip_list = []
 
     def __enter__(self):
         """ Makes ACMEHandler a Context Manager """
@@ -135,6 +137,10 @@ class CAhandler(object):
         self.logger.debug('CAhandler._cert_get(%s)', csr)
         ca_dic = self._ca_get_properties('name', self.ca_name)
         cert_dic = {}
+
+        if self.enrollment_config_log:
+            self.enrollment_config_log_skip_list.extend(['auth', 'api_password'])
+            enrollment_config_log(self.logger, self, self.enrollment_config_log_skip_list)
 
         if 'href' in ca_dic:
             data = {'ca': ca_dic['href'], 'pkcs10': csr}
@@ -257,6 +263,9 @@ class CAhandler(object):
                 self.request_timeout = int(config_dic['CAhandler']['request_timeout'])
             except Exception:
                 self.request_timeout = 20
+
+        # load enrollment config log
+        self.enrollment_config_log, self.enrollment_config_log_skip_list = config_enroll_config_log_load(self.logger, config_dic)
 
         # load profile_id
         self.profile_id = config_dic['CAhandler'].get('profile_id', None)

--- a/test/test_asa_ca_handler.py
+++ b/test/test_asa_ca_handler.py
@@ -553,6 +553,7 @@ rJSbam5r3YoSelm94VwVyaSkfd+LT4YMAP7GDDvtT6Y=
         self.assertFalse(self.cahandler._issuer_chain_get())
         self.assertFalse(mock_pem.called)
 
+    @patch('examples.ca_handler.asa_ca_handler.enrollment_config_log')
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.asa_ca_handler.convert_byte_to_string')
     @patch('examples.ca_handler.asa_ca_handler.cert_der2pem')
@@ -563,7 +564,7 @@ rJSbam5r3YoSelm94VwVyaSkfd+LT4YMAP7GDDvtT6Y=
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._issuer_chain_get')
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._issuer_verify')
     @patch('examples.ca_handler.asa_ca_handler.eab_profile_header_info_check')
-    def test_043_enroll(self, mock_pv, mock_iv, mock_icg, mock_cpg, mockccg, mock_vdg, mock_b64, mock_d2p, mock_b2s, mock_post):
+    def test_043_enroll(self, mock_pv, mock_iv, mock_icg, mock_cpg, mockccg, mock_vdg, mock_b64, mock_d2p, mock_b2s, mock_post, mock_ecl):
         """ test enroll() """
         mock_iv.return_value = None
         mock_pv.return_value = 'pv_error'
@@ -583,7 +584,9 @@ rJSbam5r3YoSelm94VwVyaSkfd+LT4YMAP7GDDvtT6Y=
         self.assertFalse(mock_post.called)
         self.assertFalse(mock_b2s.called)
         self.assertFalse(mock_d2p.called)
+        self.assertFalse(mock_ecl.called)
 
+    @patch('examples.ca_handler.asa_ca_handler.enrollment_config_log')
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.asa_ca_handler.convert_byte_to_string')
     @patch('examples.ca_handler.asa_ca_handler.cert_der2pem')
@@ -594,7 +597,7 @@ rJSbam5r3YoSelm94VwVyaSkfd+LT4YMAP7GDDvtT6Y=
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._issuer_chain_get')
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._profile_verify')
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._issuer_verify')
-    def test_044_enroll(self, mock_iv, mock_pv, mock_icg, mock_cpg, mockccg, mock_vdg, mock_b64, mock_d2p, mock_b2s, mock_post):
+    def test_044_enroll(self, mock_iv, mock_pv, mock_icg, mock_cpg, mockccg, mock_vdg, mock_b64, mock_d2p, mock_b2s, mock_post, mock_ecl):
         """ test enroll() """
         mock_iv.return_value = None
         mock_pv.return_value = None
@@ -603,6 +606,7 @@ rJSbam5r3YoSelm94VwVyaSkfd+LT4YMAP7GDDvtT6Y=
         mock_post.return_value = (200, 'cert')
         mock_b2s.return_value = 'bcert'
         self.cahandler.header_info_field = 'foo'
+        self.cahandler.enrollment_config_log = True
         self.assertEqual((None, 'bcertissuer_chain', 'cert', None), self.cahandler.enroll('csr'))
         self.assertTrue(mock_iv.called)
         self.assertTrue(mock_pv.called)
@@ -614,6 +618,7 @@ rJSbam5r3YoSelm94VwVyaSkfd+LT4YMAP7GDDvtT6Y=
         self.assertTrue(mock_post.called)
         self.assertTrue(mock_b2s.called)
         self.assertTrue(mock_d2p.called)
+        self.assertTrue(mock_ecl.called)
 
     @patch('examples.ca_handler.asa_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.asa_ca_handler.convert_byte_to_string')

--- a/test/test_certifier_handler.py
+++ b/test/test_certifier_handler.py
@@ -515,8 +515,31 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual({'mock': 'post'}, self.cahandler._cert_get('csr'))
         self.assertEqual(100, self.cahandler.profile_id)
 
+    @patch('examples.ca_handler.certifier_ca_handler.enrollment_config_log')
+    @patch('examples.ca_handler.certifier_ca_handler.CAhandler._api_post')
+    @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
+    def test_049__cert_get(self, mock_caget, mock_post, mock_ecl):
+        """ CAhandler._ca_get_properties() _ca_get_properties does returns "href" key """
+        self.cahandler.api_host = 'api_host'
+        mock_caget.return_value = {'href': 'href'}
+        mock_post.return_value = {'mock': 'post'}
+        self.assertEqual({'mock': 'post'}, self.cahandler._cert_get('csr'))
+        self.assertFalse(mock_ecl.called)
+
+    @patch('examples.ca_handler.certifier_ca_handler.enrollment_config_log')
+    @patch('examples.ca_handler.certifier_ca_handler.CAhandler._api_post')
+    @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
+    def test_050__cert_get(self, mock_caget, mock_post, mock_ecl):
+        """ CAhandler._ca_get_properties() _ca_get_properties does returns "href" key """
+        self.cahandler.api_host = 'api_host'
+        self.cahandler.enrollment_config_log = True
+        mock_caget.return_value = {'href': 'href'}
+        mock_post.return_value = {'mock': 'post'}
+        self.assertEqual({'mock': 'post'}, self.cahandler._cert_get('csr'))
+        self.assertTrue(mock_ecl.called)
+
     @patch('requests.get')
-    def test_049__cert_get_properties(self, mock_req):
+    def test_051__cert_get_properties(self, mock_req):
         """ CAhandler._cert_get_properties() all good """
         self.cahandler.api_host = 'api_host'
         self.cahandler.auth = 'auth'
@@ -526,7 +549,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual({'foo': 'bar'}, self.cahandler._cert_get_properties('serial', 'link'))
 
     @patch('requests.get')
-    def test_050__cert_get_properties(self, mock_get):
+    def test_052__cert_get_properties(self, mock_get):
         """ CAhandler._cert_get_properties() all good """
         self.cahandler.api_host = 'api_host'
         self.cahandler.auth = 'auth'
@@ -535,24 +558,24 @@ class TestACMEHandler(unittest.TestCase):
             self.assertEqual({'status': 500, 'message': 'exc_api_get', 'statusMessage': 'Internal Server Error'}, self.cahandler._cert_get_properties('serial', 'link'))
         self.assertIn('ERROR:test_a2c:CAhandler._cert_get_properties() returned error: exc_api_get', lcm.output)
 
-    def test_051_poll(self):
+    def test_053_poll(self):
         """ CAhandler.poll() poll_identifier is none """
         self.assertEqual((None, None, None, None, False), self.cahandler.poll('cert_name', None, 'csr'))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._request_poll')
-    def test_052_poll(self, mock_poll):
+    def test_054_poll(self, mock_poll):
         """ CAhandler.poll() poll_identifier is none """
         mock_poll.return_value = ('error', 'cert_bundle', 'cert_raw', 'poll_identifier', 'rejected')
         self.assertEqual(('error', 'cert_bundle', 'cert_raw', 'poll_identifier', 'rejected'), self.cahandler.poll('cert_name', 'poll_identifier', 'csr'))
 
-    def test_053__loop_poll(self):
+    def test_055__loop_poll(self):
         """ CAhandler._loop_poll() - no request url"""
         request_url = None
         self.assertEqual((None, None, None, None), self.cahandler._loop_poll(request_url))
 
     @patch('time.sleep')
     @patch('requests.get')
-    def test_054__loop_poll(self, mock_get, mock_sleep):
+    def test_056__loop_poll(self, mock_get, mock_sleep):
         """ CAhandler._loop_poll() - nothing come back from request get"""
         self.cahandler.polling_timeout = 5
         self.cahandler.timeout = 0
@@ -565,7 +588,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('time.sleep')
     @patch('requests.get')
-    def test_055__loop_poll(self, mock_get, mock_sleep):
+    def test_057__loop_poll(self, mock_get, mock_sleep):
         """ CAhandler._loop_poll() - no status returned from  request get"""
         self.cahandler.polling_timeout = 5
         self.cahandler.timeout = 0
@@ -577,7 +600,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((None, None, None, 'request_url'), self.cahandler._loop_poll(request_url))
 
     @patch('requests.get')
-    def test_056__loop_poll(self, mock_get):
+    def test_058__loop_poll(self, mock_get):
         """ CAhandler._loop_poll() - status "rejected" returned from  request get"""
         self.cahandler.polling_timeout = 6
         self.cahandler.timeout = 0
@@ -589,7 +612,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('time.sleep')
     @patch('requests.get')
-    def test_057__loop_poll(self, mock_get, mock_sleep):
+    def test_059__loop_poll(self, mock_get, mock_sleep):
         """ CAhandler._loop_poll() - status "accepted" returned from  request get but no certificate in"""
         self.cahandler.polling_timeout = 6
         self.cahandler.timeout = 0
@@ -602,7 +625,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('time.sleep')
     @patch('requests.get')
-    def test_058__loop_poll(self, mock_get, mock_sleep):
+    def test_060__loop_poll(self, mock_get, mock_sleep):
         """ CAhandler._loop_poll() - status "accepted" returned from  request "certifiate" in but no "certificateBase64" in 2dn request """
         self.cahandler.polling_timeout = 6
         self.cahandler.timeout = 0
@@ -615,7 +638,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._pem_cert_chain_generate')
     @patch('requests.get')
-    def test_059__loop_poll(self, mock_get, mock_chain):
+    def test_061__loop_poll(self, mock_get, mock_chain):
         """ CAhandler._loop_poll() - status "accepted" returned from  request "certifiate" in but no "certificateBase64" in 2dn request """
         self.cahandler.polling_timeout = 6
         self.cahandler.timeout = 0
@@ -627,32 +650,32 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((None, 'foo', 'certificateBase64', None), self.cahandler._loop_poll(request_url))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_060_enroll(self, mock_certget):
+    def test_062_enroll(self, mock_certget):
         """ CAhandler.enroll() _cert_get returns None """
         mock_certget.return_value = {}
         self.assertEqual(('internal error', None, None, None), self.cahandler.enroll('csr'))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_061_enroll(self, mock_certget):
+    def test_063_enroll(self, mock_certget):
         """ CAhandler.enroll() _cert_get returns wrong information """
         mock_certget.return_value = {'foo': 'bar'}
         self.assertEqual(('no certificate information found', None, None, None), self.cahandler.enroll('csr'))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_062_enroll(self, mock_certget):
+    def test_064_enroll(self, mock_certget):
         """ CAhandler.enroll() _cert_get returns status without error message """
         mock_certget.return_value = {'foo': 'bar', 'status': 'foo'}
         self.assertEqual(('unknown error', None, None, None), self.cahandler.enroll('csr'))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_063_enroll(self, mock_certget):
+    def test_065_enroll(self, mock_certget):
         """ CAhandler.enroll() _cert_get returns status with error message """
         mock_certget.return_value = {'foo': 'bar', 'status': 'foo', 'message': 'message'}
         self.assertEqual(('message', None, None, None), self.cahandler.enroll('csr'))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._pem_cert_chain_generate')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_064_enroll(self, mock_certget, mock_chain):
+    def test_066_enroll(self, mock_certget, mock_chain):
         """ CAhandler.enroll() _cert_get returns certb64 """
         mock_certget.return_value = {'foo': 'bar', 'certificateBase64': 'certificateBase64'}
         mock_chain.return_value = 'mock_chain'
@@ -660,7 +683,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._loop_poll')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_065_enroll(self, mock_certget, mock_loop):
+    def test_067_enroll(self, mock_certget, mock_loop):
         """ CAhandler.enroll() _cert_get returns certb64 """
         mock_certget.return_value = {'foo': 'bar', 'href': 'href'}
         mock_loop.return_value = ('error', 'cert_bundle', 'cert_raw', 'poll_identifier')
@@ -669,7 +692,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._loop_poll')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_066_enroll(self, mock_certget, mock_loop, mock_prof):
+    def test_068_enroll(self, mock_certget, mock_loop, mock_prof):
         """ CAhandler.enroll() _cert_get returns certb64 """
         mock_certget.return_value = {'foo': 'bar', 'href': 'href'}
         mock_loop.return_value = ('error', 'cert_bundle', 'cert_raw', 'poll_identifier')
@@ -680,7 +703,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._loop_poll')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_067_enroll(self, mock_certget, mock_loop, mock_prof):
+    def test_069_enroll(self, mock_certget, mock_loop, mock_prof):
         """ CAhandler.enroll() _cert_get returns certb64 """
         mock_certget.return_value = {'foo': 'bar', 'href': 'href'}
         mock_loop.return_value = ('error', 'cert_bundle', 'cert_raw', 'poll_identifier')
@@ -693,7 +716,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._loop_poll')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_068_enroll(self, mock_certget, mock_loop, mock_prof):
+    def test_070_enroll(self, mock_certget, mock_loop, mock_prof):
         """ CAhandler.enroll() _cert_get returns certb64 """
         mock_certget.return_value = {'foo': 'bar', 'href': 'href'}
         mock_loop.return_value = ('error', 'cert_bundle', 'cert_raw', 'poll_identifier')
@@ -707,7 +730,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._loop_poll')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get')
-    def test_069_enroll(self, mock_certget, mock_loop, mock_prof):
+    def test_071_enroll(self, mock_certget, mock_loop, mock_prof):
         """ CAhandler.enroll() _cert_get returns certb64 """
         mock_certget.return_value = {'foo': 'bar', 'href': 'href'}
         mock_loop.return_value = ('error', 'cert_bundle', 'cert_raw', 'poll_identifier')
@@ -720,20 +743,20 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(self.cahandler.profile_id, None)
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_070_revoke(self, mock_getca):
+    def test_072_revoke(self, mock_getca):
         """ CAhandler.revoke() _ca_get_properties returns nothing """
         mock_getca.return_value = {}
         self.assertEqual((404, 'urn:ietf:params:acme:error:serverInternal', 'CA could not be found'), self.cahandler.revoke('cert'))
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_071_revoke(self, mock_getca):
+    def test_073_revoke(self, mock_getca):
         """ CAhandler.revoke() _ca_get_properties returns wrong information """
         mock_getca.return_value = {'foo': 'bar'}
         self.assertEqual((404, 'urn:ietf:params:acme:error:serverInternal', 'CA could not be found'), self.cahandler.revoke('cert'))
 
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_072_revoke(self, mock_getca, mock_serial):
+    def test_074_revoke(self, mock_getca, mock_serial):
         """ CAhandler.revoke() _ca_get_properties cert_serial_get failed """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = None
@@ -742,7 +765,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_073_revoke(self, mock_getca, mock_serial, mock_getcert):
+    def test_075_revoke(self, mock_getca, mock_serial, mock_getcert):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties failed """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -752,7 +775,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_074_revoke(self, mock_getca, mock_serial, mock_getcert):
+    def test_076_revoke(self, mock_getca, mock_serial, mock_getcert):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties returns wrong information """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -762,7 +785,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_075_revoke(self, mock_getca, mock_serial, mock_getcert):
+    def test_077_revoke(self, mock_getca, mock_serial, mock_getcert):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties empty cert_list """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -772,7 +795,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_076_revoke(self, mock_getca, mock_serial, mock_getcert):
+    def test_078_revoke(self, mock_getca, mock_serial, mock_getcert):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties returns cert_list with wrong information """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -783,7 +806,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_077_revoke(self, mock_getca, mock_serial, mock_getcert, mock_post):
+    def test_079_revoke(self, mock_getca, mock_serial, mock_getcert, mock_post):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties returns cert_list revocation successful """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -795,7 +818,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_078_revoke(self, mock_getca, mock_serial, mock_getcert, mock_post):
+    def test_080_revoke(self, mock_getca, mock_serial, mock_getcert, mock_post):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties returns href. revocation returns status without message """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -807,7 +830,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._cert_get_properties')
     @patch('examples.ca_handler.certifier_ca_handler.cert_serial_get')
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._ca_get_properties')
-    def test_079_revoke(self, mock_getca, mock_serial, mock_getcert, mock_post):
+    def test_081_revoke(self, mock_getca, mock_serial, mock_getcert, mock_post):
         """ CAhandler.revoke() _ca_get_properties get_cert_properties returns href. revocation returns status with message """
         mock_getca.return_value = {'foo': 'bar', 'href': 'href'}
         mock_serial.return_value = 123
@@ -815,7 +838,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_post.return_value = {'foo': 'bar', 'status': 'status', 'message': 'message'}
         self.assertEqual((400, 'urn:ietf:params:acme:error:alreadyRevoked', 'message'), self.cahandler.revoke('cert'))
 
-    def test_080_trigger(self):
+    def test_082_trigger(self):
         """ CAhandler.trigger() - no payload given """
         payload = None
         self.assertEqual(('No payload given', None, None), self.cahandler.trigger(payload))
@@ -824,7 +847,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.certifier_ca_handler.b64_decode')
     @patch('examples.ca_handler.certifier_ca_handler.b64_encode')
-    def test_081_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop):
+    def test_083_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop):
         """ CAhandler.trigger() - payload  but ca_lookup failed"""
         payload = 'foo'
         mock_b64dec.return_value = 'foodecode'
@@ -837,7 +860,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.certifier_ca_handler.b64_decode')
     @patch('examples.ca_handler.certifier_ca_handler.b64_encode')
-    def test_082_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial):
+    def test_084_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial):
         """ CAhandler.trigger() - payload serial number lookup failed"""
         payload = 'foo'
         mock_b64dec.return_value = 'foodecode'
@@ -852,7 +875,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.certifier_ca_handler.b64_decode')
     @patch('examples.ca_handler.certifier_ca_handler.b64_encode')
-    def test_083_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial, mock_certprop):
+    def test_085_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial, mock_certprop):
         """ CAhandler.trigger() - payload serial number lookup failed"""
         payload = 'foo'
         mock_b64dec.return_value = 'foodecode'
@@ -869,7 +892,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.certifier_ca_handler.b64_decode')
     @patch('examples.ca_handler.certifier_ca_handler.b64_encode')
-    def test_084_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial, mock_certprop, mock_chain):
+    def test_086_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial, mock_certprop, mock_chain):
         """ CAhandler.trigger() - payload serial number lookup failed"""
         payload = 'foo'
         mock_b64dec.return_value = 'foodecode'
@@ -887,7 +910,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.certifier_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.certifier_ca_handler.b64_decode')
     @patch('examples.ca_handler.certifier_ca_handler.b64_encode')
-    def test_085_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial, mock_certprop, mock_chain):
+    def test_087_trigger(self, mock_b64dec, mock_b64enc, mock_p2d, mock_caprop, mock_serial, mock_certprop, mock_chain):
         """ CAhandler.trigger() - payload serial number lookup failed"""
         payload = 'foo'
         mock_b64dec.return_value = 'foodecode'
@@ -898,23 +921,23 @@ class TestACMEHandler(unittest.TestCase):
         mock_chain.return_value = 'chain'
         self.assertEqual((None, 'chain', 'foodecode'), self.cahandler.trigger(payload))
 
-    def test_086__pem_cert_chain_generate(self):
+    def test_088__pem_cert_chain_generate(self):
         """ _pem_cert_chain_generate - empty cert_dic """
         cert_dic = {}
         self.assertFalse(self.cahandler._pem_cert_chain_generate(cert_dic))
 
-    def test_087__pem_cert_chain_generate(self):
+    def test_089__pem_cert_chain_generate(self):
         """ _pem_cert_chain_generate - wrong dic """
         cert_dic = {'foo': 'bar'}
         self.assertFalse(self.cahandler._pem_cert_chain_generate(cert_dic))
 
-    def test_088__pem_cert_chain_generate(self):
+    def test_090__pem_cert_chain_generate(self):
         """ _pem_cert_chain_generate - certificateBase64 in dict """
         cert_dic = {'certificateBase64': 'certificateBase64'}
         self.assertEqual('-----BEGIN CERTIFICATE-----\ncertificateBase64\n-----END CERTIFICATE-----\n', self.cahandler._pem_cert_chain_generate(cert_dic))
 
     @patch('requests.get')
-    def test_089__pem_cert_chain_generate(self, mock_get):
+    def test_091__pem_cert_chain_generate(self, mock_get):
         """ _pem_cert_chain_generate - issuer in dict without certificateBase64 """
         cert_dic = {'issuer': 'issuer'}
         mockresponse = Mock()
@@ -923,7 +946,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler._pem_cert_chain_generate(cert_dic))
 
     @patch('requests.get')
-    def test_090__pem_cert_chain_generate(self, mock_get):
+    def test_092__pem_cert_chain_generate(self, mock_get):
         """ _pem_cert_chain_generate - request returns "certificates" but no active """
         cert_dic = {'issuer': 'issuer', 'certificateBase64': 'certificateBase641'}
         mockresponse1 = Mock()
@@ -934,7 +957,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual('-----BEGIN CERTIFICATE-----\ncertificateBase641\n-----END CERTIFICATE-----\n', self.cahandler._pem_cert_chain_generate(cert_dic))
 
     @patch('requests.get')
-    def test_091__pem_cert_chain_generate(self, mock_get):
+    def test_093__pem_cert_chain_generate(self, mock_get):
         """ _pem_cert_chain_generate - request returns certificate and active, 2nd request is bogus """
         cert_dic = {'issuer': 'issuer', 'certificateBase64': 'certificateBase641'}
         mockresponse1 = Mock()
@@ -945,7 +968,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual('-----BEGIN CERTIFICATE-----\ncertificateBase641\n-----END CERTIFICATE-----\n', self.cahandler._pem_cert_chain_generate(cert_dic))
 
     @patch('requests.get')
-    def test_092__pem_cert_chain_generate(self, mock_get):
+    def test_094__pem_cert_chain_generate(self, mock_get):
         """ _pem_cert_chain_generate - request returns certificate two certs """
         cert_dic = {'issuer': 'issuer', 'certificateBase64': 'certificateBase641'}
         mockresponse1 = Mock()
@@ -958,7 +981,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual('-----BEGIN CERTIFICATE-----\ncertificateBase641\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\ncertificateBase642\n-----END CERTIFICATE-----\n', self.cahandler._pem_cert_chain_generate(cert_dic))
 
     @patch('requests.get')
-    def test_093__pem_cert_chain_generate(self, mock_get):
+    def test_095__pem_cert_chain_generate(self, mock_get):
         """ _pem_cert_chain_generate - request returns certificate three certs """
         cert_dic = {'issuer': 'issuer', 'certificateBase64': 'certificateBase641'}
         mockresponse1 = Mock()
@@ -975,7 +998,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual('-----BEGIN CERTIFICATE-----\ncertificateBase641\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\ncertificateBase642\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\ncertificateBase643\n-----END CERTIFICATE-----\n', self.cahandler._pem_cert_chain_generate(cert_dic))
 
     @patch('requests.get')
-    def test_094__pem_cert_chain_generate(self, mock_get):
+    def test_096__pem_cert_chain_generate(self, mock_get):
         """ _pem_cert_chain_generate - issuerCa in """
         cert_dic = {'issuerCa': 'issuerCa', 'certificateBase64': 'certificateBase641'}
         mockresponse1 = Mock()
@@ -985,12 +1008,12 @@ class TestACMEHandler(unittest.TestCase):
         mock_get.side_effect = [mockresponse1, mockresponse2]
         self.assertEqual('-----BEGIN CERTIFICATE-----\ncertificateBase641\n-----END CERTIFICATE-----\n', self.cahandler._pem_cert_chain_generate(cert_dic))
 
-    def test_095__enter__(self):
+    def test_097__enter__(self):
         """ test __enter__ """
         self.cahandler.__enter__()
 
     @patch('requests.get')
-    def test_096_request_poll(self, mock_get):
+    def test_098_request_poll(self, mock_get):
         """ test request poll request returned exception """
         mock_get.side_effect = Exception('exc_api_get')
         result = ('"status" field not found in response.', None, None, 'url', False)
@@ -999,7 +1022,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('ERROR:test_a2c:CAhandler._request.poll() returned: exc_api_get', lcm.output)
 
     @patch('requests.get')
-    def test_097_request_poll(self, mock_get):
+    def test_099_request_poll(self, mock_get):
         """ test request poll request returned unknown status """
         mockresponse = Mock()
         mockresponse.json = lambda: {'status': 'unknown'}
@@ -1008,7 +1031,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(result, self.cahandler._request_poll('url'))
 
     @patch('requests.get')
-    def test_098_request_poll(self, mock_get):
+    def test_100_request_poll(self, mock_get):
         """ test request poll request returned status rejected """
         mockresponse = Mock()
         mockresponse.json = lambda: {'status': 'rejected'}
@@ -1017,7 +1040,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(result, self.cahandler._request_poll('url'))
 
     @patch('requests.get')
-    def test_099_request_poll(self, mock_get):
+    def test_101_request_poll(self, mock_get):
         """ test request poll request returned status accepted but no certinformation in """
         mockresponse = Mock()
         mockresponse.json = lambda: {'status': 'accepted', 'foo': 'bar'}
@@ -1026,7 +1049,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(result, self.cahandler._request_poll('url'))
 
     @patch('requests.get')
-    def test_100_request_poll(self, mock_get):
+    def test_102_request_poll(self, mock_get):
         """ test request poll request returned status accepted but no certinformation in """
         mockresponse = Mock()
         mockresponse.json = lambda: {'status': 'accepted', 'certificate': 'certificate'}
@@ -1036,7 +1059,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.certifier_ca_handler.CAhandler._pem_cert_chain_generate')
     @patch('requests.get')
-    def test_101_request_poll(self, mock_get, mock_pemgen):
+    def test_103_request_poll(self, mock_get, mock_pemgen):
         """ test request poll request returned status accepted but no certinformation in """
         mockresponse = Mock()
         mockresponse.json = lambda: {'status': 'accepted', 'certificate': 'certificate', 'certificateBase64': 'certificateBase64'}

--- a/test/test_digicert.py
+++ b/test/test_digicert.py
@@ -552,9 +552,10 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual((500, 'organisation_id is missing'), self.cahandler._order_send('csr', 'cn'))
         self.assertFalse(mock_orgid.called)
 
+    @patch('examples.ca_handler.digicert_ca_handler.enrollment_config_log')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._organiation_id_get')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_post')
-    def test_041_order_send(self, mock_post, mock_orgid):
+    def test_041_order_send(self, mock_post, mock_orgid, mock_ecl):
         """ test _order_send() """
         mock_post.return_value = ('code', 'content')
         self.cahandler.api_key = None
@@ -563,10 +564,26 @@ class TestACMEHandler(unittest.TestCase):
         mock_orgid.return_value = 1
         self.assertEqual((500, 'organisation_id is missing'), self.cahandler._order_send('csr', 'cn'))
         self.assertFalse(mock_orgid.called)
+        self.assertFalse(mock_ecl.called)
+
+    @patch('examples.ca_handler.digicert_ca_handler.enrollment_config_log')
+    @patch('examples.ca_handler.digicert_ca_handler.CAhandler._organiation_id_get')
+    @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_post')
+    def test_042_order_send(self, mock_post, mock_orgid, mock_ecl):
+        """ test _order_send() """
+        mock_post.return_value = ('code', 'content')
+        self.cahandler.api_key = None
+        self.cahandler.organization_name = 'organization_name'
+        self.cahandler.organization_id = None
+        self.cahandler.enrollment_config_log = True
+        mock_orgid.return_value = 1
+        self.assertEqual((500, 'organisation_id is missing'), self.cahandler._order_send('csr', 'cn'))
+        self.assertFalse(mock_orgid.called)
+        self.assertTrue(mock_ecl.called)
 
     @patch('examples.ca_handler.digicert_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.digicert_ca_handler.b64_encode')
-    def test_042_order_response_parse(self, mock_b64, mock_pem2der):
+    def test_043_order_response_parse(self, mock_b64, mock_pem2der):
         """ test _order_parse() """
         content_dic = {'id': 'id', 'certificate_chain': [{'pem': 'pem1'}, {'pem': 'pem2'}, {'pem': 'pem3'}]}
         mock_b64.return_value = 'b64'
@@ -574,7 +591,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.digicert_ca_handler.b64_encode')
-    def test_043_order_response_parse(self, mock_b64, mock_pem2der):
+    def test_044_order_response_parse(self, mock_b64, mock_pem2der):
         """ test _order_parse() """
         content_dic = {'id': 'id', 'cert_chain': [{'pem': 'pem1'}, {'pem': 'pem2'}, {'pem': 'pem3'}]}
         mock_b64.return_value = 'b64'
@@ -584,7 +601,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.digicert_ca_handler.b64_encode')
-    def test_044_order_response_parse(self, mock_b64, mock_pem2der):
+    def test_045_order_response_parse(self, mock_b64, mock_pem2der):
         """ test _order_parse() """
         content_dic = {'id': 'id', 'certificate_chain': [{'pem': 'pem1'}, {'_pem': 'pem2'}, {'pem': 'pem3'}]}
         mock_b64.return_value = 'b64'
@@ -594,7 +611,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.cert_pem2der')
     @patch('examples.ca_handler.digicert_ca_handler.b64_encode')
-    def test_045_order_response_parse(self, mock_b64, mock_pem2der):
+    def test_046_order_response_parse(self, mock_b64, mock_pem2der):
         """ test _order_parse() """
         content_dic = {'_id': 'id', 'certificate_chain': [{'pem': 'pem1'}, {'pem': 'pem2'}, {'pem': 'pem3'}]}
         mock_b64.return_value = 'b64'
@@ -603,7 +620,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('ERROR:test_a2c:CAhandler._order_response_parse() polling_identifier generation failed: no id in response', lcm.output)
 
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_get')
-    def test_046_organiation_id_get(self, mock_get):
+    def test_047_organiation_id_get(self, mock_get):
         """ test _organiation_id_get() """
         mock_get.return_value = (500, {'id': 'id'})
         self.cahandler.organization_name = 'organization_name'
@@ -613,14 +630,14 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.organization_id)
 
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_get')
-    def test_047_organiation_id_get(self, mock_get):
+    def test_048_organiation_id_get(self, mock_get):
         """ test _organiation_id_get() """
         mock_get.return_value = (200, {'organizations': [{'name': 'name1', 'id': 'id1'}, {'name': 'name2', 'id': 'id2'}, {'name': 'name3', 'id': 'id3'}]})
         self.cahandler.organization_name = 'name1'
         self.assertEqual('id1', self.cahandler._organiation_id_get())
 
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_get')
-    def test_048_organiation_id_get(self, mock_get):
+    def test_049_organiation_id_get(self, mock_get):
         """ test _organiation_id_get() """
         mock_get.return_value = (200, {'organizations': [{'name': 'name1', 'id': 'id1'}, {'name': 'name2', 'id': 'id2'}, {'name': 'name3', 'id': 'id3'}]})
         self.cahandler.organization_name = 'name2'
@@ -628,7 +645,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._allowed_domainlist_check')
-    def test_049_csr_check(self, mock_dlchk, mock_ehichk):
+    def test_050_csr_check(self, mock_dlchk, mock_ehichk):
         """ test _csr_check() """
         mock_dlchk.return_value = 'mock_dlchk'
         mock_ehichk.return_value = 'mock_hichk'
@@ -637,7 +654,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._allowed_domainlist_check')
-    def test_050_csr_check(self, mock_dlchk, mock_ehichk):
+    def test_051_csr_check(self, mock_dlchk, mock_ehichk):
         """ test _csr_check() """
         mock_dlchk.return_value = False
         mock_ehichk.return_value = 'mock_hichk'
@@ -645,7 +662,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.eab_profile_header_info_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._allowed_domainlist_check')
-    def test_051_csr_check(self, mock_dlchk, mock_ehichk):
+    def test_052_csr_check(self, mock_dlchk, mock_ehichk):
         """ test _csr_check() """
         mock_dlchk.return_value = False
         mock_ehichk.return_value = False
@@ -656,7 +673,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.digicert_ca_handler.csr_cn_lookup')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._csr_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._config_check')
-    def test_052_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
+    def test_053_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
         """ test enroll() """
         mock_cfgchk.return_value = 'mock_cfgchk'
         mock_csrchk.return_value = 'mock_csrchk'
@@ -675,7 +692,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.digicert_ca_handler.csr_cn_lookup')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._csr_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._config_check')
-    def test_053_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
+    def test_054_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
         """ test enroll() """
         mock_cfgchk.return_value = False
         mock_csrchk.return_value = 'mock_csrchk'
@@ -694,7 +711,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.digicert_ca_handler.csr_cn_lookup')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._csr_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._config_check')
-    def test_054_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
+    def test_055_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
         """ test enroll() """
         mock_cfgchk.return_value = False
         mock_csrchk.return_value = False
@@ -713,7 +730,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.digicert_ca_handler.csr_cn_lookup')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._csr_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._config_check')
-    def test_055_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
+    def test_056_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
         """ test enroll() """
         mock_cfgchk.return_value = False
         mock_csrchk.return_value = False
@@ -732,7 +749,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.digicert_ca_handler.csr_cn_lookup')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._csr_check')
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._config_check')
-    def test_056_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
+    def test_057_enroll(self, mock_cfgchk, mock_csrchk, mock_cnget, mock_ordersend, mock_orderparse):
         """ test enroll() """
         mock_cfgchk.return_value = False
         mock_csrchk.return_value = False
@@ -748,7 +765,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_put')
     @patch('examples.ca_handler.digicert_ca_handler.cert_serial_get')
-    def test_057_revoke(self, mock_serial, mock_put):
+    def test_058_revoke(self, mock_serial, mock_put):
         """ test revoke() """
         mock_serial.return_value = 'serial'
         mock_put.return_value = ('code', 'content')
@@ -756,7 +773,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_put')
     @patch('examples.ca_handler.digicert_ca_handler.cert_serial_get')
-    def test_058_revoke(self, mock_serial, mock_put):
+    def test_059_revoke(self, mock_serial, mock_put):
         """ test revoke() """
         mock_serial.return_value = None
         mock_put.return_value = ('code', 'content')
@@ -764,7 +781,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.digicert_ca_handler.CAhandler._api_put')
     @patch('examples.ca_handler.digicert_ca_handler.cert_serial_get')
-    def test_059_revoke(self, mock_serial, mock_put):
+    def test_060_revoke(self, mock_serial, mock_put):
         """ test revoke() """
         mock_serial.return_value = 'serial'
         mock_put.return_value = (204, 'content')

--- a/test/test_entrust.py
+++ b/test/test_entrust.py
@@ -1078,10 +1078,11 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(mock_der.called)
         self.assertTrue(mock_enc.called)
 
+    @patch('examples.ca_handler.entrust_ca_handler.enrollment_config_log')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._response_parse')
     @patch('examples.ca_handler.entrust_ca_handler.csr_cn_lookup')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_post')
-    def test_083_enroll(self, mock_req, mock_cn, mock_parse):
+    def test_083_enroll(self, mock_req, mock_cn, mock_parse, mock_ecl):
         """ test _enroll() """
         mock_cn.return_value = 'cn'
         mock_req.return_value = (201, 'response')
@@ -1090,6 +1091,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(mock_cn.called)
         self.assertTrue(mock_req.called)
         self.assertTrue(mock_parse.called)
+        self.assertFalse(mock_ecl.called)
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._response_parse')
     @patch('examples.ca_handler.entrust_ca_handler.csr_cn_lookup')
@@ -1117,9 +1119,25 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(mock_req.called)
         self.assertFalse(mock_parse.called)
 
+    @patch('examples.ca_handler.entrust_ca_handler.enrollment_config_log')
+    @patch('examples.ca_handler.entrust_ca_handler.CAhandler._response_parse')
+    @patch('examples.ca_handler.entrust_ca_handler.csr_cn_lookup')
+    @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_post')
+    def test_086_enroll(self, mock_req, mock_cn, mock_parse, mock_ecl):
+        """ test _enroll() """
+        mock_cn.return_value = 'cn'
+        mock_req.return_value = (201, 'response')
+        mock_parse.return_value = ('cert_bundle', 'cert_raw', 'poll_indentifier')
+        self.cahandler.enrollment_config_log = True
+        self.assertEqual((None, 'cert_bundle', 'cert_raw', 'poll_indentifier'), self.cahandler._enroll('csr'))
+        self.assertTrue(mock_cn.called)
+        self.assertTrue(mock_req.called)
+        self.assertTrue(mock_parse.called)
+        self.assertTrue(mock_ecl.called)
+
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._enroll')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._enroll_check')
-    def test_086_enroll(self, mock_chk, mock_enroll):
+    def test_087_enroll(self, mock_chk, mock_enroll):
         """ test enroll() """
         mock_chk.return_value = None
         mock_enroll.return_value = ('mock_err', 'mock_bundle', 'mock_raw', 'mock_poll')
@@ -1127,7 +1145,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._enroll')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._enroll_check')
-    def test_087_enroll(self, mock_chk, mock_enroll):
+    def test_088_enroll(self, mock_chk, mock_enroll):
         """ test enroll() """
         mock_chk.return_value = 'mock_chk'
         mock_enroll.return_value = ('mock_err', 'mock_bundle', 'mock_raw', 'mock_poll')
@@ -1135,7 +1153,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._trackingid_get')
-    def test_088_revoke(self, mock_track, mock_req):
+    def test_089_revoke(self, mock_track, mock_req):
         """ test revoke() """
         mock_track.return_value = 'tracking_id'
         mock_req.return_value = (200, 'response')
@@ -1143,7 +1161,7 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._trackingid_get')
-    def test_089_revoke(self, mock_track, mock_req):
+    def test_090_revoke(self, mock_track, mock_req):
         """ test revoke() """
         mock_track.return_value = 'tracking_id'
         mock_req.return_value = (500, 'response')
@@ -1151,14 +1169,14 @@ class TestACMEHandler(unittest.TestCase):
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._trackingid_get')
-    def test_090_revoke(self, mock_track, mock_req):
+    def test_091_revoke(self, mock_track, mock_req):
         """ test revoke() """
         mock_track.return_value = None
         mock_req.return_value = (200, 'response')
         self.assertEqual((500, 'urn:ietf:params:acme:error:serverInternal', 'Failed to get tracking id'), self.cahandler.revoke('csr'))
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_get')
-    def test_091_certificates_get(self, mock_req):
+    def test_092_certificates_get(self, mock_req):
         """ test certificates_get() """
         mock_req.return_value = (500, 'response')
         with self.assertLogs('test_a2c', level='INFO') as lcm:
@@ -1166,7 +1184,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('ERROR:test_a2c:CAhandler.certificates_get() failed with code: 500', lcm.output)
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_get')
-    def test_092_certificates_get(self, mock_req):
+    def test_093_certificates_get(self, mock_req):
         """ test certificates_get() """
         content = {'certificates': [1, 2, 3, 4], 'summary': {'total': 4}}
         mock_req.return_value = (200, content)
@@ -1175,7 +1193,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('INFO:test_a2c:fetching certs offset: 0, limit: 200, total: 1, buffered: 0', lcm.output)
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_get')
-    def test_093_certificates_get(self, mock_req):
+    def test_094_certificates_get(self, mock_req):
         """ test certificates_get() """
         response1 = (200, {'certificates': [1, 2, 3, 4], 'summary': {'total': 8}})
         response2 = (200, {'certificates': [5, 6, 7, 8]})
@@ -1186,7 +1204,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertIn('INFO:test_a2c:fetching certs offset: 200, limit: 200, total: 8, buffered: 4', lcm.output)
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_get')
-    def test_094_certificates_get(self, mock_req):
+    def test_095_certificates_get(self, mock_req):
         """ test certificates_get() """
         response1 = (200, {'certificates': [1, 2, 3, 4]})
         response2 = (200, {'certificates': [5, 6, 7, 8]})
@@ -1196,7 +1214,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual('Certificates lookup failed: did not get any total value', str(err.exception))
 
     @patch('examples.ca_handler.entrust_ca_handler.CAhandler._api_get')
-    def test_095_certificates_get(self, mock_req):
+    def test_096_certificates_get(self, mock_req):
         """ test certificates_get() """
         response1 = (200, {'certificates': [1, 2, 3, 4], 'summary': {'total': 9}})
         response2 = (200, {'certificates': [5, 6, 7, 8]})

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -3220,6 +3220,44 @@ jX1vlY35Ofonc4+6dRVamBiF9A==
         self.assertFalse(mock_post.called)
         self.assertFalse(mock_put.called)
 
+    def test_396_enrollment_config_log(self):
+        """ test enrollment_config_log() """
+        class myclass:
+            pass
+        myclass.foo = 'foo_val'
+        myclass.bar = 'bar_val'
+        myclass.password = 'password_val'
+        myclass.secret = 'secret_val'
+        with self.assertLogs('test_a2c', level='INFO') as lcm:
+            self.assertFalse(self.enrollment_config_log(self.logger, myclass))
+        self.assertIn("INFO:test_a2c:Enrollment configuration: ['foo: foo_val', 'bar: bar_val']", lcm.output)
+
+    def test_397_enrollment_config_log(self):
+        """ test enrollment_config_log() """
+        class myclass:
+            pass
+        myclass.foo = 'foo_val'
+        myclass.bar = 'bar_val'
+        myclass.foobar = 'foobar_val'
+        myclass.password = 'password_val'
+        myclass.secret = 'secret_val'
+        with self.assertLogs('test_a2c', level='INFO') as lcm:
+            self.assertFalse(self.enrollment_config_log(self.logger, myclass, ['foo', 'bar']))
+        self.assertIn("INFO:test_a2c:Enrollment configuration: ['foobar: foobar_val']", lcm.output)
+
+    def test_398_enrollment_config_log(self):
+        """ test enrollment_config_log() """
+        class myclass:
+            pass
+        myclass.foo = 'foo_val'
+        myclass.bar = 'bar_val'
+        myclass.foobar = 'foobar_val'
+        myclass.password = 'password_val'
+        myclass.secret = 'secret_val'
+        with self.assertLogs('test_a2c', level='INFO') as lcm:
+            self.assertFalse(self.enrollment_config_log(self.logger, myclass, 'ECLSLFAILURE'))
+        self.assertIn("ERROR:test_a2c:Enrollment configuration won't get logged due to a configuration error.", lcm.output)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_nclm_ca_handler.py
+++ b/test/test_nclm_ca_handler.py
@@ -1011,11 +1011,12 @@ class TestACMEHandler(unittest.TestCase):
         err_dic = {'serverinternal': 'serverinternal'}
         self.assertEqual((500, 'serverinternal', 'Revocation operation failed: Timeout'), self.cahandler._revocation_status_poll('cert_id', err_dic))
 
+    @patch('examples.ca_handler.nclm_ca_handler.enrollment_config_log')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._cert_enroll')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._template_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._ca_policylink_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.b64_url_recode')
-    def test_092_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
+    def test_092_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll, mock_ecl):
         """ test enroll """
         mock_recode.return_value = 'csr'
         mock_policy.return_value = 'policylink_id'
@@ -1028,12 +1029,34 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(mock_policy.called)
         self.assertTrue(mock_template.called)
         self.assertTrue(mock_enroll.called)
+        self.assertFalse(mock_ecl.called)
+
+    @patch('examples.ca_handler.nclm_ca_handler.enrollment_config_log')
+    @patch('examples.ca_handler.nclm_ca_handler.CAhandler._cert_enroll')
+    @patch('examples.ca_handler.nclm_ca_handler.CAhandler._template_id_lookup')
+    @patch('examples.ca_handler.nclm_ca_handler.CAhandler._ca_policylink_id_lookup')
+    @patch('examples.ca_handler.nclm_ca_handler.b64_url_recode')
+    def test_093_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll, mock_ecl):
+        """ test enroll """
+        mock_recode.return_value = 'csr'
+        mock_policy.return_value = 'policylink_id'
+        mock_template.return_value = 'template_id'
+        mock_enroll.return_value = ('error', 'bundle', 'raw', 'cert_id')
+        self.cahandler.enrollment_config_log = True
+        self.cahandler.template_info_dic = {'name': 'name', 'id': None}
+        self.cahandler.container_info_dic = {'name': 'name', 'id': 'id'}
+        self.assertEqual(('error', 'bundle', 'raw', 'cert_id'), self.cahandler.enroll('csr'))
+        self.assertTrue(mock_recode.called)
+        self.assertTrue(mock_policy.called)
+        self.assertTrue(mock_template.called)
+        self.assertTrue(mock_enroll.called)
+        self.assertTrue(mock_ecl.called)
 
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._cert_enroll')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._template_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._ca_policylink_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.b64_url_recode')
-    def test_093_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
+    def test_094_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
         """ test enroll """
         mock_recode.return_value = 'csr'
         mock_policy.return_value = 'policylink_id'
@@ -1051,7 +1074,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._template_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._ca_policylink_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.b64_url_recode')
-    def test_094_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
+    def test_095_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
         """ test enroll """
         mock_recode.return_value = 'csr'
         mock_policy.return_value = None
@@ -1069,7 +1092,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._template_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._ca_policylink_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.b64_url_recode')
-    def test_095_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
+    def test_096_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll):
         """ test enroll """
         mock_recode.return_value = 'csr'
         mock_policy.return_value = None
@@ -1089,7 +1112,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._template_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._ca_policylink_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.b64_url_recode')
-    def test_096_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll, mock_eab):
+    def test_097_enroll(self, mock_recode, mock_policy, mock_template, mock_enroll, mock_eab):
         """ test enroll """
         mock_recode.return_value = 'csr'
         mock_policy.return_value = 'policylink_id'
@@ -1108,7 +1131,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._cert_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.error_dic_get')
-    def test_097_revoke(self, mock_err, mock_idl, mock_post, mock_poll):
+    def test_098_revoke(self, mock_err, mock_idl, mock_post, mock_poll):
         """ test revoke """
         mock_err.return_value = {'foo': 'bar', 'serverinternal': 'serverinternal'}
         mock_idl.return_value = 'cert_id'
@@ -1124,7 +1147,7 @@ class TestACMEHandler(unittest.TestCase):
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._api_post')
     @patch('examples.ca_handler.nclm_ca_handler.CAhandler._cert_id_lookup')
     @patch('examples.ca_handler.nclm_ca_handler.error_dic_get')
-    def test_098_revoke(self, mock_err, mock_idl, mock_post, mock_poll):
+    def test_099_revoke(self, mock_err, mock_idl, mock_post, mock_poll):
         """ test revoke """
         mock_err.return_value = {'foo': 'bar', 'serverinternal': 'serverinternal'}
         mock_idl.return_value = 'cert_id'


### PR DESCRIPTION
introduction of an `enrollment_config_log` option in CA handler to log the enrollment configuration. Useful when debugging eab-profiling issues 