### PR TITLE
add nix flake package

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ coverage.lcov
 
 # apple stuff
 .DS_Store
+
+# Nix
+/.direnv
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750832941,
+        "narHash": "sha256-yz4OtUeHg548sealTins0GWYAu9C3fVbtabakUFckaM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2f892edcd78cfd1b451bf40d9695f4ef4b8f582b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "library implementing ACME server functionality";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = { self, ... }@inputs:
+  inputs.flake-parts.lib.mkFlake { inherit inputs self; } {
+    flake = {
+
+    };
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    perSystem = { self', pkgs, ... }: {
+      devShells = {
+        default = pkgs.mkShell {
+          nativeBuildInputs = [
+            pkgs.python3
+          ];
+        };
+      };
+
+      packages = {
+        default = self'.packages.acme2certifier;
+        acme2certifier = pkgs.callPackage ./utils/flake/acme2certifier.nix {
+          ca_handler = "acme_ca_handler.py"; # Override this to pick CA handler
+          config = {};
+          inherit self pkgs;
+        };
+      };
+
+      apps = {
+
+      };
+    };
+  };
+}

--- a/utils/flake/acme2certifier.nix
+++ b/utils/flake/acme2certifier.nix
@@ -1,0 +1,58 @@
+{ self, pkgs, ca_handler, config }: let
+
+  pythonPackages = pkgs.python313Packages;
+
+in pythonPackages.buildPythonPackage {
+  pname = "acme2certifier";
+  version = "0.37.1";
+  src = self;
+
+  ca_handler = "acme_ca_handler.py";
+
+  installPhase = let
+    srvConfig = (pkgs.formats.ini{}).generate "acme_srv.cfg" config;
+  in /* bash */ ''
+    mkdir -p $out/examples
+    cp examples/acme2certifier_wsgi.py $out/acme2certifier_wsgi.py
+    cp examples/ca_handler/${ca_handler} $out/ca_handler.py
+
+    cp -R examples/eab_handler/ $out/examples/eab_handler
+    cp -R examples/hooks/ $out/examples/hooks
+    cp -R examples/nginx/ $out/examples/nginx
+    #cp examples/acme_srv.cfg $out/examples
+    cp -R acme_srv/ $out/acme_srv
+    cp -R tools/ $out/tools
+    cp examples/db_handler/wsgi_handler.py $out/acme_srv/db_handler.py
+
+    cp ${srvConfig} $out/acme_srv/acme_srv.cfg
+  '';
+
+  dependencies = with pythonPackages; [
+    setuptools
+    jwcrypto
+    cryptography
+    pyopenssl
+    dnspython
+    # certsrv[ntlm]
+    pytz
+    configparser
+    python-dateutil
+    requests
+    pysocks
+    josepy
+    acme
+    xmltodict
+    pyasn1
+    pyasn1-modules
+    requests-pkcs12
+    requests-gssapi
+    gssapi
+    pyyaml
+    idna
+    werkzeug
+  ];
+
+  runtimeInputs = [
+    pkgs.krb5
+  ];
+}

--- a/utils/flake/module.nix
+++ b/utils/flake/module.nix
@@ -1,0 +1,1 @@
+_:{} # Not implemented yet


### PR DESCRIPTION
The package builds and functions but it currently requires some symlinks on the host.
I'm planning to add a proper module (hopefully next week) that will handle all of the requirements for it.

You can see the current config i was testing on my local CA here 
https://forgejo.spacetime.technology/arbel/nixos/src/branch/master/modules/server/security/acme/acme2certifier.nix

the `certsrv[ntlm]` package in [requirements.txt](https://github.com/grindsa/acme2certifier/blob/591d2721aa888309902685a5f52ad9c6e9b57be7/requirements.txt#L6C1-L6C14) is not in nixpkgs yet as far as i can tell.
it is not required for normal functionality right?