### PR TITLE
Fix logging of uncaught exceptions

### DIFF
--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -1784,7 +1784,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):  # pragma: no cover
         sys.__excepthook__(exc_type, exc_value, exc_traceback)
         return
 
-    logging.error("Uncaught exception")
+    logging.exception("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
 
 def pembundle_to_list(logger: logging.Logger, pem_bundle: str) -> List[str]:

--- a/examples/acme2certifier_wsgi.py
+++ b/examples/acme2certifier_wsgi.py
@@ -71,7 +71,7 @@ def handle_exception(exc_type, exc_value, exc_traceback):
         sys.__excepthook__(exc_type, exc_value, exc_traceback)  # pragma: no cover
         return  # pragma: no cover
 
-    LOGGER.error("Uncaught exception")
+    LOGGER.exception("Uncaught exception", exc_info=(exc_type, exc_value, exc_traceback))
 
 
 # initialize logger


### PR DESCRIPTION
I made a syntax error that caused this to happen, as it was, the log message was utterly useless...

So here is a much improved exception logline for uncaught exceptions.