### PR TITLE
Add example/email_hook.py 

### DIFF
--- a/examples/hooks/email_hook.py
+++ b/examples/hooks/email_hook.py
@@ -228,7 +228,7 @@ if __name__ == '__main__':
         '-----'
     )
 
-    # Generate the "certificate_raw" variable from the bundle in certificate_raw since it has all the info no need to duplicate it
+    # Generate the "certificate_raw" variable from the bundle in certificate since it has all the info no need to duplicate it
     cert, ca = x509.load_pem_x509_certificates(certificate.encode('utf-8'))
     certificate_raw = ''.join(cert.public_bytes(serialization.Encoding.PEM).decode('utf-8').splitlines()[1:-1])
 


### PR DESCRIPTION
Adds a useful hook that emails success/failure to configured recipient.

Fixes: https://github.com/grindsa/acme2certifier/issues/264

Note: Reposted after PR https://github.com/grindsa/acme2certifier/pull/265 vanished when I tried to base it on devel branch.