### PR TITLE
Make installable via pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,22 @@
 """build script for acme2certifier"""
 
+import pathlib
+
 from setuptools import setup
 from glob import glob
 from acme_srv.version import __version__
+
+def glob_files(pattern: str) -> t.List[str]:
+    """
+    like :func:`glob.glob()` but retrieve
+    only non-directories.
+    """
+    return [
+        file_
+        for file_ in pathlib.Path('.').glob(pattern)
+        if not file_.is_dir()
+    ]
+
 
 setup(
     name="acme2certifier",
@@ -14,45 +28,46 @@ setup(
     license="GPL",
     include_package_data=True,
     data_files=[
-        ("/usr/share/doc/acme2certifier/", glob("docs/*")),
-        ("/var/lib/acme2certifier/acme_srv/", glob("acme_srv/*.py")),
-        ("/var/lib/acme2certifier/examples", glob("examples/*.*")),
+        ("/usr/share/doc/acme2certifier/", glob_files("docs/*")),
+        ("/usr/share/doc/acme2certifier/architecture", glob_files("docs/architecture/*")),
+        ("/var/lib/acme2certifier/acme_srv/", glob_files("acme_srv/*.py")),
+        ("/var/lib/acme2certifier/examples", glob_files("examples/*.*")),
         (
             "/var/lib/acme2certifier/examples/ca_handler",
-            glob("examples/ca_handler/*.py"),
+            glob_files("examples/ca_handler/*.py"),
         ),
         (
             "/var/lib/acme2certifier/examples/db_handler",
-            glob("examples/db_handler/*.py"),
+            glob_files("examples/db_handler/*.py"),
         ),
-        ("/var/lib/acme2certifier/examples/django", glob("examples/django/*.py")),
+        ("/var/lib/acme2certifier/examples/django", glob_files("examples/django/*.py")),
         (
             "/var/lib/acme2certifier/examples/django/acme2certifier",
-            glob("examples/django/acme2certifier/*.py"),
+            glob_files("examples/django/acme2certifier/*.py"),
         ),
         (
             "/var/lib/acme2certifier/examples/django/acme",
-            glob("examples/django/acme/*.py"),
+            glob_files("examples/django/acme/*.py"),
         ),
         (
             "/var/lib/acme2certifier/examples/django/acme/fixture",
-            glob("examples/django/acme/fixture/*"),
+            glob_files("examples/django/acme/fixture/*"),
         ),
         (
             "/var/lib/acme2certifier/examples/django/acme/migrations",
-            glob("examples/django/acme/migrations/*.py"),
+            glob_files("examples/django/acme/migrations/*.py"),
         ),
-        ("/var/lib/acme2certifier/examples/nginx", glob("examples/nginx/*")),
-        ("/var/lib/acme2certifier/examples/trigger", glob("examples/trigger/*")),
-        ("/var/lib/acme2certifier/tools", glob("tools/*.py")),
-        ("/var/lib/acme2certifier/examples/Docker", glob("examples/Docker/*.*")),
+        ("/var/lib/acme2certifier/examples/nginx", glob_files("examples/nginx/*")),
+        ("/var/lib/acme2certifier/examples/trigger", glob_files("examples/trigger/*")),
+        ("/var/lib/acme2certifier/tools", glob_files("tools/*.py")),
+        ("/var/lib/acme2certifier/examples/Docker", glob_files("examples/Docker/*.*")),
         (
             "/var/lib/acme2certifier/examples/Docker/wsgi",
-            glob("examples/Docker/wsgi/*"),
+            glob_files("examples/Docker/wsgi/*"),
         ),
         (
             "/var/lib/acme2certifier/examples/Docker/django",
-            glob("examples/Docker/django/*"),
+            glob_files("examples/Docker/django/*"),
         ),
     ],
     platforms="any",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def glob_files(pattern: str) -> t.List[str]:
     """
     return [
         file_
-        for file_ in pathlib.Path('.').glob(pattern)
+        for file_ in pathlib.Path(".").glob(pattern)
         if not file_.is_dir()
     ]
 


### PR DESCRIPTION
Attempting to install acme2certifier via pip currently results in

> error: can't copy 'docs/architecture': doesn't exist or not a regular file
> [end of output]

This is because of the following glob in `setup.py`:

```Python
        ("/usr/share/doc/acme2certifier/", glob("docs/*")),
```

this includes `docs/architecture` which is not a file and setuptools does not seem to handle directories in data files.
