### PR TITLE
replace lstrip with removeprefix in WSGI path lookup

### DIFF
--- a/examples/acme2certifier_wsgi.py
+++ b/examples/acme2certifier_wsgi.py
@@ -562,7 +562,7 @@ def application(environ, start_response):
     prefix = "/"
     if "Directory" in CONFIG and "url_prefix" in CONFIG["Directory"]:
         prefix = CONFIG["Directory"]["url_prefix"] + "/"
-    path = environ.get("PATH_INFO", "").lstrip(prefix)
+    path = environ.get("PATH_INFO", "").removeprefix(prefix)
 
     for regex, callback in URLS:
         match = re.search(regex, path)


### PR DESCRIPTION
When starting a WSGI Server with the Directory:url_prefix configured: If the url_prefix contains characters from the requested path, too much is stripped from the path and some URLs become unreachable.

https://docs.python.org/3/library/stdtypes.html#str.lstrip

"The chars argument is not a prefix; rather, all combinations of its values are stripped."

removeprefix is python 3.9+ but should be safer. For check:

"/directory".lstrip("/devel-base")