### PR TITLE
Fix Location Header for Account Queries

### DIFF
--- a/.github/actions/wf_specific/error_tests/account_checks/action.yml
+++ b/.github/actions/wf_specific/error_tests/account_checks/action.yml
@@ -41,7 +41,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -58,13 +58,14 @@ runs:
       run: |
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "{'status': 400, 'type': 'urn:ietf:params:acme:error:malformed', 'detail': 'Contact information is missing'}"
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "{'status': 400, 'type': 'urn:ietf:params:acme:error:malformed', 'detail': 'Contact information is missing'}"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "{'status': 400, 'type': 'urn:ietf:params:acme:error:malformed', 'detail': 'Contact information is missing'}"
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "Test Registration with wrong email format"
       working-directory: acmeshell
@@ -78,7 +79,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -95,13 +96,14 @@ runs:
       run: |
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "{'status': 400, 'type': 'urn:ietf:params:acme:error:invalidContact', 'detail': 'The provided contact URI was invalid: Invalid contact information'}"
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "{'status': 400, 'type': 'urn:ietf:params:acme:error:invalidContact', 'detail': 'The provided contact URI was invalid: Invalid contact information'}"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "{'status': 400, 'type': 'urn:ietf:params:acme:error:invalidContact', 'detail': 'The provided contact URI was invalid: Invalid contact information'}"
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "Test Registration with correct email format"
       working-directory: acmeshell
@@ -118,7 +120,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -138,14 +140,15 @@ runs:
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "Account.onlyreturnexisting() ended with: 200"
           docker compose logs | grep "Account._deactivate_account("
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "Account.onlyreturnexisting() ended with: 200"
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "Account._deactivate_account("
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "Account.onlyreturnexisting() ended with: 200"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "Account._deactivate_account("
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "Test registration without TOC agreement using a modifed acme.sh"
       continue-on-error: true
@@ -154,7 +157,7 @@ runs:
         docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
         docker exec alma sed -i 's/termsOfServiceAgreed/foo/g' /root/.acme.sh/acme.sh
         docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
-        docker exec alma bash -c '/root/.acme.sh/acme.sh --register-account --server http://acme-srv --accountemail acme-sh@example.com'
+        docker exec alma bash -c '/root/.acme.sh/acme.sh --register-account --server http://$ACME_SERVER --accountemail acme-sh@example.com'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -172,14 +175,15 @@ runs:
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "no tos statement found."
           docker compose logs | grep "{'status': 403, 'type': 'urn:ietf:params:acme:error:userActionRequired', 'detail': 'termsofserviceagreed flag missing'}"
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "no tos statement found."
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "{'status': 403, 'type': 'urn:ietf:params:acme:error:userActionRequired', 'detail': 'termsofserviceagreed flag missing'}"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "no tos statement found."
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "{'status': 403, 'type': 'urn:ietf:params:acme:error:userActionRequired', 'detail': 'termsofserviceagreed flag missing'}"
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "Test registration with TOC agreement false using a modifed acme.sh"
       id: acmeshfail02
@@ -189,7 +193,7 @@ runs:
         docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
         docker exec alma sed -i 's/\\"termsOfServiceAgreed\\": true/\\"termsOfServiceAgreed\\": false/g' /root/.acme.sh/acme.sh
         docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
-        docker exec alma bash -c '/root/.acme.sh/acme.sh --register-account --server http://acme-srv --accountemail acme-sh@example.com'
+        docker exec alma bash -c '/root/.acme.sh/acme.sh --register-account --server http://$ACME_SERVER --accountemail acme-sh@example.com'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -207,14 +211,15 @@ runs:
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "tos:False"
           docker compose logs | grep "{'status': 403, 'type': 'urn:ietf:params:acme:error:userActionRequired', 'detail': 'Terms of service must be agreed'}"
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "tos:False"
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "{'status': 403, 'type': 'urn:ietf:params:acme:error:userActionRequired', 'detail': 'Terms of service must be agreed'}"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "tos:False"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "{'status': 403, 'type': 'urn:ietf:params:acme:error:userActionRequired', 'detail': 'Terms of service must be agreed'}"
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
 
     - name: "Update account information"
@@ -231,7 +236,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -251,14 +256,15 @@ runs:
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "validate: new@example.com result: True"
           docker compose logs | grep "DBStore.account_update("
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "validate: new@example.com result: True"
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "DBStore.account_update("
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "validate: new@example.com result: True"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "DBStore.account_update("
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "Unknown account request"
       working-directory: acmeshell
@@ -274,7 +280,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -291,9 +297,9 @@ runs:
       run: |
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "Error.acme_errormessage(urn:ietf:params:acme:error:malformed)"
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "Error.acme_errormessage(urn:ietf:params:acme:error:malformed)"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "Error.acme_errormessage(urn:ietf:params:acme:error:malformed)"
         fi
       shell: bash
       env:
@@ -313,7 +319,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -330,13 +336,14 @@ runs:
       run: |
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "Error.acme_errormessage(urn:ietf:params:acme:error:malformed)"
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "Error.acme_errormessage(urn:ietf:params:acme:error:malformed)"
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "Error.acme_errormessage(urn:ietf:params:acme:error:malformed)"
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "Key Rollover"
       working-directory: acmeshell
@@ -353,7 +360,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -372,11 +379,40 @@ runs:
         if [ "$DEPLOYMENT_TYPE" == "container" ]; then
           docker compose logs | grep "Account._rollover_account_key("
           docker compose logs | grep "Account._validate_key_change("
-          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-acme-srv-1)
+          sudo truncate -s 0 $(docker inspect --format='{{.LogPath}}' acme2certifier-$ACME_SERVER-1)
         elif [ "$DEPLOYMENT_TYPE" == "rpm" ]; then
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "Account._rollover_account_key("
-          docker exec -i acme-srv tail -n 500 /var/log/messages | grep "Account._validate_key_change("
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "Account._rollover_account_key("
+          docker exec -i $ACME_SERVER tail -n 500 /var/log/messages | grep "Account._validate_key_change("
         fi
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
+
+    - name: "Account query"
+      working-directory: acmeshell
+      run: |
+        rm -f acmeshell.enroll.log
+        cat <<EOT > commands.shell
+        newAccount -contacts=foo@bar.local,
+        post -body='{}' {{ account }}
+        EOT
+      shell: bash
+
+    - name: "Run acmeshell newAccount command"
+      working-directory: acmeshell
+      continue-on-error: true
+      run: |
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+      shell: bash
+      env:
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
+
+    - name: "Check acmeshell log"
+      working-directory: acmeshell
+      run: |
+        ACCOUNT_ID=$(grep -oP 'Created account with ID "http://[^/]+/acme/acct/\K[^"]+' acmeshell.enroll.log | uniq)
+        grep "Location: http://$ACME_SERVER/acme/acct/$ACCOUNT_ID" acmeshell.enroll.log
+      shell: bash
+      env:
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}

--- a/.github/actions/wf_specific/error_tests/account_checks/action.yml
+++ b/.github/actions/wf_specific/error_tests/account_checks/action.yml
@@ -405,7 +405,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}

--- a/.github/actions/wf_specific/error_tests/account_checks/action.yml
+++ b/.github/actions/wf_specific/error_tests/account_checks/action.yml
@@ -41,7 +41,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -50,6 +50,7 @@ runs:
     - name: "Check acmeshell log for invalidContact error"
       working-directory: acmeshell
       run: |
+        cat acmeshell.enroll.log
         grep "urn:ietf:params:acme:error:malformed" acmeshell.enroll.log
       shell: bash
 
@@ -79,7 +80,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -120,7 +121,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -154,10 +155,10 @@ runs:
       continue-on-error: true
       id: acmeshfail01
       run: |
-        docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
+        docker exec alma bash -c "grep regjson /root/.acme.sh/acme.sh"
         docker exec alma sed -i 's/termsOfServiceAgreed/foo/g' /root/.acme.sh/acme.sh
-        docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
-        docker exec alma bash -c '/root/.acme.sh/acme.sh --register-account --server http://$ACME_SERVER --accountemail acme-sh@example.com'
+        docker exec alma bash -c "grep regjson /root/.acme.sh/acme.sh"
+        docker exec alma bash -c "/root/.acme.sh/acme.sh --register-account --server http://$ACME_SERVER --accountemail acme-sh@example.com"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -189,11 +190,11 @@ runs:
       id: acmeshfail02
       continue-on-error: true
       run: |
-        docker exec alma bash -c 'cp /root/.acme.sh/acme.sh.bup /root/.acme.sh/acme.sh'
-        docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
+        docker exec alma bash -c "cp /root/.acme.sh/acme.sh.bup /root/.acme.sh/acme.sh"
+        docker exec alma bash -c "grep regjson /root/.acme.sh/acme.sh"
         docker exec alma sed -i 's/\\"termsOfServiceAgreed\\": true/\\"termsOfServiceAgreed\\": false/g' /root/.acme.sh/acme.sh
-        docker exec alma bash -c 'grep regjson /root/.acme.sh/acme.sh'
-        docker exec alma bash -c '/root/.acme.sh/acme.sh --register-account --server http://$ACME_SERVER --accountemail acme-sh@example.com'
+        docker exec alma bash -c "grep regjson /root/.acme.sh/acme.sh"
+        docker exec alma bash -c "/root/.acme.sh/acme.sh --register-account --server http://$ACME_SERVER --accountemail acme-sh@example.com"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -236,7 +237,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -280,7 +281,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -304,6 +305,7 @@ runs:
       shell: bash
       env:
         DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
 
     - name: "wrong status update"
       working-directory: acmeshell
@@ -319,7 +321,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -360,7 +362,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account=\"\" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}
@@ -403,7 +405,7 @@ runs:
       working-directory: acmeshell
       continue-on-error: true
       run: |
-        docker exec alma bash -c '/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log'
+        docker exec alma bash -c "/acmeshell/acmeshell -directory http://$ACME_SERVER -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/commands.shell &> /acmeshell/acmeshell.enroll.log"
       shell: bash
       env:
         ACME_SERVER: ${{ inputs.ACME_SERVER }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,34 @@ This is a high-level summary of the most important changes. For a full list of
 changes, see the [git commit log](https://github.com/grindsa/acme2certifier/commits)
 and pick the appropriate release branch.
 
+## Changes in 0.42.1
+
+**Bug Fixes**:
+
+- return valid "Location" header - element in case of account queries
+
+## Changes in 0.42
+
+**Features and Improvements**:
+
+- [Experimental support of MSSQl](https://github.com/grindsa/acme2certifier/blob/devel/docs/external_database_support.md#when-using-sql-server) via django-handler
+- [EAB SQL Handler](https://github.com/grindsa/acme2certifier/blob/devel/docs/eab.md#sql-handler)
+- run allowed_domainlist check as part of order processing
+- Refactoring of Core components completed
+
+## Changes in 0.41.3
+
+**Bug Fixes**:
+
+- [#307 - cert_operations_log option is not taken into account when logging certificate issuance](https://github.com/grindsa/acme2certifier/issues/306)
+
+## Changes in 0.41.2
+
+**Bug Fixes**:
+
+- [#304 - correct parsing of config files with without Challenge section](https://github.com/grindsa/acme2certifier/issues/304)
+- [#302 - fix when loading allowed_domain_list parameter from config](https://github.com/grindsa/acme2certifier/issues/302)\]
+
 ## Changes in 0.41.1
 
 **Bug Fixes**:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ and pick the appropriate release branch.
 
 **Bug Fixes**:
 
-- return valid "Location" header - element in case of account queries
+- Return a valid "Location" header for account queries
 
 ## Changes in 0.42
 

--- a/acme_srv/account.py
+++ b/acme_srv/account.py
@@ -645,7 +645,7 @@ class Account:
         account_obj = self._lookup_account_by_name(account_name)
         if account_obj:
             data = self._build_account_info(account_obj)
-            return self._build_response(200, None, data)
+            return self._build_response(200, account_name, data)
         return self._build_response(
             400, self.err_msg_dic["accountdoesnotexist"], "Account not found"
         )

--- a/acme_srv/version.py
+++ b/acme_srv/version.py
@@ -4,5 +4,5 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = "0.42"
+__version__ = "0.42.1"
 __dbversion__ = "0.41"

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -1222,6 +1222,26 @@ class TestAccount(unittest.TestCase):
             self.assertIn("data", result)
             mock_build_response.assert_called_once()
 
+    def test_051__handle_account_query_valid(self):
+        """test _handle_account_query with valid account"""
+        account_name = "test_account"
+        account_obj = {
+            "status": "valid",
+            "jwk": "{}",
+            "contact": "[]",
+            "created_at": "2026-02-08",
+        }
+        with patch.object(
+            self.account, "_lookup_account_by_name", return_value=account_obj
+        ), patch.object(
+            self.account, "_build_account_info", return_value={"status": "valid"}
+        ):
+            result = self.account._handle_account_query(account_name)
+            self.assertEqual(
+                "http://tester.local/acme/acct/test_account",
+                result["header"]["Location"],
+            )
+
     def test_051__handle_account_query_invalid(self):
         """test _handle_account_query with invalid account (not found)"""
         account_name = "test_account"


### PR DESCRIPTION
This PR addresses a bug where the "Location" header in responses to account information queries returned an invalid value (None) instead of the actual account name. The following changes were made:

- The `Account._handle_account_query()` method now correctly passes the account name to `_build_response()`, ensuring the "Location" header contains the queried account's identifier.
- Added a regression test to verify that the "Location" header is set correctly for valid account queries.
- Updated the version to 0.42.1 in `version.py`