### PR TITLE
[docs] Mention using OCI artifacts as volume source for acme.sh

### DIFF
--- a/examples/Docker/README.md
+++ b/examples/Docker/README.md
@@ -107,6 +107,43 @@ services:
 
 ______________________________________________________________________
 
+## Mounting acme.sh
+
+If you plan to use the ACME CA Handler to issue certificates using the DNS-01 challenge, a copy of [acme.sh](https://github.com/acmesh-official/acme.sh) needs to be present in the container. One can utilize the OCI volume driver in docker. This saves you from downloading and keeping acme.sh up-to-date outside of your container definition.
+
+```yaml
+version: '3.2'
+services:
+  acme-srv:
+    volumes:
+      - type: image
+        source: docker.io/neilpang/acme.sh:latest
+        target: /var/www/acme2certifier/volume/acmesh
+        volume:
+          subpath: acmebin
+```
+
+You can then tell acme_srv.cfg about these files like:
+
+```ini
+[CAhandler]
+acme_sh_script: /var/www/acme2certifier/volume/acmesh/acme.sh
+acme_sh_shell: /bin/bash
+dns_update_script: /var/www/acme2certifier/volume/acmesh/dnsapi/dns_cf.sh
+```
+
+**Note:**
+
+- Acme.sh is by default running with the HOME directory of the root user, and therefore wants to write files in a `/root/.acme.sh` directory inside the container. We can utilize `dns_update_script_variables` to override this location in acme_srv.cfg like so:
+
+  ```ini
+  dns_update_script_variables: {"LE_WORKING_DIR": "/var/www/acme2certifier/volume/acmehome"}
+  ```
+
+  The `acmehome` directory must already exist in your bind-mount for the volume
+
+______________________________________________________________________
+
 ## Starting acme2certifier
 
 ```bash


### PR DESCRIPTION
This Pull Request brings forward some of the notes and tips I made while deploying this software to my environment.

- Utilize the official acme.sh container for distributing the script files when using DNS-01 validation.
  - This is a recent-ish addition to Docker, moby/moby#48798. Since [4.3.0](https://github.com/containers/podman/releases/tag/v4.3.0) in Podman
  - The target being in `/var/www/acme2certifier/volume` is not arbitrary, as the files are owned by root in the upstream image, and therefore not readable from user www-data. It's piggybacking of the already established chown happening in the entrypoint (If desired, I can expand this PR to chown another directory earlier in the filetree for this purpose)
- As part of the validation process, I found acme.sh wanting to create a account.conf in /root, which www-data cannot write to, I documented how I navigated that fact with the current options in the software.