### PR TITLE
Min profile overwrite

### DIFF
--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -252,6 +252,16 @@ class Order(object):
                 self.logger.warning(
                     "Profile '%s' is not valid. Ignoring submitted profile.", profile
                 )
+                # cover cornercase, were whe have only one profile configured, and the submitted profile is not valid
+                # in this case we overwrite the submitted profile silently
+                if len(self.config.profiles.keys()) == 1:
+                    self.logger.info(
+                        "Only one profile configured. Overwriting submitted profile '%s' with '%s'.",
+                        profile,
+                        list(self.config.profiles.keys())[0],
+                    )
+                    error = None
+
         self.logger.debug("Order.is_profile_valid() ended with %s", error)
         return error
 
@@ -460,10 +470,11 @@ class Order(object):
         cahandler_cfg = profile_entry.get("cahandler", {})
         if param_name in cahandler_cfg:
             value = cahandler_cfg.get(param_name)
-            self.logger.warning(
-                "%s parameter found in cahandler section of the eab-profile - this is deprecated, please use the order section",
-                param_name,
-            )
+            if param_name != self.config.profile_mapping_field:
+                self.logger.warning(
+                    "%s parameter found in cahandler section of the eab-profile - this is deprecated, please use the order section",
+                    param_name,
+                )
             self.logger.debug(
                 "Order._apply_eab_profile() - apply %s from eab profile.", param_name
             )

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -252,7 +252,7 @@ class Order(object):
                 self.logger.warning(
                     "Profile '%s' is not valid. Ignoring submitted profile.", profile
                 )
-                # cover cornercase, were whe have only one profile configured, and the submitted profile is not valid
+                # cover cornercase, where we have only one profile configured, and the submitted profile is not valid
                 # in this case we overwrite the submitted profile silently
                 if len(self.config.profiles.keys()) == 1:
                     self.logger.info(
@@ -295,7 +295,24 @@ class Order(object):
         error = self.is_profile_valid(payload["profile"])
         if not error:
             if self.config.profiles:
-                data_dic["profile"] = payload["profile"]
+                profile = payload["profile"]
+                if (
+                    not self.config.profiles_check_disable
+                    and profile not in self.config.profiles
+                    and not (
+                        self.config.dryrun_profilename
+                        and self.config.dryrun_profilename == profile
+                    )
+                    and len(self.config.profiles.keys()) == 1
+                ):
+                    profile = list(self.config.profiles.keys())[0]
+                    self.logger.info(
+                        "Order.add_profile_to_order(): overwriting submitted profile '%s' with '%s'.",
+                        payload["profile"],
+                        profile,
+                    )
+
+                data_dic["profile"] = profile
             elif (
                 self.config.dryrun_profilename
                 and self.config.dryrun_profilename == payload["profile"]
@@ -389,6 +406,11 @@ class Order(object):
                 account_name,
             )
             self.config.profiles = eab_profile_dic
+            if self.config.profiles_check_disable:
+                self.logger.debug(
+                    "Order._apply_eab_profile() - enabling profile validation because EAB profile mapping is present"
+                )
+            self.config.profiles_check_disable = False
 
     def _profile_mapping_to_dict(self, profile_value) -> Dict[str, bool]:
         """Normalize profile mapping value to dict keys."""

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -410,7 +410,7 @@ class Order(object):
                 self.logger.debug(
                     "Order._apply_eab_profile() - enabling profile validation because EAB profile mapping is present"
                 )
-            self.config.profiles_check_disable = False
+                self.config.profiles_check_disable = False
 
     def _profile_mapping_to_dict(self, profile_value) -> Dict[str, bool]:
         """Normalize profile mapping value to dict keys."""

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -695,18 +695,32 @@ class Order(object):
         if not ca_handler_class:
             return None
 
-        # Attempt to instantiate the CAhandler class with logger, fallback to no-arg constructor if it fails
+        # Best effort: try instance attributes, but never fail startup on constructor issues.
+        ca_handler_obj = None
         try:
             ca_handler_obj = ca_handler_class(logger=self.logger)
         except TypeError:
-            ca_handler_obj = ca_handler_class()
-        mapping_field = getattr(ca_handler_obj, "profile_mapping_field", None)
-        if mapping_field:
-            self.logger.debug(
-                "Order._load_profile_mapping_field() - profile_mapping_field '%s' loaded from CAhandler instance",
-                mapping_field,
+            try:
+                ca_handler_obj = ca_handler_class()
+            except Exception as err_:
+                self.logger.warning(
+                    "Order._load_profile_mapping_field() - failed to instantiate CAhandler without logger: %s",
+                    err_,
+                )
+        except Exception as err_:
+            self.logger.warning(
+                "Order._load_profile_mapping_field() - failed to instantiate CAhandler with logger: %s",
+                err_,
             )
-            return mapping_field
+
+        if ca_handler_obj:
+            mapping_field = getattr(ca_handler_obj, "profile_mapping_field", None)
+            if mapping_field:
+                self.logger.debug(
+                    "Order._load_profile_mapping_field() - profile_mapping_field '%s' loaded from CAhandler instance",
+                    mapping_field,
+                )
+                return mapping_field
 
         # Check for class-level attribute if instance attribute is not found
         mapping_field = getattr(ca_handler_class, "profile_mapping_field", None)

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -7,6 +7,7 @@ from typing import Any, List, Tuple, Dict, Optional
 from dataclasses import dataclass, field
 from acme_srv.helper import (
     b64_url_recode,
+    ca_handler_load,
     config_allowed_domainlist_load,
     config_allowed_iplist_load,
     config_profile_load,
@@ -163,6 +164,7 @@ class OrderConfiguration:
     allowed_iplist: List[str] = field(default_factory=list)
     eab_profiling: bool = False
     eab_handler: Optional[Any] = None
+    profile_mapping_field: Optional[str] = None
     dryrun_profilename: Optional[str] = None
     wildcard_certificate_disable: bool = False
 
@@ -342,7 +344,10 @@ class Order(object):
                     "wildcard_certificate_disable",
                     self.config.wildcard_certificate_disable,
                 )
-                raise NotImplementedError('foo')
+
+                eab_profile_dic = self._load_eab_profile_mapping(profile_dic, eab_kid)
+                self._apply_eab_profile_mapping(account_name, eab_profile_dic)
+
         except Exception as err:
             self.logger.error(
                 "Failed to process EAB profile for Account %s (kid: %s): %s",
@@ -350,6 +355,56 @@ class Order(object):
                 eab_kid,
                 err,
             )
+
+    def _load_eab_profile_mapping(self, profile_dic, eab_kid) -> Dict[str, bool]:
+        """Load and normalize profile mapping from EAB profile."""
+        if not self.config.profile_mapping_field:
+            return {}
+
+        eab_profile = self._load_eab_profile_param(
+            profile_dic,
+            eab_kid,
+            self.config.profile_mapping_field,
+            None,
+        )
+        return self._profile_mapping_to_dict(eab_profile)
+
+    def _apply_eab_profile_mapping(
+        self, account_name: str, eab_profile_dic: Dict[str, bool]
+    ) -> None:
+        """Overwrite configured profiles with EAB profile mapping if provided."""
+        if eab_profile_dic:
+            self.logger.debug(
+                "Order._apply_eab_profile() - overwrite profile information from eab profile for account %s",
+                account_name,
+            )
+            self.config.profiles = eab_profile_dic
+
+    def _profile_mapping_to_dict(self, profile_value) -> Dict[str, bool]:
+        """Normalize profile mapping value to dict keys."""
+        if profile_value is None:
+            return {}
+
+        if isinstance(profile_value, str):
+            key = profile_value.strip()
+            return {key: True} if key else {}
+
+        if isinstance(profile_value, list):
+            return {
+                str(item).strip(): True
+                for item in profile_value
+                if item is not None and str(item).strip()
+            }
+
+        if isinstance(profile_value, dict):
+            # already in target format
+            return profile_value
+
+        self.logger.warning(
+            "Unsupported profile mapping type: %s",
+            type(profile_value).__name__,
+        )
+        return {}
 
     def create_order(
         self, payload: Dict[str, str], account_name: str
@@ -582,7 +637,54 @@ class Order(object):
             self.config.eab_handler,
         ) = config_eab_profile_load(self.logger, config_dic)
 
-        self.logger.debug("Order._config_load() ended.")
+        self.config.profile_mapping_field = self._load_profile_mapping_field(config_dic)
+
+        self.logger.debug("Order._load_configuration() ended.")
+
+    def _load_profile_mapping_field(self, config_dic: Dict[str, str]) -> Optional[str]:
+        """Load profile mapping field from configuration."""
+        self.logger.debug("Order._load_profile_mapping_field()")
+        ca_handler_module = ca_handler_load(self.logger, config_dic)
+
+        if not ca_handler_module:
+            return None
+
+        # Backward compatibility: allow module-level definition.
+        if hasattr(ca_handler_module, "profile_mapping_field"):
+            mapping_field = getattr(ca_handler_module, "profile_mapping_field")
+            self.logger.debug(
+                "Order._load_profile_mapping_field() - profile_mapping_field '%s' loaded from CA handler module",
+                mapping_field,
+            )
+            return mapping_field
+
+        ca_handler_class = getattr(ca_handler_module, "CAhandler", None)
+        if not ca_handler_class:
+            return None
+
+        # Attempt to instantiate the CAhandler class with logger, fallback to no-arg constructor if it fails
+        try:
+            ca_handler_obj = ca_handler_class(logger=self.logger)
+        except TypeError:
+            ca_handler_obj = ca_handler_class()
+        mapping_field = getattr(ca_handler_obj, "profile_mapping_field", None)
+        if mapping_field:
+            self.logger.debug(
+                "Order._load_profile_mapping_field() - profile_mapping_field '%s' loaded from CAhandler instance",
+                mapping_field,
+            )
+            return mapping_field
+
+        # Check for class-level attribute if instance attribute is not found
+        mapping_field = getattr(ca_handler_class, "profile_mapping_field", None)
+        if mapping_field:
+            self.logger.debug(
+                "Order._load_profile_mapping_field() - profile_mapping_field '%s' loaded from CAhandler class",
+                mapping_field,
+            )
+            return mapping_field
+
+        return None
 
     def _name_get(self, url: str) -> str:
         """get ordername"""

--- a/examples/ca_handler/asa_ca_handler.py
+++ b/examples/ca_handler/asa_ca_handler.py
@@ -52,6 +52,7 @@ class CAhandler(object):
         self.enrollment_config_log = False
         self.enrollment_config_log_skip_list = []
         self.profiles = {}
+        self.profile_mapping_field = "profile_name"
 
     def __enter__(self):
         """Makes CAhandler a Context Manager"""
@@ -232,7 +233,7 @@ class CAhandler(object):
             self._config_password_load(config_dic["CAhandler"])
             self._config_key_load(config_dic["CAhandler"])
             self.ca_name = config_dic["CAhandler"].get("ca_name")
-            self.profile_name = config_dic["CAhandler"].get("profile_name")
+            self.profile_name = config_dic["CAhandler"].get(self.profile_mapping_field)
 
             if (
                 "ca_bundle" in config_dic["CAhandler"]
@@ -266,7 +267,7 @@ class CAhandler(object):
             "api_password",
             "api_key",
             "ca_name",
-            "profile_name",
+            self.profile_mapping_field,
         ]:
             if not getattr(self, ele):
                 self.logger.error(
@@ -483,7 +484,7 @@ class CAhandler(object):
         poll_indentifier = None
 
         # check for eab profiling and header_info
-        error = eab_profile_header_info_check(self.logger, self, csr, "profile_name")
+        error = eab_profile_header_info_check(self.logger, self, csr, self.profile_mapping_field)
 
         if self.enrollment_config_log:
             self.enrollment_config_log_skip_list.extend(["api_password", "auth"])
@@ -531,7 +532,7 @@ class CAhandler(object):
                 "api_password",
                 "api_key",
                 "ca_name",
-                "profile_name",
+                self.profile_mapping_field,
             ],
         )
 

--- a/examples/ca_handler/certifier_ca_handler.py
+++ b/examples/ca_handler/certifier_ca_handler.py
@@ -55,6 +55,7 @@ class CAhandler(object):
         self.enrollment_config_log = False
         self.enrollment_config_log_skip_list = []
         self.profiles = {}
+        self.profile_mapping_field = "profile_id"
 
     def __enter__(self):
         """Makes ACMEHandler a Context Manager"""
@@ -386,7 +387,7 @@ class CAhandler(object):
         ) = config_enroll_config_log_load(self.logger, config_dic)
 
         # load profile_id
-        self.profile_id = config_dic.get("CAhandler", "profile_id", fallback=None)
+        self.profile_id = config_dic.get("CAhandler", self.profile_mapping_field, fallback=None)
 
         # check if we get a ca bundle for verification
         if "ca_bundle" in config_dic["CAhandler"]:
@@ -460,7 +461,7 @@ class CAhandler(object):
         self.logger.debug("CAhandler._csr_check()")
 
         # check for eab profiling and header_info
-        error = eab_profile_header_info_check(self.logger, self, csr, "profile_id")
+        error = eab_profile_header_info_check(self.logger, self, csr, self.profile_mapping_field)
 
         self.logger.debug("CAhandler._csr_check() ended with: %s", error)
         return error

--- a/examples/ca_handler/nclm_ca_handler.py
+++ b/examples/ca_handler/nclm_ca_handler.py
@@ -55,6 +55,7 @@ class CAhandler(object):
         self.enrollment_config_log = False
         self.enrollment_config_log_skip_list = []
         self.profiles = {}
+        self.profile_mapping_field = "template_name"
 
     def __enter__(self):
         """Makes CAhandler a Context Manager"""
@@ -477,7 +478,7 @@ class CAhandler(object):
         self.api_host = config_dic.get("CAhandler", "api_host", fallback=self.api_host)
         self.ca_name = config_dic.get("CAhandler", "ca_name", fallback=self.ca_name)
         self.template_info_dic["name"] = config_dic.get(
-            "CAhandler", "template_name", fallback=None
+            "CAhandler", self.profile_mapping_field, fallback=None
         )
         if "container_name" in config_dic["CAhandler"]:
             self.container_info_dic["name"] = config_dic.get(
@@ -611,7 +612,7 @@ class CAhandler(object):
         self.logger.debug("CAhandler._csr_check()")
 
         # check for eab profiling and header_info
-        error = eab_profile_header_info_check(self.logger, self, csr, "template_name")
+        error = eab_profile_header_info_check(self.logger, self, csr, self.profile_mapping_field)
 
         self.logger.debug("CAhandler._csr_check() ended with: %s", error)
         return error

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -316,7 +316,7 @@ class TestOrderClass(unittest.TestCase):
 
     def test_025_is_profile_valid_invalid(self):
         self.order.config.profiles_check_disable = False
-        self.order.config.profiles = {"bar": {}}
+        self.order.config.profiles = {"bar": True, "baz": True}
         with self.assertLogs("test_a2c", level="WARNING") as log_cm:
             self.assertEqual(
                 self.order.is_profile_valid("foo"),
@@ -327,7 +327,21 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_026_is_profile_valid_valid_profile(self):
+    def test_027_is_profile_valid_invalid_override(self):
+        self.order.config.profiles_check_disable = False
+        self.order.config.profiles = {"bar": True}
+        with self.assertLogs("test_a2c", level="INFO") as log_cm:
+            self.assertFalse(self.order.is_profile_valid("foo"))
+        self.assertIn(
+            "INFO:test_a2c:Only one profile configured. Overwriting submitted profile 'foo' with 'bar'.",
+            log_cm.output,
+        )
+        self.assertIn(
+            "INFO:test_a2c:Only one profile configured. Overwriting submitted profile 'foo' with 'bar'.",
+            log_cm.output,
+        )
+
+    def test_028_is_profile_valid_valid_profile(self):
 
         self.order.config.profiles_check_disable = True
         self.order.config.profiles = {"foo": {}}
@@ -347,7 +361,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_027_add_profile_to_order_valid(self):
+    def test_029_add_profile_to_order_valid(self):
         self.order.config.profiles = {"foo": {}}
         self.order.config.profiles_check_disable = False
         data_dic = {}
@@ -356,7 +370,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(updated_dic["profile"], "foo")
 
-    def test_028_add_profile_to_order_invalid(self):
+    def test_030_add_profile_to_order_invalid(self):
         self.order.config.profiles = {}
         self.order.config.profiles_check_disable = False
         data_dic = {}
@@ -365,7 +379,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(error, "urn:ietf:params:acme:error:invalidProfile")
         self.assertNotIn("profile", updated_dic)
 
-    def test_029_add_profile_to_order_no_profiles_configured(self):
+    def test_031_add_profile_to_order_no_profiles_configured(self):
         self.order.config.profiles = {}
         self.order.config.profiles_check_disable = False
         data_dic = {}
@@ -381,7 +395,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_030_process_order_request_db_error_logging(self):
+    def test_032_process_order_request_db_error_logging(self):
         self.order.repository.certificate_lookup.side_effect = Exception("DB error")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
             result = self.order._process_order_request(
@@ -392,7 +406,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_031_edge_case_empty_identifiers(self):
+    def test_033_edge_case_empty_identifiers(self):
         # _check_identifiers_validity with empty list
         result = self.order._check_identifiers_validity(
             []
@@ -402,7 +416,7 @@ class TestOrderClass(unittest.TestCase):
             (self.order.error_msg_dic["malformed"], "malformed identifiers list"),
         )
 
-    def test_032_edge_case_too_many_identifiers(self):
+    def test_034_edge_case_too_many_identifiers(self):
         # _check_identifiers_validity with too many identifiers
         self.order.config.identifier_limit = 1  # Set identifier limit to 1 for testing
         result = self.order._check_identifiers_validity(
@@ -416,7 +430,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_033_edge_case_invalid_identifier_type(self):
+    def test_035_edge_case_invalid_identifier_type(self):
         # are_identifiers_allowed with unsupported type
         self.order.config.tnauthlist_support = False
         self.order.config.email_identifier_support = False
@@ -429,7 +443,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_034_edge_case_missing_type(self):
+    def test_036_edge_case_missing_type(self):
         # are_identifiers_allowed with missing type
         result = self.order.are_identifiers_allowed([{"value": "bar"}])
         self.assertEqual(
@@ -437,13 +451,13 @@ class TestOrderClass(unittest.TestCase):
             (self.order.error_msg_dic["malformed"], "Identifier type is missing"),
         )
 
-    def test_035_edge_case_invalid_profile_config(self):
+    def test_037_edge_case_invalid_profile_config(self):
         # _set_profiles_from_db with invalid JSON
         with patch.object(self.order.logger, "error") as mock_log:
             self.order._set_profiles_from_db("notjson")
             mock_log.assert_called()
 
-    def test_036_order_dic_create_all_fields(self):
+    def test_038_order_dic_create_all_fields(self):
         # test _order_dic_create with all fields
         tmp_dic = {
             "status": "pending",
@@ -459,7 +473,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(result["notAfter"], "2009-02-13T23:31:32Z")
         self.assertIsInstance(result["identifiers"], list)
 
-    def test_037_order_dic_create_invalid_identifiers(self):
+    def test_039_order_dic_create_invalid_identifiers(self):
         # test _order_dic_create with invalid JSON in identifiers
         tmp_dic = {"identifiers": "notjson"}
         with patch.object(self.order.logger, "error") as mock_log:
@@ -468,7 +482,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertIn("identifiers", tmp_dic)
             mock_log.assert_called()
 
-    def test_038_get_authorization_list_db_error(self):
+    def test_040_get_authorization_list_db_error(self):
         # test _get_authorization_list with DB error
         self.order.repository.authorization_lookup.side_effect = Exception("DB error")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -478,7 +492,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_039_update_validity_list_ready(self):
+    def test_041_update_validity_list_ready(self):
         # test _update_validity_list sets order to ready
         authz_list = [{"name": "auth1", "status__name": "valid"}]
         order_dic = {"status": "pending", "authorizations": []}
@@ -486,7 +500,7 @@ class TestOrderClass(unittest.TestCase):
             self.order._update_validity_list(authz_list, order_dic, "_")
             mock_update.assert_called_with({"name": "_", "status": "ready"})
 
-    def test_040_update_validity_list_not_ready(self):
+    def test_042_update_validity_list_not_ready(self):
         # test _update_validity_list does not set order to ready
         authz_list = [{"name": "auth1", "status__name": "pending"}]
         order_dic = {"status": "pending", "authorizations": []}
@@ -494,7 +508,7 @@ class TestOrderClass(unittest.TestCase):
             self.order._update_validity_list(authz_list, order_dic, "_")
             mock_update.assert_not_called()
 
-    def test_041_get_order_details_with_authz(self):
+    def test_043_get_order_details_with_authz(self):
         # test get_order_details with authorizations
         self.order.repository.order_lookup.return_value = {
             "status": "pending",
@@ -508,7 +522,7 @@ class TestOrderClass(unittest.TestCase):
             mock_update.assert_called()
             self.assertIn("status", result)
 
-    def test_042_invalidate_expired_orders(self):
+    def test_044_invalidate_expired_orders(self):
         # test invalidate_expired_orders with valid and invalid orders
         self.order.repository.orders_invalid_search.return_value = [
             {"name": "order1", "status__name": "pending"},
@@ -520,7 +534,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertNotIn("order2", [o["name"] for o in output])
             mock_update.assert_called_once_with({"name": "order1", "status": "invalid"})
 
-    def test_043_create_from_content_success(self):
+    def test_045_create_from_content_success(self):
         # test create_from_content with successful order creation
         with patch.object(
             self.order.message,
@@ -554,7 +568,7 @@ class TestOrderClass(unittest.TestCase):
                     self.assertIn("header", result)
                     self.assertIn("data", result)
 
-    def test_044_create_from_content_rejected(self):
+    def test_046_create_from_content_rejected(self):
         # test create_from_content with rejected identifier
         with patch.object(
             self.order.message,
@@ -589,7 +603,7 @@ class TestOrderClass(unittest.TestCase):
                         "data" not in result or result.get("data", {}) == {}
                     )
 
-    def test_045_create_from_content_error(self):
+    def test_047_create_from_content_error(self):
         # test create_from_content with generic error
         with patch.object(
             self.order.message,
@@ -624,7 +638,7 @@ class TestOrderClass(unittest.TestCase):
                         "data" not in result or result.get("data", {}) == {}
                     )
 
-    def test_046_create_from_content_check_fail(self):
+    def test_048_create_from_content_check_fail(self):
         # test create_from_content with check returning error
         with patch.object(
             self.order.message,
@@ -639,7 +653,7 @@ class TestOrderClass(unittest.TestCase):
                 result = self.order.create_from_content("content")
                 self.assertIsInstance(result, dict)
 
-    def test_047_parse_order_message_all_paths(self):
+    def test_049_parse_order_message_all_paths(self):
         # test _parse_order_message for all code paths
         # url in protected, order_name, order_dic, process_order_request
         with patch.object(self.order, "_name_get", return_value="order"):
@@ -682,7 +696,7 @@ class TestOrderClass(unittest.TestCase):
         )
         self.assertEqual(code, 400)
 
-    def test_048_parse_order_content_success(self):
+    def test_050_parse_order_content_success(self):
         # test parse_order_content with code 200 and status processing
         with patch.object(
             self.order.message,
@@ -708,7 +722,7 @@ class TestOrderClass(unittest.TestCase):
                         self.assertIn("header", result)
                         self.assertIn("data", result)
 
-    def test_049_parse_order_content_expiry_disabled(self):
+    def test_051_parse_order_content_expiry_disabled(self):
         # test parse_order_content with expiry_check_disable True
         self.order.config.expiry_check_disable = True
         with patch.object(
@@ -735,7 +749,7 @@ class TestOrderClass(unittest.TestCase):
                         self.assertIn("header", result)
                         self.assertIn("data", result)
 
-    def test_050_legacy_api_compatibility(self):
+    def test_052_legacy_api_compatibility(self):
         # test legacy API wrappers
         with patch.object(
             self.order, "invalidate_expired_orders", return_value=([], [])
@@ -750,7 +764,7 @@ class TestOrderClass(unittest.TestCase):
         ):
             self.assertEqual(self.order.parse("content"), {"foo": "bar"})
 
-    def test_051_add_order_and_authorizations_success(self):
+    def test_053_add_order_and_authorizations_success(self):
         # Order and authorizations added successfully
         self.order.repository.add_order.return_value = "oid"
         self.order.repository.add_authorization.return_value = None
@@ -778,7 +792,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_called_once()
 
-    def test_052_add_order_and_authorizations_order_db_error(self):
+    def test_054_add_order_and_authorizations_order_db_error(self):
         # Adding order raises DB error
         self.order.repository.add_order.side_effect = Exception("fail")
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -807,7 +821,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_called_once_with(None, payload, auth_dic)
 
-    def test_053_add_order_and_authorizations_authz_db_error(self):
+    def test_055_add_order_and_authorizations_authz_db_error(self):
         # Adding authorization raises DB error
         self.order.repository.add_order.return_value = "oid"
         self.order.repository.add_authorization.side_effect = Exception("fail")
@@ -836,7 +850,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_called_once()
 
-    def test_054_add_order_and_authorizations_with_error_input(self):
+    def test_056_add_order_and_authorizations_with_error_input(self):
         # If error is already set, should skip adding order/authorizations
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
         data_dic = {"foo": "bar"}
@@ -863,7 +877,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_not_called()
 
-    def test_055_add_order_and_authorizations_logging(self):
+    def test_057_add_order_and_authorizations_logging(self):
         self.order.repository.add_order.return_value = "oid"
         self.order.repository.add_authorization.return_value = None
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -881,25 +895,25 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_056_load_header_info_config_valid(self):
+    def test_058_load_header_info_config_valid(self):
         config_dic = {"Order": {"header_info_list": '["X-Header1", "X-Header2"]'}}
         self.order.config.header_info_list = []
         self.order._load_header_info_config(config_dic)
         self.assertEqual(self.order.config.header_info_list, ["X-Header1", "X-Header2"])
 
-    def test_057_load_header_info_config_invalid_json(self):
+    def test_059_load_header_info_config_invalid_json(self):
         config_dic = {"Order": {"header_info_list": "notjson"}}
         with patch.object(self.order.logger, "warning") as mock_warn:
             self.order._load_header_info_config(config_dic)
             mock_warn.assert_called()
 
-    def test_058_load_header_info_config_missing_key(self):
+    def test_060_load_header_info_config_missing_key(self):
         config_dic = {"Order": {}}
         self.order.config.header_info_list = ["shouldnotchange"]
         self.order._load_header_info_config(config_dic)
         self.assertEqual(self.order.config.header_info_list, ["shouldnotchange"])
 
-    def test_059_load_header_info_config_logging(self):
+    def test_061_load_header_info_config_logging(self):
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             config_dic = {"Order": {"header_info_list": '["X-Header1"]'}}
             self.order._load_header_info_config(config_dic)
@@ -915,7 +929,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_060_load_order_config_all_options(self):
+    def test_062_load_order_config_all_options(self):
         import configparser
 
         config_dic = configparser.ConfigParser()
@@ -941,7 +955,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(self.order.config.validity, 456)
         self.assertEqual(self.order.config.identifier_limit, 7)
 
-    def test_061_load_order_config_invalid_ints(self):
+    def test_063_load_order_config_invalid_ints(self):
         import configparser
 
         config_dic = configparser.ConfigParser()
@@ -966,7 +980,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_062_load_order_config_missing_sections(self):
+    def test_064_load_order_config_missing_sections(self):
         import configparser
 
         config_dic = configparser.ConfigParser()
@@ -977,7 +991,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(self.order.config.validity, 86400)
         self.assertEqual(self.order.config.identifier_limit, 20)
 
-    def test_063_create_order_invalid_identifiers(self):
+    def test_065_create_order_invalid_identifiers(self):
         # Identifiers are invalid, triggers error path
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
         account_name = "acct"
@@ -995,7 +1009,7 @@ class TestOrderClass(unittest.TestCase):
             mock_check.assert_called_once()
             mock_add_order_authz.assert_called_once()
 
-    def test_064_create_order_profile_invalid(self):
+    def test_066_create_order_profile_invalid(self):
         # Profile is present but invalid, triggers error path
         payload = {
             "identifiers": [{"type": "dns", "value": "example.com"}],
@@ -1028,7 +1042,7 @@ class TestOrderClass(unittest.TestCase):
             mock_add_profile.assert_called_once()
             mock_add_order_authz.assert_called_once()
 
-    def test_065_create_order_add_order_and_authz_error(self):
+    def test_067_create_order_add_order_and_authz_error(self):
         # Error occurs in _add_order_and_authorizations
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
         account_name = "acct"
@@ -1044,7 +1058,7 @@ class TestOrderClass(unittest.TestCase):
             mock_check.assert_called_once()
             mock_add_order_authz.assert_called_once()
 
-    def test_066_create_order_no_identifiers(self):
+    def test_068_create_order_no_identifiers(self):
         # Payload missing 'identifiers', triggers unsupportedidentifier error
         payload = {"profile": "foo"}
         account_name = "acct"
@@ -1060,7 +1074,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertEqual(expires, "2009-02-14T23:31:30Z")
             self.assertFalse(detail)
 
-    def test_067_create_order_logging(self):
+    def test_069_create_order_logging(self):
         # Check all log messages with severity INFO and higher
         # Use unified logger and log_stream
         with patch(
@@ -1099,10 +1113,12 @@ class TestOrderClass(unittest.TestCase):
                     "DEBUG:test_a2c:Order.create_order() ended", log_cm.output
                 )
 
-    def test_068_load_profile_config_all_paths(self):
-        with patch.object(self.order, "_load_profiles_from_config") as m1, patch.object(
-            self.order, "_load_profiles_from_db_if_sync"
-        ) as m2, patch.object(self.order, "_maybe_disable_profile_check") as m3:
+    def test_070_load_profile_config_all_paths(self):
+        with (
+            patch.object(self.order, "_load_profiles_from_config") as m1,
+            patch.object(self.order, "_load_profiles_from_db_if_sync") as m2,
+            patch.object(self.order, "_maybe_disable_profile_check") as m3,
+        ):
             with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
                 self.order._load_profile_config({"Order": {}, "CAhandler": {}})
                 m1.assert_called_once()
@@ -1113,10 +1129,12 @@ class TestOrderClass(unittest.TestCase):
             "DEBUG:test_a2c:Order._load_profile_config() ended", log_cm.output
         )
 
-    def test_069_load_profile_config_all_paths(self):
-        with patch.object(self.order, "_load_profiles_from_config") as m1, patch.object(
-            self.order, "_load_profiles_from_db_if_sync"
-        ) as m2, patch.object(self.order, "_maybe_disable_profile_check") as m3:
+    def test_071_load_profile_config_all_paths(self):
+        with (
+            patch.object(self.order, "_load_profiles_from_config") as m1,
+            patch.object(self.order, "_load_profiles_from_db_if_sync") as m2,
+            patch.object(self.order, "_maybe_disable_profile_check") as m3,
+        ):
             with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
                 self.order._load_profile_config({"Order": {}, "CAhandler": {}})
                 m1.assert_called_once()
@@ -1128,7 +1146,7 @@ class TestOrderClass(unittest.TestCase):
             "DEBUG:test_a2c:Order._load_profile_config() ended", log_cm.output
         )
 
-    def test_070_load_profiles_from_config_with_profiles(self):
+    def test_072_load_profiles_from_config_with_profiles(self):
         # Should load profiles and set profiles_check_disable to False
         config_dic = {
             "Order": {
@@ -1146,7 +1164,7 @@ class TestOrderClass(unittest.TestCase):
             },
         )
 
-    def test_071_load_profiles_from_config_no_profiles(self):
+    def test_073_load_profiles_from_config_no_profiles(self):
         # Should not set profiles or change profiles_check_disable
         config_dic = {"Order": {}}
         self.order.config.profiles = {"bar": {}}
@@ -1155,7 +1173,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(self.order.config.profiles, {"bar": {}})
         self.assertTrue(self.order.config.profiles_check_disable)
 
-    def test_072_load_profiles_from_db_if_sync_profiles_sync_true(self):
+    def test_074_load_profiles_from_db_if_sync_profiles_sync_true(self):
         # Should load profiles from DB if profiles_sync is set and True
         import configparser
 
@@ -1172,7 +1190,7 @@ class TestOrderClass(unittest.TestCase):
             '{"profiles": {"foo": {}}}'
         )
 
-    def test_073_load_profiles_from_db_if_sync_profiles_sync_false(self):
+    def test_075_load_profiles_from_db_if_sync_profiles_sync_false(self):
         # Should not load profiles from DB if profiles_sync is False
         import configparser
 
@@ -1185,7 +1203,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertFalse(self.order.config.profiles_sync)
         self.order._set_profiles_from_db.assert_not_called()
 
-    def test_074_load_profiles_from_db_if_sync_no_profiles_sync(self):
+    def test_076_load_profiles_from_db_if_sync_no_profiles_sync(self):
         # Should not load profiles from DB if profiles_sync key is missing
 
         config_dic = {"CAhandler": {}}
@@ -1198,7 +1216,7 @@ class TestOrderClass(unittest.TestCase):
         )
         self.order._set_profiles_from_db.assert_not_called()
 
-    def test_075_load_profiles_from_db_if_sync_db_error(self):
+    def test_077_load_profiles_from_db_if_sync_db_error(self):
         # Should log and handle DB error
         import configparser
 
@@ -1216,18 +1234,18 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_076_set_profiles_from_db_valid_json(self):
+    def test_078_set_profiles_from_db_valid_json(self):
         # Should set profiles from valid JSON string
         self.order._set_profiles_from_db('{"profiles": {"foo": {}}}')
         self.assertEqual(self.order.config.profiles, {"foo": {}})
 
-    def test_077_set_profiles_from_db_invalid_json(self):
+    def test_079_set_profiles_from_db_invalid_json(self):
         # Should log error on invalid JSON
         with patch.object(self.order.logger, "error") as mock_log:
             self.order._set_profiles_from_db("notjson")
             mock_log.assert_called()
 
-    def test_078_maybe_disable_profile_check_true(self):
+    def test_080_maybe_disable_profile_check_true(self):
         # Should set profiles_check_disable to True if config says so
         import configparser
 
@@ -1238,7 +1256,7 @@ class TestOrderClass(unittest.TestCase):
         self.order._maybe_disable_profile_check(config_dic)
         self.assertTrue(self.order.config.profiles_check_disable)
 
-    def test_079_maybe_disable_profile_check_false(self):
+    def test_081_maybe_disable_profile_check_false(self):
         # Should set profiles_check_disable to False if config says so
         import configparser
 
@@ -1249,7 +1267,7 @@ class TestOrderClass(unittest.TestCase):
         self.order._maybe_disable_profile_check(config_dic)
         self.assertFalse(self.order.config.profiles_check_disable)
 
-    def test_080_maybe_disable_profile_check_no_profiles(self):
+    def test_082_maybe_disable_profile_check_no_profiles(self):
         # Should not change profiles_check_disable if no profiles
         import configparser
 
@@ -1261,7 +1279,7 @@ class TestOrderClass(unittest.TestCase):
         self.order._maybe_disable_profile_check(config_dic)
         self.assertFalse(self.order.config.profiles_check_disable)
 
-    def test_081_load_configuration_authz_validity_error(self):
+    def test_083_load_configuration_authz_validity_error(self):
         # Test _load_configuration with invalid Authorization validity (should log warning)
         # Use unified logger and log_stream
         import configparser
@@ -1281,7 +1299,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_082_load_configuration_without_ordersection(self):
+    def test_084_load_configuration_without_ordersection(self):
         # Test _load_configuration without oder section in config (should use defaults and log warnings for missing options)
         import configparser
 
@@ -1296,14 +1314,14 @@ class TestOrderClass(unittest.TestCase):
             self.assertEqual(self.order.config.validity, 86400)
             self.assertEqual(self.order.config.identifier_limit, 20)
 
-    def test_083_name_get_logging(self):
+    def test_085_name_get_logging(self):
         with patch(
             "acme_srv.order.parse_url", return_value={"path": "/acme/order/ord123"}
         ):
             result = self.order._name_get("/acme/order/ord123")
             self.assertEqual(result, "ord123")
 
-    def test_084_name_get_with_slash(self):
+    def test_086_name_get_with_slash(self):
         # Should split and return first part if slash in order name
         with patch(
             "acme_srv.order.parse_url",
@@ -1312,7 +1330,7 @@ class TestOrderClass(unittest.TestCase):
             result = self.order._name_get("/acme/order/ord456/extra")
             self.assertEqual(result, "ord456")
 
-    def test_085_name_get_logging(self):
+    def test_087_name_get_logging(self):
         # Should log debug messages using central logger and log_stream
         with patch(
             "acme_srv.order.parse_url", return_value={"path": "/acme/order/ord789"}
@@ -1324,7 +1342,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertIn("DEBUG:test_a2c:Order._name_get() ended", log_cm.output)
 
-    def test_086_are_identifiers_allowed_valid(self):
+    def test_088_are_identifiers_allowed_valid(self):
         # Should return None for valid identifiers
         with patch("acme_srv.order.validate_identifier", return_value=True):
             result = self.order.are_identifiers_allowed(
@@ -1332,7 +1350,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_087_are_identifiers_allowed_invalid_type(self):
+    def test_089_are_identifiers_allowed_invalid_type(self):
         # Should return unsupportedidentifier for unknown type
         with patch("acme_srv.order.validate_identifier", return_value=True):
             result = self.order.are_identifiers_allowed(
@@ -1346,7 +1364,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_088_are_identifiers_allowed_invalid_value(self):
+    def test_090_are_identifiers_allowed_invalid_value(self):
         # Should return rejectedidentifier if validate_identifier returns False
         with patch("acme_srv.order.validate_identifier", return_value=False):
             result = self.order.are_identifiers_allowed(
@@ -1360,7 +1378,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_089_are_identifiers_allowed_missing_type(self):
+    def test_091_are_identifiers_allowed_missing_type(self):
         # Should return malformed if type is missing
         result = self.order.are_identifiers_allowed([{"value": "foo.com"}])
         result = self.order.are_identifiers_allowed([{"value": "foo.com"}])
@@ -1369,7 +1387,7 @@ class TestOrderClass(unittest.TestCase):
             (self.order.error_msg_dic["malformed"], "Identifier type is missing"),
         )
 
-    def test_090_are_identifiers_allowed_tnauthlist_and_email(self):
+    def test_092_are_identifiers_allowed_tnauthlist_and_email(self):
         # Should allow tnauthlist and email if config enabled
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.tnauthlist_support = True
@@ -1382,7 +1400,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_092_are_identifiers_allowed_wildcard_rejected_when_disabled(self):
+    def test_093_are_identifiers_allowed_wildcard_rejected_when_disabled(self):
         # Should reject wildcard DNS identifiers when wildcard support is disabled
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.wildcard_certificate_disable = True
@@ -1397,7 +1415,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_093_are_identifiers_allowed_wildcard_allowed_when_not_disabled(self):
+    def test_094_are_identifiers_allowed_wildcard_allowed_when_not_disabled(self):
         # Should allow wildcard DNS identifiers when wildcard support is enabled
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.wildcard_certificate_disable = False
@@ -1406,7 +1424,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_094_rewrite_email_identifiers_basic(self):
+    def test_095_rewrite_email_identifiers_basic(self):
         # Should rewrite DNS with @ to email
         self.order.config.email_identifier_support = True
         self.order.config.email_identifier_rewrite = True
@@ -1417,7 +1435,7 @@ class TestOrderClass(unittest.TestCase):
             result[0]["value"], "foo@bar.com"
         )  # Additional assertion to differentiate
 
-    def test_095_rewrite_email_identifiers_no_rewrite(self):
+    def test_096_rewrite_email_identifiers_no_rewrite(self):
         # Should not rewrite if no @ in value
         input_list = [{"type": "dns", "value": "foobar.com"}]
         result = self.order._rewrite_email_identifiers(input_list)
@@ -1426,7 +1444,7 @@ class TestOrderClass(unittest.TestCase):
             result[0]["value"], "foobar.com"
         )  # Additional assertion to differentiate
 
-    def test_096_rewrite_email_identifiers_other_types(self):
+    def test_097_rewrite_email_identifiers_other_types(self):
         # Should not rewrite if type is not dns
         input_list = [{"type": "email", "value": "foo@bar.com"}]
         result = self.order._rewrite_email_identifiers(input_list)
@@ -1435,7 +1453,7 @@ class TestOrderClass(unittest.TestCase):
             result[0]["value"], "foo@bar.com"
         )  # Additional assertion to differentiate
 
-    def test_097_rewrite_email_identifiers_logging(self):
+    def test_098_rewrite_email_identifiers_logging(self):
         # Should log info and debug messages using the unified logger
         self.order.config.email_identifier_support = True
         self.order.config.email_identifier_rewrite = True
@@ -1453,7 +1471,7 @@ class TestOrderClass(unittest.TestCase):
             "DEBUG:test_a2c:Order._rewrite_email_identifiers() ended", log_cm.output
         )
 
-    def test_098_name_get_basic(self):
+    def test_099_name_get_basic(self):
         # Should log debug messages using central logger and log_stream
         with patch(
             "acme_srv.order.parse_url", return_value={"path": "/acme/order/ord123"}
@@ -1466,7 +1484,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertIn("DEBUG:test_a2c:Order._name_get() ended", log_cm.output)
 
-    def test_099_process_csr_all_paths(self):
+    def test_100_process_csr_all_paths(self):
         # Covers: found, not found, error, logging
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             # Found path
@@ -1492,7 +1510,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_100_process_csr_rejected_identifier(self):
+    def test_101_process_csr_rejected_identifier(self):
         # Covers: enroll_and_store returns rejectedIdentifier leading to 401
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             self.order._get_order_info = MagicMock(return_value={"name": "order1"})
@@ -1514,7 +1532,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_101_process_csr_serverinternal_error(self):
+    def test_102_process_csr_serverinternal_error(self):
         # Covers: enroll_and_store returns serverinternal leading to 500
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
 
@@ -1542,7 +1560,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_102_process_csr_certificate_store_failure(self):
+    def test_103_process_csr_certificate_store_failure(self):
         # Covers: store_csr returns falsy leading to 500 and CSR processing failed detail
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             self.order._get_order_info = MagicMock(return_value={"name": "order1"})
@@ -1566,7 +1584,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_103_finalize_order_all_paths(self):
+    def test_104_finalize_order_all_paths(self):
         # Covers: ready, valid/idempotent, not ready, logging
 
         # Ready path
@@ -1588,7 +1606,7 @@ class TestOrderClass(unittest.TestCase):
         result = self.order._finalize_order("order1", {"csr": "csrval"})
         self.assertEqual(result[0], 403)
 
-    def test_104_finalize_csr_updates_status_when_no_detail(self):
+    def test_105_finalize_csr_updates_status_when_no_detail(self):
         # When code==200 and no detail, order_status should update to valid
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
@@ -1599,7 +1617,7 @@ class TestOrderClass(unittest.TestCase):
             {"name": "order1", "status": "valid"}
         )
 
-    def test_105_finalize_csr_handles_timeout(self):
+    def test_106_finalize_csr_handles_timeout(self):
         # When certificate_name=='timeout', code is set to 200 and message=timeout
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
@@ -1611,7 +1629,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_106_finalize_csr_handles_rejected_identifier(self):
+    def test_107_finalize_csr_handles_rejected_identifier(self):
         # When certificate_name=='urn:ietf:params:acme:error:rejectedIdentifier', code=401 and message set
         self.order._header_info_lookup = MagicMock(return_value={})
         rej = "urn:ietf:params:acme:error:rejectedIdentifier"
@@ -1623,7 +1641,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_107_finalize_csr_enrollment_failed_else_branch(self):
+    def test_108_finalize_csr_enrollment_failed_else_branch(self):
         # Else branch: message set to certificate_name and detail='enrollment failed'
 
         self.order.repository.order_update = MagicMock()
@@ -1636,7 +1654,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_108_order_dic_create_all_paths(self):
+    def test_109_order_dic_create_all_paths(self):
         # Covers: all fields, parse error, logging
         tmp_dic = {
             "status": "pending",
@@ -1663,7 +1681,7 @@ class TestOrderClass(unittest.TestCase):
             "ERROR:test_a2c:Error while parsing the identifier notjson", log_cm.output
         )
 
-    def test_109_get_authorization_list_all_paths(self):
+    def test_110_get_authorization_list_all_paths(self):
         self.order.repository.authorization_lookup.return_value = [
             {"name": "auth1", "status__name": "valid"}
         ]
@@ -1672,7 +1690,7 @@ class TestOrderClass(unittest.TestCase):
             [{"name": "auth1", "status__name": "valid"}],
         )
 
-    def test_110_get_authorization_list_all_paths(self):
+    def test_111_get_authorization_list_all_paths(self):
         # DB error path
         self.order.repository.authorization_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
@@ -1690,7 +1708,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_111_update_validity_list_all_paths(self):
+    def test_112_update_validity_list_all_paths(self):
         # Covers: all code paths, logging
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             # All valid
@@ -1708,7 +1726,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._update_validity_list()", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order.get_order_details() ended", log_cm.output)
 
-    def test_112_get_order_details_all_paths(self):
+    def test_113_get_order_details_all_paths(self):
         # Covers: found, not found, logging
 
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
@@ -1723,7 +1741,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order.get_order_details(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order.get_order_details() ended", log_cm.output)
 
-    def test_113_invalidate_expired_orders_all_paths(self):
+    def test_114_invalidate_expired_orders_all_paths(self):
         # Covers: success, db error, logging
         self.order.repository.orders_invalid_search.return_value = [
             {"name": "order1", "status__name": "pending"}
@@ -1748,7 +1766,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_114_invalidate_expired_orders_all_paths(self):
+    def test_115_invalidate_expired_orders_all_paths(self):
         # DB error path
         self.order.repository.orders_invalid_search.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -1759,7 +1777,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_115_process_order_request_all_paths(self):
+    def test_116_process_order_request_all_paths(self):
         # Covers: finalize, polling, cert found, cert not found, url missing, logging
 
         self.order._finalize_order = MagicMock(return_value=(200, "msg", None, "cert"))
@@ -1799,7 +1817,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_116_check_identifiers_validity_all_paths(self):
+    def test_117_check_identifiers_validity_all_paths(self):
         # Covers: valid, too many, malformed, email rewrite, allowed, rejected, and logging
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.identifier_limit = 2
@@ -1826,7 +1844,7 @@ class TestOrderClass(unittest.TestCase):
                 (self.order.error_msg_dic["malformed"], "malformed identifiers list"),
             )
 
-    def test_117_check_identifiers_validity_all_paths(self):
+    def test_118_check_identifiers_validity_all_paths(self):
         with patch("acme_srv.order.validate_identifier", return_value=False):
             self.order.config.identifier_limit = 2
             self.order.config.email_identifier_support = True
@@ -1841,13 +1859,13 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_118_get_order_info_all_paths(self):
+    def test_119_get_order_info_all_paths(self):
         # Covers: successful lookup, DB error, logging
         self.order.repository.order_lookup.return_value = {"name": "order1"}
         result = self.order._get_order_info("order1")
         self.assertEqual(result, {"name": "order1"})
 
-    def test_119_get_order_info_all_paths(self):
+    def test_120_get_order_info_all_paths(self):
         # Clear log buffer before error path
         self.order.repository.order_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -1858,7 +1876,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_120_header_info_lookup_all_paths(self):
+    def test_121_header_info_lookup_all_paths(self):
         # Covers: header present, header missing, header_info_list missing, logging
         # Use central logger and log_stream from setUp
 
@@ -1876,14 +1894,14 @@ class TestOrderClass(unittest.TestCase):
         result = self.order._header_info_lookup({"X-Test": "foo"})
         self.assertIsNone(result)
 
-    def test_121_enter_loads_configuration_and_returns_self(self):
+    def test_122_enter_loads_configuration_and_returns_self(self):
         # Covers __enter__: should call _load_configuration and return self
         with patch.object(self.order, "_load_configuration") as mock_load_config:
             result = self.order.__enter__()
             mock_load_config.assert_called_once()
             self.assertIs(result, self.order)
 
-    def test_122_parse_order_content_adds_certificate(self):
+    def test_123_parse_order_content_adds_certificate(self):
         # Covers lines 976-978: certificate_name and status valid adds certificate path
         with patch.object(
             self.order.message,
@@ -1912,7 +1930,7 @@ class TestOrderClass(unittest.TestCase):
                             "https://example.com/acme/cert/cert123",
                         )
 
-    def test_123_invalidate_expired_orders_update_error_logging(self):
+    def test_124_invalidate_expired_orders_update_error_logging(self):
         # Covers lines 831-840: order_update raises OrderDatabaseError and logs CRITICAL
         self.order.repository.orders_invalid_search = MagicMock(
             return_value=[{"name": "order1", "status__name": "pending"}]
@@ -1926,7 +1944,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_124_process_csr_generic_error(self):
+    def test_125_process_csr_generic_error(self):
         # Covers lines 681-684: error is not rejectedIdentifier or serverinternal
         with patch.object(
             self.order, "_get_order_info", return_value={"name": "order1"}
@@ -1940,7 +1958,7 @@ class TestOrderClass(unittest.TestCase):
                 self.assertEqual(result[0], 400)
                 self.assertEqual(result[1], "someerror")
 
-    def test_125_process_csr_serverinternal_error(self):
+    def test_126_process_csr_serverinternal_error(self):
         # Covers lines 684-689: error == serverinternal triggers code=500
         with patch.object(
             self.order, "_get_order_info", return_value={"name": "order1"}
@@ -1957,7 +1975,7 @@ class TestOrderClass(unittest.TestCase):
                 self.assertEqual(result[0], 500)
                 self.assertEqual(result[1], "urn:ietf:params:acme:error:serverInternal")
 
-    def test_126_process_order_request_db_error_logging(self):
+    def test_127_process_order_request_db_error_logging(self):
         # Covers: OrderDatabaseError in certificate_lookup and CRITICAL log
         self.order.repository.certificate_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -1972,7 +1990,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_127_process_order_request_no_url(self):
+    def test_128_process_order_request_no_url(self):
         # Covers lines 634-638: protected dict missing 'url' and checks log
         with patch.object(self.order.logger, "debug") as mock_debug:
             result = self.order._process_order_request("ordername", {}, {}, None)
@@ -1988,7 +2006,7 @@ class TestOrderClass(unittest.TestCase):
                 "url is missing in protected",
             )
 
-    def test_128_finalize_order_valid_OrderDatabaseError(self):
+    def test_129_finalize_order_valid_OrderDatabaseError(self):
         # Covers lines 593-597: status not ready
         self.order.repository.order_lookup.return_value = {"status": "valid"}
         self.order.config.idempotent_finalize = True
@@ -2005,7 +2023,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_129_finalize_order_ready_nocsr(self):
+    def test_130_finalize_order_ready_nocsr(self):
         # Covers lines 593-597: status not ready
         self.order.repository.order_lookup.return_value = {"status": "ready"}
         result = self.order._finalize_order("ordername", {}, None)
@@ -2014,7 +2032,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(result[2], "csr is missing in payload")
         self.assertIsNone(result[3])
 
-    def test_130_finalize_csr_timeout(self):
+    def test_131_finalize_csr_timeout(self):
         # Patch _process_csr to return (200, 'timeout', 'not_none') so the elif branch is taken
         with patch.object(
             self.order, "_process_csr", return_value=(400, "timeout", "not_none")
@@ -2027,7 +2045,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertEqual(result[2], "not_none")
             self.assertEqual(result[3], "timeout")
 
-    def test_131_from_content_rejectedidentifier_with_detail(self):
+    def test_132_from_content_rejectedidentifier_with_detail(self):
         # Ensure the 'rejectedidentifier' error branch is covered
         rejected = self.order.error_msg_dic["rejectedidentifier"]
         with patch.object(
@@ -2057,7 +2075,7 @@ class TestOrderClass(unittest.TestCase):
                     self.assertEqual(result["type"], rejected)
                     self.assertEqual(result["detail"], "detail")
 
-    def test_132_from_content_rejectedidentifier_without_detail(self):
+    def test_133_from_content_rejectedidentifier_without_detail(self):
         # Ensure the 'rejectedidentifier' error branch is covered
         rejected = self.order.error_msg_dic["rejectedidentifier"]
         with patch.object(
@@ -2090,7 +2108,7 @@ class TestOrderClass(unittest.TestCase):
                         "Some of the requested identifiers got rejected",
                     )
 
-    def test_133_apply_eab_profile_eab_profiling_disabled(self):
+    def test_134_apply_eab_profile_eab_profiling_disabled(self):
         self.order.config.eab_profiling = False
         with patch.object(self.order, "_apply_eab_profile") as mock_apply_eab:
             payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -2103,14 +2121,14 @@ class TestOrderClass(unittest.TestCase):
                 self.order.create_order(payload, account_name)
                 mock_apply_eab.assert_not_called()
 
-    def test_134_apply_eab_profile_account_lookup_db_error(self):
+    def test_135_apply_eab_profile_account_lookup_db_error(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.side_effect = Exception("fail")
         with patch.object(self.order.logger, "critical") as mock_critical:
             self.order._apply_eab_profile("acct")
             mock_critical.assert_called()
 
-    def test_135_apply_eab_profile_no_eab_kid(self):
+    def test_136_apply_eab_profile_no_eab_kid(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {}
         with patch.object(self.order.logger, "debug") as mock_debug:
@@ -2120,7 +2138,7 @@ class TestOrderClass(unittest.TestCase):
                 "acct",
             )
 
-    def test_136_apply_eab_profile_allowed_domainlist_order_section(self):
+    def test_137_apply_eab_profile_allowed_domainlist_order_section(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid1"}
         mock_eab_handler = MagicMock()
@@ -2135,7 +2153,7 @@ class TestOrderClass(unittest.TestCase):
             )
         self.assertEqual(self.order.config.allowed_domainlist, ["example.com"])
 
-    def test_137_apply_eab_profile_allowed_domainlist_cahandler_section(self):
+    def test_138_apply_eab_profile_allowed_domainlist_cahandler_section(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid2"}
         mock_eab_handler = MagicMock()
@@ -2150,7 +2168,7 @@ class TestOrderClass(unittest.TestCase):
             )
         self.assertEqual(self.order.config.allowed_domainlist, ["test.com"])
 
-    def test_138_apply_eab_profile_wildcard_disable_false_order_section(self):
+    def test_139_apply_eab_profile_wildcard_disable_false_order_section(self):
         self.order.config.eab_profiling = True
         self.order.config.wildcard_certificate_disable = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid_false"}
@@ -2165,7 +2183,7 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertFalse(self.order.config.wildcard_certificate_disable)
 
-    def test_139_load_eab_profile_param_false_cahandler_section(self):
+    def test_140_load_eab_profile_param_false_cahandler_section(self):
         profile_dic = {
             "kid_false": {"cahandler": {"wildcard_certificate_disable": False}}
         }
@@ -2180,21 +2198,21 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_140_load_eab_profile_param_empty_list_in_order_section(self):
+    def test_141_load_eab_profile_param_empty_list_in_order_section(self):
         profile_dic = {"kid_list": {"order": {"allowed_domainlist": []}}}
         value = self.order._load_eab_profile_param(
             profile_dic, "kid_list", "allowed_domainlist", ["default.com"]
         )
         self.assertEqual(value, [])
 
-    def test_141_load_eab_profile_param_empty_string_in_order_section(self):
+    def test_142_load_eab_profile_param_empty_string_in_order_section(self):
         profile_dic = {"kid_str": {"order": {"custom_key": ""}}}
         value = self.order._load_eab_profile_param(
             profile_dic, "kid_str", "custom_key", "fallback"
         )
         self.assertEqual(value, "")
 
-    def test_142_load_eab_profile_param_order_section_has_precedence(self):
+    def test_143_load_eab_profile_param_order_section_has_precedence(self):
         profile_dic = {
             "kid_precedence": {
                 "order": {"wildcard_certificate_disable": False},
@@ -2206,14 +2224,14 @@ class TestOrderClass(unittest.TestCase):
         )
         self.assertFalse(value)
 
-    def test_143_load_eab_profile_param_returns_default_if_param_missing(self):
+    def test_144_load_eab_profile_param_returns_default_if_param_missing(self):
         profile_dic = {"kid_missing": {"order": {}, "cahandler": {}}}
         value = self.order._load_eab_profile_param(
             profile_dic, "kid_missing", "wildcard_certificate_disable", True
         )
         self.assertTrue(value)
 
-    def test_144_apply_eab_profile_generic_exception(self):
+    def test_145_apply_eab_profile_generic_exception(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid3"}
         mock_eab_handler = MagicMock()
@@ -2228,7 +2246,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_145_create_order_eab_profiling_branch(self):
+    def test_146_create_order_eab_profiling_branch(self):
         # Covers: if self.config.eab_profiling and self.config.eab_handler
         self.order.config.eab_profiling = True
         self.order.config.eab_handler = MagicMock()
@@ -2243,7 +2261,7 @@ class TestOrderClass(unittest.TestCase):
                 self.order.create_order(payload, account_name)
                 mock_apply_eab.assert_called_once_with(account_name)
 
-    def test_146_create_order_invalid_profile_detail(self):
+    def test_147_create_order_invalid_profile_detail(self):
         # Covers: if error == self.error_msg_dic["invalidprofile"]: detail = "Invalid profile specified"
         self.order.config.eab_profiling = False
         self.order.config.eab_handler = None
@@ -2268,7 +2286,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertIsNone(error)
             self.assertEqual(detail, "Invalid profile specified")
 
-    def test_147_are_identifiers_allowed_fqdn_not_whitelisted(self):
+    def test_148_are_identifiers_allowed_fqdn_not_whitelisted(self):
         # Covers: FQDN/SAN not allowed by configuration (lines 551-566)
         with patch("acme_srv.order.validate_identifier", return_value=True), patch(
             "acme_srv.order.is_domain_whitelisted", return_value=False
@@ -2285,7 +2303,9 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_148_check_single_identifier_wildcard_flag_reconstructs_for_domainlist(self):
+    def test_149_check_single_identifier_wildcard_flag_reconstructs_for_domainlist(
+        self,
+    ):
         # Covers wildcard-intent fallback for normalized identifiers against wildcard-only policy
         self.order.config.allowed_domainlist = ["*.bar.local"]
         identifier = {"type": "dns", "value": "bar.local", "wildcard": True}
@@ -2311,7 +2331,9 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_149_check_single_identifier_non_wildcard_skips_reconstruct_and_rejects(self):
+    def test_150_check_single_identifier_non_wildcard_skips_reconstruct_and_rejects(
+        self,
+    ):
         # Covers non-wildcard guard: wildcard reconstruction must not broaden policy
         self.order.config.allowed_domainlist = ["*.bar.local"]
         identifier = {"type": "dns", "value": "bar.local"}
@@ -2333,7 +2355,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_150_apply_eab_profile_disabled(self):
+    def test_151_apply_eab_profile_disabled(self):
         # Covers: logger.critical branch in _apply_eab_profile (line 270)
         self.order.config.eab_profiling = False
         self.order.config.eab_handler = MagicMock()
@@ -2346,7 +2368,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertFalse(mock_account_lookup.called)
             self.assertFalse(mock_critical.called)
 
-    def test_151_check_single_identifier_missing_type(self):
+    def test_152_check_single_identifier_missing_type(self):
         # Covers error message for missing 'type' (line 556)
         identifier = {"value": "bar"}
         allowed_identifiers = ["dns", "ip"]
@@ -2358,7 +2380,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(detail, "Identifier type is missing")
         self.assertIn("ERROR:test_a2c:Identifier type is missing", log_cm.output)
 
-    def test_152_check_single_identifier_wrong_type(self):
+    def test_153_check_single_identifier_wrong_type(self):
         # Covers error message for missing 'type' (line 556)
         identifier = {"type": "unknown", "value": "bar"}
         allowed_identifiers = ["dns", "ip"]
@@ -2372,7 +2394,7 @@ class TestOrderClass(unittest.TestCase):
             "ERROR:test_a2c:Identifier type unknown not supported", log_cm.output
         )
 
-    def test_153_check_single_identifier_invalid_value(self):
+    def test_154_check_single_identifier_invalid_value(self):
         # Covers error message for invalid value (line 571)
         identifier = {"type": "dns", "value": "foo"}
         allowed_identifiers = ["dns", "ip"]
@@ -2388,7 +2410,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_154_add_authorizations_to_db_success(self):
+    def test_155_add_authorizations_to_db_success(self):
         # Test normal case: authorizations added successfully
         self.order.repository.add_authorization.return_value = None
         self.order.config.authz_validity = 1000
@@ -2409,7 +2431,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(payload["identifiers"][0]["status"], "pending")
         self.assertIn(list(auth_dic.keys())[0], auth_dic)
 
-    def test_155_add_authorizations_to_db_malformed(self):
+    def test_156_add_authorizations_to_db_malformed(self):
         # Test malformed case: oid is None
         oid = None
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -2425,7 +2447,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_156_add_authorizations_to_db_db_error(self):
+    def test_157_add_authorizations_to_db_db_error(self):
         # Test DB error: add_authorization raises exception
         self.order.repository.add_authorization.side_effect = Exception("fail")
         oid = "order123"
@@ -2439,7 +2461,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_157_add_authorizations_to_db_sectigo_sim(self):
+    def test_158_add_authorizations_to_db_sectigo_sim(self):
         # Covers sectigo_sim branch: status set to valid and update_authorization called
         self.order.config.sectigo_sim = True
         self.order.repository.add_authorization.return_value = None
@@ -2462,7 +2484,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_158_create_from_content_malformed_identifier(self):
+    def test_159_create_from_content_malformed_identifier(self):
         # Covers the branch where error == self.order.error_msg_dic["malformed"] and detail is None
         malformed_error = self.order.error_msg_dic["malformed"]
         with patch.object(
@@ -2491,7 +2513,7 @@ class TestOrderClass(unittest.TestCase):
                 response["detail"], "One of the requested identifiers is not supported"
             )
 
-    def test_159_load_configuration_directory_url_prefix(self):
+    def test_160_load_configuration_directory_url_prefix(self):
         # Covers the Directory/url_prefix branch in _load_configuration (line 513)
         import configparser
 
@@ -2511,7 +2533,7 @@ class TestOrderClass(unittest.TestCase):
                 all(v.startswith("/prefix/") for v in self.order.path_dic.values())
             )
 
-    def test_160_check_single_identifier_missing_value(self):
+    def test_161_check_single_identifier_missing_value(self):
         # Covers lines 578-579: missing 'value' in identifier
         identifier = {"type": "dns"}
         allowed_identifiers = ["dns", "ip"]
@@ -2523,7 +2545,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(detail, "Identifier value is missing")
         self.assertIn("ERROR:test_a2c:Identifier value is missing", log_cm.output)
 
-    def test_161_is_profile_valid_dryrun_profile_logging(self):
+    def test_162_is_profile_valid_dryrun_profile_logging(self):
         # Set up dryrun profile
         self.order.config.dryrun_profilename = "dryrun-profile"
         self.order.config.profiles_check_disable = False
@@ -2537,7 +2559,7 @@ class TestOrderClass(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    def test_162_add_profile_to_order_dryrun_profile_logging(self):
+    def test_163_add_profile_to_order_dryrun_profile_logging(self):
         # Set up dryrun profile and no profiles configured
         self.order.config.profiles = {}
         self.order.config.dryrun_profilename = "dryrun-profile"
@@ -2555,7 +2577,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(updated_dic["profile"], "dryrun-profile")
 
-    def test_163_finalize_csr_handles_dryrun_skipped(self):
+    def test_164_finalize_csr_handles_dryrun_skipped(self):
         # When detail is 'Dry run mode - enrollment skipped', message should be unauthorized error
         self.order._header_info_lookup = MagicMock(return_value={})
         self.order._process_csr = MagicMock(
@@ -2572,7 +2594,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_164_are_identifiers_allowed_ip_not_whitelisted(self):
+    def test_165_are_identifiers_allowed_ip_not_whitelisted(self):
         # Setup: allowed_iplist is set, is_ip_whitelisted returns False
         self.order.config.allowed_iplist = ["192.168.1.0/24"]
         identifier = {"type": "ip", "value": "10.0.0.1"}
@@ -2590,7 +2612,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertIsNone(error)
             self.assertIsNone(msg)
 
-    def test_165_are_identifiers_allowed_ip_whitelisted(self):
+    def test_166_are_identifiers_allowed_ip_whitelisted(self):
         # Should allow IP if in allowed_iplist
         with patch("acme_srv.order.validate_identifier", return_value=True), patch(
             "acme_srv.order.is_ip_whitelisted", return_value=True
@@ -2601,7 +2623,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_166_are_identifiers_allowed_ip_not_whitelisted(self):
+    def test_167_are_identifiers_allowed_ip_not_whitelisted(self):
         # Should reject IP if not in allowed_iplist
         with patch("acme_srv.order.validate_identifier", return_value=True), patch(
             "acme_srv.order.is_ip_whitelisted", return_value=False
@@ -2618,7 +2640,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_167_are_identifiers_allowed_iplist_empty(self):
+    def test_168_are_identifiers_allowed_iplist_empty(self):
         # Should allow any IP if allowed_iplist is empty
         with patch("acme_srv.order.validate_identifier", return_value=True), patch(
             "acme_srv.order.is_ip_whitelisted", return_value=False
@@ -2629,7 +2651,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_168_are_identifiers_allowed_multiple_ips(self):
+    def test_169_are_identifiers_allowed_multiple_ips(self):
         # Should reject on first non-whitelisted IP, allow if all whitelisted
         with patch("acme_srv.order.validate_identifier", return_value=True), patch(
             "acme_srv.order.is_ip_whitelisted", side_effect=[True, False]
@@ -2659,6 +2681,161 @@ class TestOrderClass(unittest.TestCase):
                 ]
             )
             self.assertEqual(result, (None, None))
+
+    def test_170_load_profile_mapping_field_returns_none_without_module(self):
+        with patch("acme_srv.order.ca_handler_load", return_value=None):
+            self.assertIsNone(self.order._load_profile_mapping_field({}))
+
+    def test_171_load_profile_mapping_field_from_module_attribute(self):
+        ca_module = types.SimpleNamespace(profile_mapping_field="module_profile")
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            result = self.order._load_profile_mapping_field({})
+
+        self.assertEqual(result, "module_profile")
+
+    def test_172_load_profile_mapping_field_from_instance_attribute(self):
+        class DummyCAhandler:
+            def __init__(self, logger=None):
+                self.logger = logger
+                self.profile_mapping_field = "instance_profile"
+
+        ca_module = types.SimpleNamespace(CAhandler=DummyCAhandler)
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            result = self.order._load_profile_mapping_field({})
+
+        self.assertEqual(result, "instance_profile")
+
+    def test_173_load_profile_mapping_field_from_noarg_instance_fallback(self):
+        class DummyCAhandler:
+            def __init__(self):
+                self.profile_mapping_field = "noarg_instance_profile"
+
+        ca_module = types.SimpleNamespace(CAhandler=DummyCAhandler)
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            result = self.order._load_profile_mapping_field({})
+
+        self.assertEqual(result, "noarg_instance_profile")
+
+    def test_174_load_profile_mapping_field_from_class_attribute(self):
+        class DummyCAhandler:
+            profile_mapping_field = "class_profile"
+
+            def __init__(self, logger=None):
+                self.logger = logger
+
+        ca_module = types.SimpleNamespace(CAhandler=DummyCAhandler)
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            result = self.order._load_profile_mapping_field({})
+
+        self.assertEqual(result, "class_profile")
+
+    def test_175_load_profile_mapping_field_returns_none_without_handler_class(self):
+        ca_module = types.SimpleNamespace()
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            self.assertIsNone(self.order._load_profile_mapping_field({}))
+
+    def test_176_load_profile_mapping_field_class_fallback_after_empty_instance(self):
+        class DummyCAhandler:
+            profile_mapping_field = "class_profile"
+
+            def __init__(self, logger=None):
+                self.logger = logger
+                # Shadow class attribute so instance lookup returns falsy and class fallback is used.
+                self.profile_mapping_field = None
+
+        ca_module = types.SimpleNamespace(CAhandler=DummyCAhandler)
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            result = self.order._load_profile_mapping_field({})
+
+        self.assertEqual(result, "class_profile")
+
+    def test_177_load_profile_mapping_field_returns_none_when_not_defined(self):
+        class DummyCAhandler:
+            def __init__(self, logger=None):
+                self.logger = logger
+                self.profile_mapping_field = None
+
+        ca_module = types.SimpleNamespace(CAhandler=DummyCAhandler)
+
+        with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
+            self.assertIsNone(self.order._load_profile_mapping_field({}))
+
+    def test_178_profile_mapping_to_dict_none(self):
+        self.assertEqual(self.order._profile_mapping_to_dict(None), {})
+
+    def test_179_profile_mapping_to_dict_string(self):
+        self.assertEqual(
+            self.order._profile_mapping_to_dict("  profile_a  "),
+            {"profile_a": True},
+        )
+        self.assertEqual(self.order._profile_mapping_to_dict("   "), {})
+
+    def test_180_profile_mapping_to_dict_list(self):
+        value = [" profile_a ", "profile_b", "", None, 123]
+        self.assertEqual(
+            self.order._profile_mapping_to_dict(value),
+            {"profile_a": True, "profile_b": True, "123": True},
+        )
+
+    def test_181_profile_mapping_to_dict_dict_passthrough(self):
+        value = {"profile_a": True, "profile_b": False}
+        self.assertEqual(self.order._profile_mapping_to_dict(value), value)
+
+    def test_182_profile_mapping_to_dict_unsupported_type(self):
+        with self.assertLogs("test_a2c", level="WARNING") as log_cm:
+            self.assertEqual(self.order._profile_mapping_to_dict(42.0), {})
+        self.assertIn(
+            "WARNING:test_a2c:Unsupported profile mapping type: float",
+            log_cm.output,
+        )
+
+    def test_183_load_eab_profile_mapping_without_mapping_field(self):
+        self.order.config.profile_mapping_field = None
+        self.assertEqual(self.order._load_eab_profile_mapping({"kid": {}}, "kid"), {})
+
+    def test_184_load_eab_profile_mapping_uses_param_and_normalizer(self):
+        self.order.config.profile_mapping_field = "template"
+        with (
+            patch.object(
+                self.order,
+                "_load_eab_profile_param",
+                return_value="profile-a",
+            ) as mock_load_param,
+            patch.object(
+                self.order,
+                "_profile_mapping_to_dict",
+                return_value={"profile-a": True},
+            ) as mock_to_dict,
+        ):
+            result = self.order._load_eab_profile_mapping({"kid": {}}, "kid")
+
+        mock_load_param.assert_called_once_with(
+            {"kid": {}}, "kid", "template", None
+        )
+        mock_to_dict.assert_called_once_with("profile-a")
+        self.assertEqual(result, {"profile-a": True})
+
+    def test_185_apply_eab_profile_mapping_updates_profiles(self):
+        self.order.config.profiles = {"old": True}
+        with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+            self.order._apply_eab_profile_mapping("acct1", {"new": True})
+
+        self.assertEqual(self.order.config.profiles, {"new": True})
+        self.assertIn(
+            "DEBUG:test_a2c:Order._apply_eab_profile() - overwrite profile information from eab profile for account acct1",
+            log_cm.output,
+        )
+
+    def test_186_apply_eab_profile_mapping_noop_for_empty_mapping(self):
+        self.order.config.profiles = {"keep": True}
+        self.order._apply_eab_profile_mapping("acct1", {})
+        self.assertEqual(self.order.config.profiles, {"keep": True})
 
 
 if __name__ == "__main__":

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -337,7 +337,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
         self.assertIn(
-            "INFO:test_a2c:Only one profile configured. Overwriting submitted profile 'foo' with 'bar'.",
+            "WARNING:test_a2c:Profile 'foo' is not valid. Ignoring submitted profile.",
             log_cm.output,
         )
 
@@ -1114,32 +1114,28 @@ class TestOrderClass(unittest.TestCase):
                 )
 
     def test_070_load_profile_config_all_paths(self):
-        with (
-            patch.object(self.order, "_load_profiles_from_config") as m1,
-            patch.object(self.order, "_load_profiles_from_db_if_sync") as m2,
-            patch.object(self.order, "_maybe_disable_profile_check") as m3,
-        ):
-            with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
-                self.order._load_profile_config({"Order": {}, "CAhandler": {}})
-                m1.assert_called_once()
-                m2.assert_called_once()
-                m3.assert_called_once()
+        with patch.object(self.order, "_load_profiles_from_config") as m1:
+            with patch.object(self.order, "_load_profiles_from_db_if_sync") as m2:
+                with patch.object(self.order, "_maybe_disable_profile_check") as m3:
+                    with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+                        self.order._load_profile_config({"Order": {}, "CAhandler": {}})
+                        m1.assert_called_once()
+                        m2.assert_called_once()
+                        m3.assert_called_once()
         self.assertIn("DEBUG:test_a2c:Order._load_profile_config()", log_cm.output)
         self.assertIn(
             "DEBUG:test_a2c:Order._load_profile_config() ended", log_cm.output
         )
 
     def test_071_load_profile_config_all_paths(self):
-        with (
-            patch.object(self.order, "_load_profiles_from_config") as m1,
-            patch.object(self.order, "_load_profiles_from_db_if_sync") as m2,
-            patch.object(self.order, "_maybe_disable_profile_check") as m3,
-        ):
-            with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
-                self.order._load_profile_config({"Order": {}, "CAhandler": {}})
-                m1.assert_called_once()
-                m2.assert_called_once()
-                m3.assert_called_once()
+        with patch.object(self.order, "_load_profiles_from_config") as m1:
+            with patch.object(self.order, "_load_profiles_from_db_if_sync") as m2:
+                with patch.object(self.order, "_maybe_disable_profile_check") as m3:
+                    with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+                        self.order._load_profile_config({"Order": {}, "CAhandler": {}})
+                        m1.assert_called_once()
+                        m2.assert_called_once()
+                        m3.assert_called_once()
 
         self.assertIn("DEBUG:test_a2c:Order._load_profile_config()", log_cm.output)
         self.assertIn(


### PR DESCRIPTION
This branch improves how profiles are derived during order processing when EAB profiling is enabled, and fixes a corner case where an invalid submitted profile should be silently replaced when only one configured profile exists.

1.  Added support for a configurable profile mapping field in order processing, sourced from the active CA handler
2. Applied EAB profile mapping to overwrite runtime profile configuration when present, and re-enabled profile validation in that case.
Fixed the one-profile corner case:
3. if a client submits an invalid profile and exactly one profile is configured, the request now silently falls back to the only configured profile instead of failing.