### PR TITLE
fix(order): surface the CA's real finalize error to the client

### DIFF
--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -1095,7 +1095,11 @@ class Order(object):
             message = "urn:ietf:params:acme:error:unauthorized"
         else:
             message = certificate_name
-            detail = "enrollment failed"
+            # Preserve the CA handler's real failure detail (e.g. the upstream
+            # ACME server's problem "detail") so it reaches the client; only fall
+            # back to the generic string when the handler provided none.
+            if not detail:
+                detail = "enrollment failed"
 
         self.logger.debug("Order._finalize_csr() ended")
         return (code, message, detail, certificate_name)

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -1677,12 +1677,27 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_109_finalize_csr_enrollment_failed_else_branch(self):
-        # Else branch: message set to certificate_name and detail='enrollment failed'
+    def test_109_finalize_csr_else_branch_preserves_ca_detail(self):
+        # Else branch: the CA handler's real failure detail is preserved and
+        # reaches the client instead of being replaced by a generic string.
 
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
         self.order._process_csr = MagicMock(return_value=(400, "error", "d"))
+        with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+            result = self.order._finalize_csr("order1", {"csr": "csrval"})
+            self.assertEqual(result, (400, "error", "d", "error"))
+            self.order.repository.order_update.assert_not_called()
+        self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
+        self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
+
+    def test_109a_finalize_csr_else_branch_generic_fallback(self):
+        # Else branch: fall back to the generic detail only when the handler
+        # provided none.
+
+        self.order.repository.order_update = MagicMock()
+        self.order._header_info_lookup = MagicMock(return_value={})
+        self.order._process_csr = MagicMock(return_value=(400, "error", None))
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             result = self.order._finalize_csr("order1", {"csr": "csrval"})
             self.assertEqual(result, (400, "error", "enrollment failed", "error"))


### PR DESCRIPTION
## Problem

When certificate enrollment fails at order finalization, acme2certifier always
returns a generic problem document to the ACME client:

```
500 urn:ietf:params:acme:error:serverInternal :: enrollment failed
```

The CA handler's actual failure reason is discarded, even though the handler
provides it. This makes real, actionable errors undiagnosable from the client
side (cert-manager, certbot, acme.sh, …) — the operator has to go read the
acme2certifier server logs to find out what actually happened.

### Real-world example

Using the `acme_ca_handler` (proxying to an upstream ACME CA), a wildcard order
was rejected by the upstream CA because of a CAA policy. The handler logged and
returned the real detail:

```
Enrollment error: urn:ietf:params:acme:error:serverInternal :: The server
experienced an internal error :: Domain Check failed with message: CAA record
found. Please instruct your DNS admin to create two CAA records with "issue"
and "issuewild" tags with the value "ca.example".
```

…but the client only ever saw `enrollment failed`, turning a clear "fix your CAA
records" into an opaque server error.

## Root cause

The CA handler already returns the real reason (`acme_ca_handler.enroll()` sets
`error = str(err)`), and `Order._process_csr()` forwards it as `detail`. It is
`Order._finalize_csr()` that throws it away — the final `else` branch
unconditionally overwrites `detail`:

```python
else:
    message = certificate_name
    detail = "enrollment failed"
```

## Fix

Keep the handler-provided `detail` and only fall back to the generic string when
no detail was supplied:

```python
else:
    message = certificate_name
    # Preserve the CA handler's real failure detail (e.g. the upstream ACME
    # server's problem "detail") so it reaches the client; only fall back to the
    # generic string when the handler provided none.
    if not detail:
        detail = "enrollment failed"
```

This changes only the failure message surfaced to the client; issuance behaviour
is unchanged. Handlers that return no detail keep the previous "enrollment
failed" output, so it is backwards compatible.

## Tests

- Updated `test_109_finalize_csr_...` to assert the real detail is preserved when
  the handler provides one.
- Added a test for the fallback path (no detail → `"enrollment failed"`).
- `pytest test/test_order.py` → all green.
