### PR TITLE
Improved error handling in Account, Authorization, Certificate and Order classes

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,14 @@
+# Python Caches & Virtual Environments
+__pycache__/
+*.py[cod]
+*$py.class
+.venv/
+venv/
+ENV/
+.pytest_cache/
+.coverage
+.mypy_cache/
+.ruff_cache/
+
+# GitHub Workflow Caches (Lokale Test-Tools wie act)
+.act/

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,26 @@
+# ROLE
+You are an expert Python Backend Engineer, DevOps Specialist, and Network Security Architect specialized in the ACME Protocol (RFC 8555) and its modern extensions.
+
+# ACME PROTOCOL EXPERTISE
+- Fully understand core ACME operations (NewOrder, Challenge validation, Finalize, Roll-overs).
+- Implement TLS-ALPN-01 (RFC 8737) and IP Address validation (RFC 8738).
+- Implement ACME Renewal Information (ARI via RFC 9773) for proactive load balancing and 'replaces' fields.
+- Design for 'dns-persist-01' (draft-ietf-acme-dns-persist) by managing persistent DNS TXT records at _validation-persist.<fqdn> bound to account URIs.
+- Support 'acme-profiles' (draft-ietf-acme-profiles) by explicitly defining profile fields within the Order object instead of relying solely on CSR parsing.
+
+# PYTHON GUIDELINES
+- Always use explicit Type Hints for function signatures and return types.
+- Favor modern tooling (use 'uv' or 'poetry' if present, otherwise strict pip).
+- Write comprehensive tests using 'pytest' only (never use unittest).
+- Format code using Black/Ruff style (clean, readable, PEP 8 compliant).
+
+# GITHUB WORKFLOWS & CI/CD
+- Always use specific, pinned versions for Actions (e.g., actions/checkout@v4).
+- Ensure YAML files use correct indentation (2 spaces) and valid GitHub Actions syntax.
+- Always include standard error handling/fail-fast strategies in workflow steps.
+- When modifying workflows, only output the changed steps or jobs, not the entire YAML file.
+
+# OUTPUT STYLE
+- Be extremely brief. No conversational filler, no pleasantries.
+- Provide only the minimal code/YAML diff required.
+- Do not explain standard syntax unless explicitly asked.

--- a/acme_srv/account.py
+++ b/acme_srv/account.py
@@ -249,7 +249,7 @@ class Account:
         self.config = AccountConfiguration()
         self.err_msg_dic = error_dic_get(self.logger)
 
-    def __enter__(self) -> "Order":
+    def __enter__(self):
         """Enter the context manager, loading configuration."""
         self._load_configuration()
         return self

--- a/acme_srv/account.py
+++ b/acme_srv/account.py
@@ -501,11 +501,19 @@ class Account:
         """Handle account deactivation."""
         self.logger.debug("Account._handle_deactivation(%s)", account_name)
         if payload.get("status", "").lower() == "deactivated":
+            account_obj = self._lookup_account_by_name(account_name)
+            if not account_obj:
+                return self._build_response(
+                    400,
+                    self.err_msg_dic["accountdoesnotexist"],
+                    "Deactivation failed",
+                )
             code, message, detail = self._deactivate_account(account_name)
             if code == 200:
-                return self._build_response(code, message, payload)
-            else:
-                return self._build_response(code, message, detail)
+                data = self._build_account_info(account_obj)
+                data["status"] = "deactivated"
+                return self._build_response(code, account_name, data)
+            return self._build_response(code, message, detail)
         else:
             return self._build_response(
                 400, self.err_msg_dic["malformed"], "Invalid status for deactivation"

--- a/acme_srv/account.py
+++ b/acme_srv/account.py
@@ -58,16 +58,22 @@ class ExternalAccountBinding:
         result = False
         if "jwk" in protected:
             jwk_outer = protected["jwk"]
-            jwk_inner = b64decode_pad(self.logger, payload)
-            jwk_inner = json.loads(jwk_inner)
-            if json.dumps(jwk_outer, sort_keys=True) == json.dumps(
-                jwk_inner, sort_keys=True
-            ):
-                result = True
+            try:
+                jwk_inner = json.loads(b64decode_pad(self.logger, payload))
+            except Exception as err:
+                self.logger.error("Failed to decode EAB JWK payload: %s", err)
             else:
-                self.logger.error("JWK from outer and inner JWS do not match")
-                self.logger.debug("outer: %s", jwk_outer)
-                self.logger.debug("inner: %s", jwk_inner)
+                if isinstance(jwk_inner, dict):
+                    if json.dumps(jwk_outer, sort_keys=True) == json.dumps(
+                        jwk_inner, sort_keys=True
+                    ):
+                        result = True
+                    else:
+                        self.logger.error("JWK from outer and inner JWS do not match")
+                        self.logger.debug("outer: %s", jwk_outer)
+                        self.logger.debug("inner: %s", jwk_inner)
+                else:
+                    self.logger.error("EAB JWK payload is not a JSON object")
         else:
             self.logger.error("No JWK in protected header")
         self.logger.debug("ExternalAccountBinding.compare_jwk() ended with: %s", result)

--- a/acme_srv/account.py
+++ b/acme_srv/account.py
@@ -753,7 +753,11 @@ class Account:
             ] = f'{self.server_name}{self.config.path_dic["acct_path"]}{message}'
 
             # add exernal account binding
-            if self.config.eab_check and "externalaccountbinding" in payload:
+            if (
+                self.config.eab_check
+                and payload
+                and "externalaccountbinding" in payload
+            ):
                 response_dic["data"]["externalaccountbinding"] = payload[
                     "externalaccountbinding"
                 ]

--- a/acme_srv/authorization.py
+++ b/acme_srv/authorization.py
@@ -1005,7 +1005,7 @@ class Authorization(object):
             )
         except AuthorizationError as err:
             self.logger.warning("Failed to search for expired authorizations: %s", err)
-            return field_list, []
+            return [], []
 
         # Process expired authorizations
         expired_output = []

--- a/acme_srv/authorization.py
+++ b/acme_srv/authorization.py
@@ -285,6 +285,33 @@ class AuthorizationBusinessLogic:
         )
         return token, expires
 
+    def resolve_authorization_token_and_expiry(
+        self, auth_record: Optional[Dict[str, str]]
+    ) -> Tuple[str, int, bool]:
+        """Return token and expiry, persisting to DB only when no token exists yet."""
+        self.logger.debug(
+            "AuthorizationBusinessLogic.resolve_authorization_token_and_expiry()"
+        )
+
+        existing_token = auth_record.get("token") if auth_record else None
+        if isinstance(existing_token, str):
+            existing_token = existing_token.strip() or None
+
+        if existing_token:
+            expires = auth_record.get("expires")
+            if not expires:
+                expires = uts_now() + self.config.validity
+            self.logger.debug(
+                "AuthorizationBusinessLogic.resolve_authorization_token_and_expiry() reusing existing token"
+            )
+            return existing_token, expires, False
+
+        token, expires = self.generate_authorization_token_and_expiry()
+        self.logger.debug(
+            "AuthorizationBusinessLogic.resolve_authorization_token_and_expiry() generated new token"
+        )
+        return token, expires, True
+
     def enrich_authorization_with_identifier_info(
         self, auth_db_info: Dict[str, str]
     ) -> Tuple[Dict[str, str], bool]:
@@ -642,15 +669,18 @@ class Authorization(object):
         self.logger.debug("Authorization name: %s", authz_name)
 
         # Check if authorization exists
-        authz = self.repository.find_authorization_by_name(authz_name)
+        authz = self.repository.find_authorization_by_name(
+            authz_name, ["name", "token", "expires"]
+        )
         if not authz:
             self.logger.debug("Authorization not found: %s", authz_name)
             return {}
 
-        # Generate new token and expiry
-        token, expires = self.business_logic.generate_authorization_token_and_expiry()
-        # Update authorization with new expiry and token (if there is no token yet)
-        self.repository.update_authorization_expiry(authz_name, token, expires)
+        token, expires, persist_token = (
+            self.business_logic.resolve_authorization_token_and_expiry(authz)
+        )
+        if persist_token:
+            self.repository.update_authorization_expiry(authz_name, token, expires)
 
         # Create base authorization info
         authz_info = {

--- a/acme_srv/authorization.py
+++ b/acme_srv/authorization.py
@@ -785,9 +785,13 @@ class Authorization(object):
             id_value,
         )
         if (
-            (id_type == "dns" and self.config.email_identifier_rewrite)
-            or id_type == "email"
-        ) and "@" in id_value:
+            id_value
+            and (
+                (id_type == "dns" and self.config.email_identifier_rewrite)
+                or id_type == "email"
+            )
+            and "@" in id_value
+        ):
             self._handle_email_prevalidation(
                 authz_name, auth_details, id_value, authz_info
             )

--- a/acme_srv/certificate.py
+++ b/acme_srv/certificate.py
@@ -863,13 +863,13 @@ class Certificate(object):
 
     def _execute_pre_enrollment_hooks(
         self, certificate_name: str, order_name: str, csr: str
-    ) -> List[str]:
+    ) -> Optional[Tuple[Optional[str], str, str]]:
         self.logger.debug(
             "Certificate._execute_pre_enrollment_hooks(%s, %s)",
             certificate_name,
             order_name,
         )
-        hook_error = []
+        hook_error = None
         if self.hooks:
             try:
                 self.hooks.pre_hook(certificate_name, order_name, csr)

--- a/acme_srv/certificate.py
+++ b/acme_srv/certificate.py
@@ -34,6 +34,7 @@ from acme_srv.message import Message
 from acme_srv.threadwithreturnvalue import ThreadWithReturnValue
 from acme_srv.certificate_manager import CertificateManager
 from acme_srv.certificate_repository import DatabaseCertificateRepository
+from acme_srv.helpers.global_variables import DRYRUN_ENROLLMENT_SKIPPED_DETAIL
 
 
 # CertificateLogger moved from certificate_logger.py
@@ -1436,7 +1437,7 @@ class Certificate(object):
                 )
                 return (
                     self.err_msg_dic["unauthorized"],
-                    "Dry run mode - enrollment and certificate issuance skipped",
+                    DRYRUN_ENROLLMENT_SKIPPED_DETAIL,
                 )
 
             # Process enrollment

--- a/acme_srv/helpers/global_variables.py
+++ b/acme_srv/helpers/global_variables.py
@@ -3,3 +3,8 @@
 
 PARSING_ERR_MSG = "failed to parse"
 USER_AGENT = "acme2certifier"
+
+# Returned as enrollment detail when dry-run mode skips certificate issuance.
+DRYRUN_ENROLLMENT_SKIPPED_DETAIL = (
+    "Dry run mode - enrollment and certificate issuance skipped"
+)

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -226,6 +226,8 @@ class Order(object):
                     self.logger.critical(
                         "Database error: failed to add authorization: %s", err_
                     )
+                    error = self.error_msg_dic["serverinternal"]
+                    break
         else:
             error = self.error_msg_dic["malformed"]
 

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -26,6 +26,7 @@ from acme_srv.helper import (
 )
 from acme_srv.certificate import Certificate
 from acme_srv.db_handler import DBstore
+from acme_srv.helpers.global_variables import DRYRUN_ENROLLMENT_SKIPPED_DETAIL
 from acme_srv.message import Message
 
 
@@ -1091,7 +1092,7 @@ class Order(object):
         elif certificate_name == "urn:ietf:params:acme:error:rejectedIdentifier":
             code = 401
             message = certificate_name
-        elif detail in ["Dry run mode - enrollment skipped"]:
+        elif detail == DRYRUN_ENROLLMENT_SKIPPED_DETAIL:
             message = "urn:ietf:params:acme:error:unauthorized"
         else:
             message = certificate_name
@@ -1215,7 +1216,7 @@ class Order(object):
                     )
                     if (
                         error == "urn:ietf:params:acme:error:rejectedIdentifier"
-                        or detail in ["Dry run mode - enrollment skipped"]
+                        or detail == DRYRUN_ENROLLMENT_SKIPPED_DETAIL
                     ):
                         code = 401
                         message = error

--- a/docs/dryrun.md
+++ b/docs/dryrun.md
@@ -29,7 +29,7 @@ When an ACME client submits a certificate order and the dry run mode is enabled 
 - **Instead of forwarding the CSR to the CA**, acme2certifier returns an `unauthorized` error with the detail message:
 
 ```log
-Dry run mode - enrollment skipped
+Dry run mode - enrollment and certificate issuance skipped
 ```
 
 - No certificate is stored in the database and nothing is sent to the CA backend.
@@ -139,5 +139,5 @@ The following log entries can help confirm that dry run mode is working as expec
 | :---------- | :------ |
 | `Helper.config_dryrun_load() ended with: True/None` | Global dry run mode is enabled. |
 | `Certificate._validate_csr_against_order(): enabling dryrun mode for profile: <name>` | Profile-based dry run has been triggered for this request. |
-| `Dry run mode enabled - skipping enrollment and database storage` | The enrollment step has been skipped for this request. |
+| `Dry run mode enabled - skipping enrollment and certificate issuance` | The enrollment step has been skipped for this request. |
 | `Dryrun profile name not set in configuration, please set dryrun_profile parameter` | `dryrun = profile` is configured but `dryrun_profile` is missing. |

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -205,6 +205,29 @@ class TestExternalAccountBinding(unittest.TestCase):
         """test compare_jwk no jwk in protected"""
         self.assertFalse(self.eab.compare_jwk({}, "payload"))
 
+    def test_005b_compare_jwk_invalid_payload(self):
+        """test compare_jwk with invalid base64 or JSON payload"""
+        protected = {"jwk": {"kty": "oct", "k": "abc"}}
+        with self.assertLogs("test_a2c", level="ERROR") as log_cm:
+            self.assertFalse(self.eab.compare_jwk(protected, "invalid_base64"))
+        self.assertIn(
+            "ERROR:test_a2c:Failed to decode EAB JWK payload:",
+            log_cm.output[0],
+        )
+
+    def test_005c_compare_jwk_non_json_payload(self):
+        """test compare_jwk with base64 payload that is not JSON"""
+        import base64
+
+        protected = {"jwk": {"kty": "oct", "k": "abc"}}
+        payload = base64.b64encode(b"not json").decode()
+        with self.assertLogs("test_a2c", level="ERROR") as log_cm:
+            self.assertFalse(self.eab.compare_jwk(protected, payload))
+        self.assertIn(
+            "ERROR:test_a2c:Failed to decode EAB JWK payload:",
+            log_cm.output[0],
+        )
+
     def test_006_verify_signature_success(self):
         """test verify_signature success"""
         content = {"foo": "bar"}

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -648,28 +648,66 @@ class TestAccount(unittest.TestCase):
     def test_018__handle_deactivation_success(self):
         """test _handle_deactivation success"""
         payload = {"status": "deactivated"}
+        account_obj = {
+            "status": "valid",
+            "jwk": '{"kty": "RSA", "n": "abc", "e": "AQAB"}',
+            "contact": '["mailto:test@example.com"]',
+            "created_at": "2026-02-08 12:00:00",
+        }
         with patch.object(
-            self.account, "_deactivate_account", return_value=(200, None, None)
+            self.account, "_lookup_account_by_name", return_value=account_obj
         ):
-            result = self.account._handle_deactivation("test_account", payload)
-            self.assertIn("data", result)
-            self.assertEqual(result["code"], 200)
-            self.assertEqual(result["data"]["status"], "deactivated")
+            with patch.object(
+                self.account, "_deactivate_account", return_value=(200, None, None)
+            ):
+                result = self.account._handle_deactivation("test_account", payload)
+                self.assertIn("data", result)
+                self.assertEqual(result["code"], 200)
+                self.assertEqual(result["data"]["status"], "deactivated")
+                self.assertEqual(
+                    result["data"]["contact"], ["mailto:test@example.com"]
+                )
+                self.assertEqual(
+                    result["data"]["key"], {"kty": "RSA", "n": "abc", "e": "AQAB"}
+                )
 
     def test_018__handle_deactivation_fail(self):
-        """test _handle_deactivation success"""
+        """test _handle_deactivation failure"""
+        payload = {"status": "deactivated"}
+        account_obj = {
+            "status": "valid",
+            "jwk": "{}",
+            "contact": "[]",
+            "created_at": "2026-02-08",
+        }
+        with patch.object(
+            self.account, "_lookup_account_by_name", return_value=account_obj
+        ):
+            with patch.object(
+                self.account,
+                "_deactivate_account",
+                return_value=(400, "deact_message", "deact_detail"),
+            ):
+                result = self.account._handle_deactivation("test_account", payload)
+                self.assertIn("data", result)
+                self.assertEqual(result["data"]["status"], 400)
+                self.assertEqual(result["data"]["type"], "deact_message")
+                self.assertEqual(result["data"]["detail"], "deact_detail")
+
+    def test_018b__handle_deactivation_account_not_found(self):
+        """test _handle_deactivation when account lookup fails"""
         payload = {"status": "deactivated"}
         with patch.object(
-            self.account,
-            "_deactivate_account",
-            return_value=(400, "deact_message", "deact_detail"),
+            self.account, "_lookup_account_by_name", return_value=None
         ):
-            # with patch.object(self.account, "_build_response", return_value={"data": {}}):
-            result = self.account._handle_deactivation("test_account", payload)
-            self.assertIn("data", result)
-            self.assertEqual(result["data"]["status"], 400)
-            self.assertEqual(result["data"]["type"], "deact_message")
-            self.assertEqual(result["data"]["detail"], "deact_detail")
+            with patch.object(self.account, "_deactivate_account") as mock_deactivate:
+                result = self.account._handle_deactivation("test_account", payload)
+                mock_deactivate.assert_not_called()
+                self.assertEqual(result["data"]["status"], 400)
+                self.assertEqual(
+                    result["data"]["type"],
+                    self.account.err_msg_dic["accountdoesnotexist"],
+                )
 
     def test_019__handle_deactivation_status_invalid(self):
         """test _handle_deactivation invalid status"""

--- a/test/test_account.py
+++ b/test/test_account.py
@@ -1512,6 +1512,23 @@ class TestAccount(unittest.TestCase):
             self.assertIn("externalaccountbinding", result["data"])
             mock_prepare.assert_called_once()
 
+    def test_062b__build_response_200_eab_check_no_payload(self):
+        """test _build_response with eab_check and no payload (e.g. key rollover)"""
+        self.account.server_name = "http://tester.local"
+        self.account.config.path_dic = {"acct_path": "/acme/acct/"}
+        self.account.config.eab_check = True
+        with patch.object(
+            self.account.message,
+            "prepare_response",
+            side_effect=lambda response_dic, status_dic: response_dic,
+        ):
+            result = self.account._build_response(200, "test_account", None)
+        self.assertEqual(
+            result["header"]["Location"],
+            "http://tester.local/acme/acct/test_account",
+        )
+        self.assertNotIn("externalaccountbinding", result.get("data", {}))
+
     def test_063_parse_request_error(self):
         """test parse_request returns error response when message.check fails"""
         content = {"foo": "bar"}

--- a/test/test_authorization.py
+++ b/test/test_authorization.py
@@ -1897,6 +1897,26 @@ class TestAuthorization(unittest.TestCase):
         # Clean up
         domain_utils.is_domain_whitelisted = orig_is_domain_whitelisted
 
+    def test_087b_apply_prevalidation_whitelist_missing_id_value(self):
+        """Test _apply_prevalidation_whitelist skips email branch when id_value is None."""
+        self.authorization.config.email_identifier_rewrite = True
+        self.authorization.config.prevalidated_emaillist = ["user@example.com"]
+        self.authorization.repository = Mock()
+
+        authz_info = {"status": "pending"}
+        self.authorization._apply_prevalidation_whitelist(
+            "authz1", {}, "email", None, authz_info
+        )
+
+        self.assertEqual(authz_info["status"], "pending")
+        self.authorization.repository.mark_authorization_as_valid.assert_not_called()
+
+        self.authorization._apply_prevalidation_whitelist(
+            "authz2", {}, "dns", None, {"status": "pending"}
+        )
+
+        self.authorization.repository.mark_authorization_as_valid.assert_not_called()
+
     def test_088_handle_domain_prevalidation_wildcard_identifier_matches_policy(self):
         """Wildcard identifiers normalized to base domain should still match wildcard whitelist entries."""
         self.authorization.config.prevalidated_domainlist = ["*.bar.local"]

--- a/test/test_authorization.py
+++ b/test/test_authorization.py
@@ -431,6 +431,45 @@ class TestAuthorizationBusinessLogic(unittest.TestCase):
         self.assertEqual(expires, 1000003600)  # 1000000000 + 3600
         mock_generate_string.assert_called_once_with(self.mock_logger, 32)
 
+    @patch("acme_srv.authorization.generate_random_string")
+    @patch("acme_srv.authorization.uts_now")
+    def test_028b_resolve_authorization_token_and_expiry_reuse(
+        self, mock_uts_now, mock_generate_string
+    ):
+        """Test resolve reuses existing authorization token and expiry"""
+        auth_record = {"token": "existing_token", "expires": 1234567890}
+
+        token, expires, persist = (
+            self.business_logic.resolve_authorization_token_and_expiry(auth_record)
+        )
+
+        self.assertEqual(token, "existing_token")
+        self.assertEqual(expires, 1234567890)
+        self.assertFalse(persist)
+        mock_generate_string.assert_not_called()
+        mock_uts_now.assert_not_called()
+
+    @patch("acme_srv.authorization.generate_random_string")
+    @patch("acme_srv.authorization.uts_now")
+    def test_028c_resolve_authorization_token_and_expiry_generate(
+        self, mock_uts_now, mock_generate_string
+    ):
+        """Test resolve generates token when authorization has none yet"""
+        mock_uts_now.return_value = 1000000000
+        mock_generate_string.return_value = "random_token"
+        self.config.validity = 3600
+
+        token, expires, persist = (
+            self.business_logic.resolve_authorization_token_and_expiry(
+                {"name": "authz1"}
+            )
+        )
+
+        self.assertEqual(token, "random_token")
+        self.assertEqual(expires, 1000003600)
+        self.assertTrue(persist)
+        mock_generate_string.assert_called_once_with(self.mock_logger, 32)
+
     def test_029_enrich_authorization_with_identifier_info_empty(self):
         """Test enrichment with empty auth info"""
         (
@@ -922,9 +961,10 @@ class TestAuthorization(unittest.TestCase):
         mock_business_logic.extract_authorization_name_from_url.return_value = (
             "test_authz"
         )
-        mock_business_logic.generate_authorization_token_and_expiry.return_value = (
+        mock_business_logic.resolve_authorization_token_and_expiry.return_value = (
             "token",
             1234567890,
+            True,
         )
         mock_business_logic.extract_identifier_info_for_challenge.return_value = (
             None,
@@ -952,6 +992,53 @@ class TestAuthorization(unittest.TestCase):
         )
 
     @patch("acme_srv.authorization.uts_to_date_utc")
+    def test_059b_get_authorization_details_reuses_existing_token(
+        self, mock_uts_to_date
+    ):
+        """Test get_authorization_details reuses stored token on subsequent fetch"""
+        mock_uts_to_date.return_value = "2021-01-01T00:00:00Z"
+
+        mock_repository = Mock()
+        mock_challenge_manager = Mock()
+
+        mock_repository.find_authorization_by_name.side_effect = [
+            {
+                "name": "test_authz",
+                "token": "existing_token",
+                "expires": 1234567890,
+            },
+            None,
+        ]
+        mock_challenge_manager.get_challenge_set_for_authorization.return_value = []
+
+        self.authorization.server_name = "http://example.com"
+        self.authorization.config.authz_path = "/authz/"
+        self.authorization.repository = mock_repository
+        self.authorization.challenge_manager = mock_challenge_manager
+
+        result = self.authorization.get_authorization_details(
+            "http://example.com/authz/test_authz"
+        )
+
+        expected = {
+            "expires": "2021-01-01T00:00:00Z",
+            "status": "pending",
+            "challenges": [],
+        }
+        self.assertEqual(result, expected)
+        mock_repository.update_authorization_expiry.assert_not_called()
+        mock_challenge_manager.get_challenge_set_for_authorization.assert_called_once_with(
+            "test_authz",
+            "pending",
+            "existing_token",
+            False,
+            1234567890,
+            None,
+            None,
+            False,
+        )
+
+    @patch("acme_srv.authorization.uts_to_date_utc")
     def test_060_get_authorization_details_success_with_details(self, mock_uts_to_date):
         """Test get_authorization_details with full details"""
         mock_uts_to_date.return_value = "2021-01-01T00:00:00Z"
@@ -969,9 +1056,10 @@ class TestAuthorization(unittest.TestCase):
         mock_business_logic.extract_authorization_name_from_url.return_value = (
             "test_authz"
         )
-        mock_business_logic.generate_authorization_token_and_expiry.return_value = (
+        mock_business_logic.resolve_authorization_token_and_expiry.return_value = (
             "token",
             1234567890,
+            True,
         )
         mock_business_logic.enrich_authorization_with_identifier_info.return_value = (
             {"status": "valid", "identifier": {"type": "dns", "value": "example.com"}},
@@ -1016,9 +1104,10 @@ class TestAuthorization(unittest.TestCase):
         mock_business_logic.extract_authorization_name_from_url.return_value = (
             "test_authz"
         )
-        mock_business_logic.generate_authorization_token_and_expiry.return_value = (
+        mock_business_logic.resolve_authorization_token_and_expiry.return_value = (
             "token",
             1234567890,
+            True,
         )
         mock_business_logic.extract_identifier_info_for_challenge.return_value = (
             "dns",
@@ -1071,9 +1160,10 @@ class TestAuthorization(unittest.TestCase):
         mock_business_logic.extract_authorization_name_from_url.return_value = (
             "test_authz"
         )
-        mock_business_logic.generate_authorization_token_and_expiry.return_value = (
+        mock_business_logic.resolve_authorization_token_and_expiry.return_value = (
             "token",
             1234567890,
+            True,
         )
         mock_business_logic.enrich_authorization_with_identifier_info.return_value = (
             {
@@ -1158,9 +1248,10 @@ class TestAuthorization(unittest.TestCase):
         mock_business_logic.extract_authorization_name_from_url.return_value = (
             "test_authz"
         )
-        mock_business_logic.generate_authorization_token_and_expiry.return_value = (
+        mock_business_logic.resolve_authorization_token_and_expiry.return_value = (
             "token",
             1234567890,
+            True,
         )
         mock_business_logic.enrich_authorization_with_identifier_info.return_value = (
             {
@@ -1233,9 +1324,10 @@ class TestAuthorization(unittest.TestCase):
         mock_business_logic.extract_authorization_name_from_url.return_value = (
             "test_authz"
         )
-        mock_business_logic.generate_authorization_token_and_expiry.return_value = (
+        mock_business_logic.resolve_authorization_token_and_expiry.return_value = (
             "token",
             1234567890,
+            True,
         )
         mock_business_logic.enrich_authorization_with_identifier_info.return_value = (
             {

--- a/test/test_authorization.py
+++ b/test/test_authorization.py
@@ -1428,6 +1428,7 @@ class TestAuthorization(unittest.TestCase):
 
         field_list, output_list = self.authorization.expire_invalid_authorizations()
 
+        self.assertEqual(field_list, [])
         self.assertEqual(len(output_list), 0)
         # Check that warning was called with the right pattern and message
         self.assertTrue(self.mock_logger.warning.called)

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -869,10 +869,9 @@ class TestCertificate(unittest.TestCase):
 
     def test_065_execute_pre_enrollment_hooks(self):
         self.cert.hook_handler = MagicMock()
-        self.cert.hook_handler.execute_pre_enrollment_hooks.return_value = []
-        # _execute_pre_enrollment_hooks returns a list (possibly empty)
+        self.cert.hook_handler.execute_pre_enrollment_hooks.return_value = None
         result = self.cert._execute_pre_enrollment_hooks("order", "csr", None)
-        self.assertIsInstance(result, list)
+        self.assertIsNone(result)
 
     def test_066_pre_enrollment_hooks_with_hooks(self):
         self.cert.hooks = MagicMock()
@@ -880,7 +879,7 @@ class TestCertificate(unittest.TestCase):
         hook_errors = self.cert._execute_pre_enrollment_hooks(
             "cert_name", "order", "csr"
         )
-        self.assertEqual(hook_errors, [])
+        self.assertIsNone(hook_errors)
 
     def test_067_execute_post_enrollment_hooks(self):
         # Test normal post_hook execution logs debug (line 915)
@@ -1929,7 +1928,7 @@ class TestCertificate(unittest.TestCase):
     def test_147_process_enrollment_and_store_certificate_success(self):
         # Pre-enrollment hooks return empty (no error)
         with (
-            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
+            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=None),
             patch.object(
                 self.cert,
                 "_process_certificate_enrollment",
@@ -1955,7 +1954,7 @@ class TestCertificate(unittest.TestCase):
     def test_148_process_enrollment_and_store_certificate_enrollment_error(self):
         # Enrollment returns no certificate, triggers error handling
         with (
-            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
+            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=None),
             patch.object(
                 self.cert,
                 "_process_certificate_enrollment",
@@ -1977,17 +1976,19 @@ class TestCertificate(unittest.TestCase):
     def test_149_process_enrollment_and_store_certificate_pre_hook_error(self):
         # Pre-enrollment hook returns error, should return early
         with patch.object(
-            self.cert, "_execute_pre_enrollment_hooks", return_value=["pre_hook_error"]
+            self.cert,
+            "_execute_pre_enrollment_hooks",
+            return_value=(None, "pre_hook_error", "hook failed"),
         ):
             result = self.cert._process_enrollment_and_store_certificate(
                 "cert_name", "csr", "order_name"
             )
-            self.assertEqual(result, ["pre_hook_error"])
+            self.assertEqual(result, (None, "pre_hook_error", "hook failed"))
 
     def test_150_process_enrollment_and_store_certificate_post_hook_error(self):
         # Post-enrollment hook returns error, should return early
         with (
-            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
+            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=None),
             patch.object(
                 self.cert,
                 "_process_certificate_enrollment",
@@ -2013,7 +2014,7 @@ class TestCertificate(unittest.TestCase):
     def test_151_process_enrollment_and_store_certificate_store_error(self):
         # _store_certificate_and_update_order returns error, should return error
         with (
-            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
+            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=None),
             patch.object(
                 self.cert,
                 "_process_certificate_enrollment",
@@ -2033,7 +2034,7 @@ class TestCertificate(unittest.TestCase):
     def test_152_process_enrollment_and_store_certificate_logger_exception(self):
         # Exception in logger should not crash method
         with (
-            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
+            patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=None),
             patch.object(
                 self.cert,
                 "_process_certificate_enrollment",
@@ -2799,7 +2800,7 @@ class TestCertificate(unittest.TestCase):
 
     def test_195_process_enrollment_and_store_certificate_log_exception(self):
         """Test _process_enrollment_and_store_certificate covers log_certificate_issuance exception branch (lines 930-933)."""
-        self.cert._execute_pre_enrollment_hooks = MagicMock(return_value=[])
+        self.cert._execute_pre_enrollment_hooks = MagicMock(return_value=None)
         self.cert._process_certificate_enrollment = MagicMock(
             return_value=(None, "cert", "raw", "poll", True)
         )

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -3035,6 +3035,8 @@ class TestCertificate(unittest.TestCase):
         self.cert.config.dryrun = True
         self.cert.err_msg_dic["unauthorized"] = "unauthorized"
         # Patch dependencies so validation passes
+        from acme_srv.helpers.global_variables import DRYRUN_ENROLLMENT_SKIPPED_DETAIL
+
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value=None),
             patch.object(self.cert, "_validate_csr_against_order", return_value=True),
@@ -3051,7 +3053,7 @@ class TestCertificate(unittest.TestCase):
             result,
             (
                 "unauthorized",
-                "Dry run mode - enrollment and certificate issuance skipped",
+                DRYRUN_ENROLLMENT_SKIPPED_DETAIL,
             ),
         )
 

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -861,13 +861,13 @@ class TestOrderClass(unittest.TestCase):
                 result = self.order._add_order_and_authorizations(
                     data_dic, auth_dic, payload, error
                 )
-                self.assertIsNone(result)  # error is None, but DB error is logged
+                self.assertEqual(result, self.order.error_msg_dic["serverinternal"])
             self.assertIn(
                 "CRITICAL:test_a2c:Database error: failed to add authorization: fail",
                 log_cm.output,
             )
             self.assertIn(
-                "DEBUG:test_a2c:Order._add_order_and_authorizations() ended with None",
+                f"DEBUG:test_a2c:Order._add_order_and_authorizations() ended with {self.order.error_msg_dic['serverinternal']}",
                 log_cm.output,
             )
             mock_add_authz.assert_called_once()
@@ -2504,7 +2504,7 @@ class TestOrderClass(unittest.TestCase):
         auth_dic = {}
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
             error = self.order._add_authorizations_to_db(oid, payload, auth_dic)
-            self.assertIsNone(error)  # error is not set in DB error, just logged
+            self.assertEqual(error, self.order.error_msg_dic["serverinternal"])
         self.assertIn(
             "CRITICAL:test_a2c:Database error: failed to add authorization: fail",
             log_cm.output,

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -249,26 +249,29 @@ class TestOrderRepository(unittest.TestCase):
 class TestOrderClass(unittest.TestCase):
     def test_021_process_csr_dryrun_skipped(self):
         # Covers: enroll_and_store returns dryrun skipped, triggers code=401, message=error, detail preserved
+        from acme_srv.helpers.global_variables import DRYRUN_ENROLLMENT_SKIPPED_DETAIL
+
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             self.order._get_order_info = MagicMock(return_value={"name": "order1"})
             cert_mock = MagicMock()
             cert_mock.store_csr.return_value = "cert1"
             cert_mock.enroll_and_store.return_value = (
                 "some_error",
-                "Dry run mode - enrollment skipped",
+                DRYRUN_ENROLLMENT_SKIPPED_DETAIL,
             )
             with patch("acme_srv.order.Certificate") as cert_class:
                 cert_class.return_value.__enter__.return_value = cert_mock
                 with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
                     result = self.order._process_csr("order1", "csr", "header")
                     self.assertEqual(
-                        result, (401, "some_error", "Dry run mode - enrollment skipped")
+                        result,
+                        (401, "some_error", DRYRUN_ENROLLMENT_SKIPPED_DETAIL),
                     )
                 self.assertIn(
                     "DEBUG:test_a2c:Order._process_csr(order1)", log_cm.output
                 )
                 self.assertIn(
-                    "DEBUG:test_a2c:Order._process_csr() ended with order:order1 401:{some_error:Dry run mode - enrollment skipped",
+                    f"DEBUG:test_a2c:Order._process_csr() ended with order:order1 401:{{some_error:{DRYRUN_ENROLLMENT_SKIPPED_DETAIL}",
                     log_cm.output,
                 )
 
@@ -2628,10 +2631,12 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(updated_dic["profile"], "dryrun-profile")
 
     def test_165_finalize_csr_handles_dryrun_skipped(self):
-        # When detail is 'Dry run mode - enrollment skipped', message should be unauthorized error
+        # When detail is DRYRUN_ENROLLMENT_SKIPPED_DETAIL, message should be unauthorized error
+        from acme_srv.helpers.global_variables import DRYRUN_ENROLLMENT_SKIPPED_DETAIL
+
         self.order._header_info_lookup = MagicMock(return_value={})
         self.order._process_csr = MagicMock(
-            return_value=(400, "certX", "Dry run mode - enrollment skipped")
+            return_value=(400, "certX", DRYRUN_ENROLLMENT_SKIPPED_DETAIL)
         )
         result = self.order._finalize_csr("order1", {"csr": "csrval"})
         self.assertEqual(
@@ -2639,7 +2644,7 @@ class TestOrderClass(unittest.TestCase):
             (
                 400,
                 "urn:ietf:params:acme:error:unauthorized",
-                "Dry run mode - enrollment skipped",
+                DRYRUN_ENROLLMENT_SKIPPED_DETAIL,
                 "certX",
             ),
         )


### PR DESCRIPTION
Hardens Account, Authorization, Certificate, and Order paths with safer error handling, correct ACME responses, and aligned dry-run messaging.

- **Account**: EAB compare_jwk tolerates decode/parse failures; deactivation returns a proper deactivated account object (and accountDoesNotExist when missing); key-rollover/EAB response building no longer assumes a payload; drop incorrect __enter__ return type hint.
- **Authorization**: Reuse existing authz tokens instead of regenerating them; null-safe email prevalidation; expire_invalid_authorizations returns ([], []) on DB search failure.
- **Order / Certificate**: Authorization DB insert failures return serverInternal; pre-enrollment hook errors use a consistent (code, message, detail)-style result; dry-run detail text shared via DRYRUN_ENROLLMENT_SKIPPED_DETAIL (docs updated).