### PR TITLE
Enrollment-error forwarding to acme-client

### DIFF
--- a/.github/actions/wf_specific/error_tests/account_checks/action.yml
+++ b/.github/actions/wf_specific/error_tests/account_checks/action.yml
@@ -131,8 +131,8 @@ runs:
       working-directory: acmeshell
       run: |
         # cat acmeshell.enroll.log
-        grep "{\"status\": \"valid\"" acmeshell.enroll.log
-        grep "{\"status\": \"deactivated\"}" acmeshell.enroll.log
+        grep "\"status\": \"valid\"" acmeshell.enroll.log
+        grep "\"status\": \"deactivated\"" acmeshell.enroll.log
       shell: bash
 
     - name: "Check a2c logs"
@@ -248,7 +248,8 @@ runs:
       run: |
         # grep "HTTP\/1.1 201 OK" acmeshell.enroll.log
         # grep "HTTP\/1.1 200 Created" acmeshell.enroll.log
-        grep "\"contact\": \[\"mailto:new@example.com\"\], \"createdAt\":" acmeshell.enroll.log
+        # grep "\"contact\": \[\"mailto:new@example.com\"\], \"createdAt\":" acmeshell.enroll.log
+        grep "mailto:new@example.com" acmeshell.enroll.log
       shell: bash
 
     - name: "Check a2c logs"
@@ -330,7 +331,9 @@ runs:
     - name: "Check acmeshell log"
       working-directory: acmeshell
       run: |
-        grep "{\"status\": 400, \"type\": \"urn:ietf:params:acme:error:malformed\", \"detail\": \"Invalid status for deactivation\"}" acmeshell.enroll.log
+        grep "\"status\": 400," acmeshell.enroll.log
+        grep "\"type\": \"urn:ietf:params:acme:error:malformed\"," acmeshell.enroll.log
+        grep "\"detail\": \"Invalid status for deactivation\"" acmeshell.enroll.log
       shell: bash
 
     - name: "Check a2c logs"

--- a/.github/actions/wf_specific/error_tests/account_checks/action.yml
+++ b/.github/actions/wf_specific/error_tests/account_checks/action.yml
@@ -291,7 +291,9 @@ runs:
     - name: "Check acmeshell log"
       working-directory: acmeshell
       run: |
-        grep "{\"status\": 400, \"type\": \"urn:ietf:params:acme:error:malformed\", \"detail\": \"Unknown request\"}" acmeshell.enroll.log
+        grep "\"status\": 400," acmeshell.enroll.log
+        grep "\"type\": \"urn:ietf:params:acme:error:malformed\"," acmeshell.enroll.log
+        grep "\"detail\": \"Unknown request\"" acmeshell.enroll.log
       shell: bash
 
     - name: "Check a2c logs"

--- a/acme_srv/certificate.py
+++ b/acme_srv/certificate.py
@@ -253,6 +253,7 @@ class CertificateConfiguration:
     ignore_success_hook_failure: bool = False
     ca_error_details_forward: bool = False
 
+
 class Certificate(object):
     """CA  handler"""
 

--- a/acme_srv/certificate.py
+++ b/acme_srv/certificate.py
@@ -247,7 +247,7 @@ class CertificateConfiguration:
     ignore_pre_hook_failure: bool = False
     ignore_post_hook_failure: bool = True
     ignore_success_hook_failure: bool = False
-
+    ca_error_details_forward: bool = False
 
 class Certificate(object):
     """CA  handler"""
@@ -571,6 +571,10 @@ class Certificate(object):
                 )
                 self.config.cn2san_add = True
 
+            self.config.ca_error_details_forward = config_dic.getboolean(
+                "CAhandler", "ca_error_details_forward", fallback=False
+            )
+
         # Directory section
         if "Directory" in config_dic and "url_prefix" in config_dic["Directory"]:
             self.path_dic = {
@@ -853,6 +857,9 @@ class Certificate(object):
         elif error == "Either CN or SANs are not allowed by configuration":
             error = self.err_msg_dic["rejectedidentifier"]
             detail = "CN or SANs are not allowed by configuration"
+        elif error and self.config.ca_error_details_forward:
+            detail = error
+            error = self.err_msg_dic["serverinternal"]
         else:
             error = self.err_msg_dic["serverinternal"]
         self.logger.debug(

--- a/acme_srv/certificate.py
+++ b/acme_srv/certificate.py
@@ -34,6 +34,10 @@ from acme_srv.message import Message
 from acme_srv.threadwithreturnvalue import ThreadWithReturnValue
 from acme_srv.certificate_manager import CertificateManager
 from acme_srv.certificate_repository import DatabaseCertificateRepository
+from acme_srv.helpers.global_variables import (
+    DRYRUN_ENROLLMENT_SKIPPED_DETAIL,
+    ENROLLMENT_FAILED_DETAIL,
+)
 
 
 # CertificateLogger moved from certificate_logger.py
@@ -828,6 +832,21 @@ class Certificate(object):
         self.logger.debug("Certificate._store_certificate_and_update_order() ended")
         return (result, error)
 
+    def _resolve_client_enrollment_error(
+        self, raw_error: str, poll_identifier: Optional[str]
+    ) -> Tuple[str, str]:
+        """Map internal enrollment failure to ACME type and client-visible detail."""
+        if poll_identifier:
+            return raw_error, poll_identifier
+        if raw_error == "Either CN or SANs are not allowed by configuration":
+            return (
+                self.err_msg_dic["rejectedidentifier"],
+                "CN or SANs are not allowed by configuration",
+            )
+        if self.config.ca_error_details_forward and raw_error:
+            return self.err_msg_dic["serverinternal"], raw_error
+        return self.err_msg_dic["serverinternal"], ENROLLMENT_FAILED_DETAIL
+
     def _handle_enrollment_error(
         self, error: str, poll_identifier: str, order_name: str, certificate_name: str
     ) -> Tuple[None, str, str]:
@@ -835,7 +854,6 @@ class Certificate(object):
         self.logger.debug("Certificate._handle_enrollment_error(%s)", error)
 
         result = None
-        detail = None
         try:
             if not poll_identifier:
                 self.logger.debug(
@@ -851,17 +869,7 @@ class Certificate(object):
                 "Database error: failed to store certificate error: %s", err_
             )
 
-        # cover polling cases
-        if poll_identifier:
-            detail = poll_identifier
-        elif error == "Either CN or SANs are not allowed by configuration":
-            error = self.err_msg_dic["rejectedidentifier"]
-            detail = "CN or SANs are not allowed by configuration"
-        elif error and self.config.ca_error_details_forward:
-            detail = error
-            error = self.err_msg_dic["serverinternal"]
-        else:
-            error = self.err_msg_dic["serverinternal"]
+        error, detail = self._resolve_client_enrollment_error(error, poll_identifier)
         self.logger.debug(
             "Certificate._handle_enrollment_error() ended with: %s", result
         )

--- a/acme_srv/helpers/global_variables.py
+++ b/acme_srv/helpers/global_variables.py
@@ -3,3 +3,11 @@
 
 PARSING_ERR_MSG = "failed to parse"
 USER_AGENT = "acme2certifier"
+
+# Returned as enrollment detail when dry-run mode skips certificate issuance.
+DRYRUN_ENROLLMENT_SKIPPED_DETAIL = (
+    "Dry run mode - enrollment and certificate issuance skipped"
+)
+
+# Generic client-visible detail for enrollment failures when CA errors are not forwarded.
+ENROLLMENT_FAILED_DETAIL = "enrollment failed"

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -168,6 +168,7 @@ class OrderConfiguration:
     profile_mapping_field: Optional[str] = None
     dryrun_profilename: Optional[str] = None
     wildcard_certificate_disable: bool = False
+    ca_error_details_forward: bool = False
 
 
 class Order(object):
@@ -372,6 +373,13 @@ class Order(object):
                     "wildcard_certificate_disable",
                     self.config.wildcard_certificate_disable,
                 )
+                self.config.ca_error_details_forward = self._load_eab_profile_param(
+                    profile_dic,
+                    eab_kid,
+                    "ca_error_details_forward",
+                    self.config.ca_error_details_forward,
+                    section="cahandler"
+                )
 
                 eab_profile_dic = self._load_eab_profile_mapping(profile_dic, eab_kid)
                 self._apply_eab_profile_mapping(account_name, eab_profile_dic)
@@ -476,32 +484,33 @@ class Order(object):
         self.logger.debug("Order.create_order() ended")
         return (error, detail, order_name, auth_dic, uts_to_date_utc(expires))
 
-    def _load_eab_profile_param(self, profile_dic, eab_kid, param_name, default=None):
+    def _load_eab_profile_param(self, profile_dic, eab_kid, param_name, default=None, section="order"):
         """Helper to load allowed_iplist or allowed_domainlist from EAB profile."""
         profile_entry = profile_dic.get(eab_kid, {})
-        order_cfg = profile_entry.get("order", {})
+        order_cfg = profile_entry.get(section, {})
 
         # Prefer order section and honor explicit falsy values like False or []
         if param_name in order_cfg:
             value = order_cfg.get(param_name)
             self.logger.debug(
-                "Order._apply_eab_profile() - apply %s from eab profile.", param_name
+                "Order._load_eab_profile_param() - apply %s from eab profile.", param_name
             )
             return value
 
         # Backward compatibility for deprecated cahandler section
-        cahandler_cfg = profile_entry.get("cahandler", {})
-        if param_name in cahandler_cfg:
-            value = cahandler_cfg.get(param_name)
-            if param_name != self.config.profile_mapping_field:
-                self.logger.warning(
-                    "%s parameter found in cahandler section of the eab-profile - this is deprecated, please use the order section",
-                    param_name,
+        if section == "order":
+            cahandler_cfg = profile_entry.get("cahandler", {})
+            if param_name in cahandler_cfg:
+                value = cahandler_cfg.get(param_name)
+                if param_name != self.config.profile_mapping_field:
+                    self.logger.warning(
+                        "%s parameter found in cahandler section of the eab-profile - this is deprecated, please use the order section",
+                        param_name,
+                    )
+                self.logger.debug(
+                    "Order._load_eab_profile_param() - apply %s from eab profile.", param_name
                 )
-            self.logger.debug(
-                "Order._apply_eab_profile() - apply %s from eab profile.", param_name
-            )
-            return value
+                return value
 
         return default
 
@@ -546,6 +555,10 @@ class Order(object):
             self.config.wildcard_certificate_disable = config_dic.getboolean(
                 "Order", "wildcard_certificate_disable", fallback=False
             )
+            self.config.ca_error_details_forward = config_dic.getboolean(
+                "CAhandler", "ca_error_details_forward", fallback=False
+            )
+
             try:
                 self.config.retry_after = int(
                     config_dic.get(
@@ -1080,6 +1093,7 @@ class Order(object):
         code, certificate_name, detail = self._process_csr(
             order_name, payload["csr"], header_info
         )
+
         # change status only if we do not have a poll_identifier (stored in detail variable)
         if code == 200:
             if not detail:
@@ -1095,10 +1109,7 @@ class Order(object):
             message = "urn:ietf:params:acme:error:unauthorized"
         else:
             message = certificate_name
-            # Preserve the CA handler's real failure detail (e.g. the upstream
-            # ACME server's problem "detail") so it reaches the client; only fall
-            # back to the generic string when the handler provided none.
-            if not detail:
+            if not (self.config.ca_error_details_forward and detail):
                 detail = "enrollment failed"
 
         self.logger.debug("Order._finalize_csr() ended")

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -1095,7 +1095,11 @@ class Order(object):
             message = "urn:ietf:params:acme:error:unauthorized"
         else:
             message = certificate_name
-            detail = "enrollment failed"
+            # Preserve the CA handler's real failure detail (e.g. the upstream
+            # ACME server's problem "detail") so it reaches the client; only fall
+            # back to the generic string when the handler provided none.
+            if not detail:
+                detail = "enrollment failed"
 
         self.logger.debug("Order._finalize_csr() ended")
         return (code, message, detail, certificate_name)

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -26,6 +26,10 @@ from acme_srv.helper import (
 )
 from acme_srv.certificate import Certificate
 from acme_srv.db_handler import DBstore
+from acme_srv.helpers.global_variables import (
+    DRYRUN_ENROLLMENT_SKIPPED_DETAIL,
+    ENROLLMENT_FAILED_DETAIL,
+)
 from acme_srv.message import Message
 
 
@@ -76,9 +80,11 @@ class OrderRepository:
             )
             raise OrderDatabaseError(f"Failed to update authorization: {err}") from err
 
-    def order_lookup(self, key, value):
+    def order_lookup(self, key, value, vlist=None):
         """Look up an order in the database."""
         try:
+            if vlist:
+                return self.dbstore.order_lookup(key, value, vlist)
             return self.dbstore.order_lookup(key, value)
         except Exception as err:
             self.logger.critical("Database error: failed to look up order: %s", err)
@@ -1060,6 +1066,22 @@ class Order(object):
             result = None
         return result
 
+    def _get_order_account_name(self, order_name: str) -> Optional[str]:
+        """Lookup account name for an order (needed for EAB profile at finalize)."""
+        self.logger.debug("Order._get_order_account_name(%s)", order_name)
+        try:
+            order_dic = self.repository.order_lookup(
+                "name", order_name, vlist=["account__name"]
+            )
+        except Exception as err_:
+            self.logger.critical(
+                "Database error: failed to look up order account: %s", err_
+            )
+            return None
+        if not order_dic:
+            return None
+        return order_dic.get("account__name") or order_dic.get("account")
+
     def _header_info_lookup(self, header: Optional[Dict[str, Any]]) -> str:
         """lookup header information and serialize them in a string"""
         self.logger.debug("Order._header_info_lookup()")
@@ -1109,8 +1131,8 @@ class Order(object):
             message = "urn:ietf:params:acme:error:unauthorized"
         else:
             message = certificate_name
-            if not (self.config.ca_error_details_forward and detail):
-                detail = "enrollment failed"
+            if not detail:
+                detail = ENROLLMENT_FAILED_DETAIL
 
         self.logger.debug("Order._finalize_csr() ended")
         return (code, message, detail, certificate_name)
@@ -1211,6 +1233,52 @@ class Order(object):
         )
         return (code, message, detail, certificate_name)
 
+    def _apply_finalize_eab_profile(self, order_name: str) -> None:
+        """Apply EAB profile for finalize flow when enabled."""
+        if not (self.config.eab_profiling and self.config.eab_handler):
+            return
+
+        account_name = self._get_order_account_name(order_name)
+        if account_name:
+            self._apply_eab_profile(account_name)
+
+    def _map_csr_enrollment_result(
+        self, certificate_name: str, error: str, detail: str
+    ) -> Tuple[int, str, str]:
+        """Map CA enrollment result to ACME response tuple."""
+        if (
+            error == "urn:ietf:params:acme:error:rejectedIdentifier"
+            or detail == DRYRUN_ENROLLMENT_SKIPPED_DETAIL
+        ):
+            return 401, error, detail
+
+        if not error:
+            return 200, certificate_name, detail
+
+        if error == self.error_msg_dic["serverinternal"]:
+            return 500, error, detail
+
+        return 400, error, detail
+
+    def _enroll_certificate_for_order(
+        self, order_name: str, csr: str, header_info: str
+    ) -> Tuple[int, str, str]:
+        """Store CSR and perform enrollment for an order."""
+        with Certificate(self.debug, self.server_name, self.logger) as certificate:
+            certificate.config.ca_error_details_forward = (
+                self.config.ca_error_details_forward
+            )
+            certificate_name = certificate.store_csr(order_name, csr, header_info)
+            if not certificate_name:
+                return (
+                    500,
+                    self.error_msg_dic["serverinternal"],
+                    "CSR processing failed",
+                )
+
+            error, detail = certificate.enroll_and_store(certificate_name, csr, order_name)
+            return self._map_csr_enrollment_result(certificate_name, error, detail)
+
     def _process_csr(
         self, order_name: str, csr: str, header_info: str
     ) -> Tuple[int, str, str]:
@@ -1218,38 +1286,16 @@ class Order(object):
         self.logger.debug("Order._process_csr(%s)", order_name)
 
         order_dic = self._get_order_info(order_name)
-        if order_dic:
-            # change decoding from b64url to b64
-            csr = b64_url_recode(self.logger, csr)
-
-            with Certificate(self.debug, self.server_name, self.logger) as certificate:
-                certificate_name = certificate.store_csr(order_name, csr, header_info)
-                if certificate_name:
-                    error, detail = certificate.enroll_and_store(
-                        certificate_name, csr, order_name
-                    )
-                    if (
-                        error == "urn:ietf:params:acme:error:rejectedIdentifier"
-                        or detail in ["Dry run mode - enrollment skipped"]
-                    ):
-                        code = 401
-                        message = error
-                    elif not error:
-                        code = 200
-                        message = certificate_name
-                    else:
-                        code = 400
-                        message = error
-                        if message == self.error_msg_dic["serverinternal"]:
-                            code = 500
-                else:
-                    code = 500
-                    message = self.error_msg_dic["serverinternal"]
-                    detail = "CSR processing failed"
-        else:
+        if not order_dic:
             code = 400
             message = self.error_msg_dic["unauthorized"]
             detail = f"order: {order_name} not found"
+        else:
+            self._apply_finalize_eab_profile(order_name)
+            csr = b64_url_recode(self.logger, csr)
+            code, message, detail = self._enroll_certificate_for_order(
+                order_name, csr, header_info
+            )
 
         self.logger.debug(
             "Order._process_csr() ended with order:%s %s:{%s:%s",

--- a/acme_srv/order.py
+++ b/acme_srv/order.py
@@ -384,7 +384,7 @@ class Order(object):
                     eab_kid,
                     "ca_error_details_forward",
                     self.config.ca_error_details_forward,
-                    section="cahandler"
+                    section="cahandler",
                 )
 
                 eab_profile_dic = self._load_eab_profile_mapping(profile_dic, eab_kid)
@@ -490,7 +490,9 @@ class Order(object):
         self.logger.debug("Order.create_order() ended")
         return (error, detail, order_name, auth_dic, uts_to_date_utc(expires))
 
-    def _load_eab_profile_param(self, profile_dic, eab_kid, param_name, default=None, section="order"):
+    def _load_eab_profile_param(
+        self, profile_dic, eab_kid, param_name, default=None, section="order"
+    ):
         """Helper to load allowed_iplist or allowed_domainlist from EAB profile."""
         profile_entry = profile_dic.get(eab_kid, {})
         order_cfg = profile_entry.get(section, {})
@@ -499,7 +501,8 @@ class Order(object):
         if param_name in order_cfg:
             value = order_cfg.get(param_name)
             self.logger.debug(
-                "Order._load_eab_profile_param() - apply %s from eab profile.", param_name
+                "Order._load_eab_profile_param() - apply %s from eab profile.",
+                param_name,
             )
             return value
 
@@ -514,7 +517,8 @@ class Order(object):
                         param_name,
                     )
                 self.logger.debug(
-                    "Order._load_eab_profile_param() - apply %s from eab profile.", param_name
+                    "Order._load_eab_profile_param() - apply %s from eab profile.",
+                    param_name,
                 )
                 return value
 
@@ -1276,7 +1280,9 @@ class Order(object):
                     "CSR processing failed",
                 )
 
-            error, detail = certificate.enroll_and_store(certificate_name, csr, order_name)
+            error, detail = certificate.enroll_and_store(
+                certificate_name, csr, order_name
+            )
             return self._map_csr_enrollment_result(certificate_name, error, detail)
 
     def _process_csr(

--- a/examples/acme2certifier_wsgi.py
+++ b/examples/acme2certifier_wsgi.py
@@ -45,7 +45,8 @@ WRT_ERROR_MSG = json.dumps(
         "status": 405,
         "message": HTTP_CODE_DIC[405],
         "detail": "Wrong request type. Expected POST.",
-    }
+    },
+    indent=2,
 ).encode("utf-8")
 CONTENT_TYPE_JSON = "application/json"
 WSGI_INPUT = "wsgi.input"
@@ -133,7 +134,7 @@ def acct(environ, start_response):
         start_response(
             f'{response_dic["code"]} {HTTP_CODE_DIC[response_dic["code"]]}', headers
         )
-        return [json.dumps(response_dic["data"]).encode("utf-8")]
+        return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
 
 
 def acmechallenge_serve(environ, start_response):
@@ -174,7 +175,7 @@ def authz(environ, start_response):
             logger_info(
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
-            return [json.dumps(response_dic["data"]).encode("utf-8")]
+            return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
     else:
         err_wrong_request_method(start_response)
         return [WRT_ERROR_MSG]
@@ -198,7 +199,7 @@ def newaccount(environ, start_response):
             logger_info(
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
-            return [json.dumps(response_dic["data"]).encode("utf-8")]
+            return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
 
     else:
         err_wrong_request_method(start_response)
@@ -219,7 +220,8 @@ def directory(environ, start_response):
                         "status": 403,
                         "message": HTTP_CODE_DIC[403],
                         "detail": response_dic["error"],
-                    }
+                    },
+                    indent=2,
                 ).encode("utf-8")
             ]
         else:
@@ -227,7 +229,7 @@ def directory(environ, start_response):
             start_response("200 OK", headers)
             # logging
             logger_info(LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], "")
-            return [json.dumps(response_dic).encode("utf-8")]
+            return [json.dumps(response_dic, indent=2).encode("utf-8")]
 
 
 def cert(environ, start_response):
@@ -293,7 +295,7 @@ def chall(environ, start_response):
             logger_info(
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
-            return [json.dumps(response_dic["data"]).encode("utf-8")]
+            return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
 
         elif environ["REQUEST_METHOD"] == "GET":
 
@@ -311,7 +313,7 @@ def chall(environ, start_response):
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
             # send response
-            return [json.dumps(response_dic["data"]).encode("utf-8")]
+            return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
 
         else:
             err_wrong_request_method(start_response)
@@ -339,7 +341,8 @@ def newnonce(environ, start_response):
                     "status": 405,
                     "message": HTTP_CODE_DIC[405],
                     "detail": "Wrong request type. Expected HEAD or GET.",
-                }
+                },
+                indent=2,
             ).encode("utf-8")
         ]
 
@@ -361,7 +364,7 @@ def neworders(environ, start_response):
             logger_info(
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
-            return [json.dumps(response_dic["data"]).encode("utf-8")]
+            return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
 
     else:
         err_wrong_request_method(start_response)
@@ -385,7 +388,7 @@ def order(environ, start_response):
             logger_info(
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
-            return [json.dumps(response_dic["data"]).encode("utf-8")]
+            return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
 
     else:
         err_wrong_request_method(start_response)
@@ -427,7 +430,7 @@ def renewalinfo(environ, start_response):
 
             # send response
             if "data" in response_dic:
-                return [json.dumps(response_dic["data"]).encode("utf-8")]
+                return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
             else:
                 return []
 
@@ -454,7 +457,7 @@ def revokecert(environ, start_response):
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
             if "data" in response_dic:
-                return [json.dumps(response_dic["data"]).encode("utf-8")]
+                return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
             else:
                 return []
     else:
@@ -481,7 +484,7 @@ def trigger(environ, start_response):
             )
 
             if "data" in response_dic:
-                return [json.dumps(response_dic["data"]).encode("utf-8")]
+                return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
             else:
                 return []
     else:
@@ -506,7 +509,7 @@ def housekeeping(environ, start_response):
             logger_info(LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], "****")
 
             if "data" in response_dic:
-                return [json.dumps(response_dic["data"]).encode("utf-8")]
+                return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
             else:
                 return []
     else:
@@ -519,7 +522,8 @@ def not_found(_environ, start_response):
     start_response("404 NOT FOUND", [("Content-Type", "text/plain")])
     return [
         json.dumps(
-            {"status": 404, "message": HTTP_CODE_DIC[404], "detail": "Not Found"}
+            {"status": 404, "message": HTTP_CODE_DIC[404], "detail": "Not Found"},
+            indent=2,
         ).encode("utf-8")
     ]
 

--- a/examples/django/acme_srv/a2c_response.py
+++ b/examples/django/acme_srv/a2c_response.py
@@ -27,7 +27,7 @@ class JsonResponse(HttpResponse):
                 "safe parameter to False."
             )
         if json_dumps_params is None:
-            json_dumps_params = {}
+            json_dumps_params = {"indent": 2}
 
         if "status" in kwargs and kwargs["status"] > 201:
             kwargs.setdefault("content_type", "application/problem+json")

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -56,7 +56,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
     @patch("acme_srv.certificate.cert_dates_get", return_value=(0, 1234567890))
-    def test_001_log_issuance_success_text(
+    def test_002_log_issuance_success_text(
         self, mock_san, mock_cn, mock_serial, mock_dates
     ):
         self.mock_repository.order_lookup.return_value = {
@@ -78,7 +78,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_serial_get", return_value="serial")
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
-    def test_002_log_revocation_success_json(self, mock_san, mock_cn, mock_serial):
+    def test_003_log_revocation_success_json(self, mock_san, mock_cn, mock_serial):
         self.mock_repository.certificate_lookup.return_value = {
             "name": "cert_name",
             "order__account__name": "acc",
@@ -96,7 +96,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_serial_get", return_value="serial")
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
-    def test_002_log_revocation_success_text(self, mock_san, mock_cn, mock_serial):
+    def test_004_log_revocation_success_text(self, mock_san, mock_cn, mock_serial):
         self.mock_repository.certificate_lookup.return_value = {
             "name": "cert_name",
             "order__account__name": "acc",
@@ -115,7 +115,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_serial_get", return_value="serial")
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
-    def test_003_log_issuance_db_error(self, mock_san, mock_cn, mock_serial):
+    def test_005_log_issuance_db_error(self, mock_san, mock_cn, mock_serial):
         self.mock_repository.order_lookup.side_effect = Exception("DB error")
         with self.assertLogs("test_a2c", level="ERROR") as lcm:
             self.certlogger.log_certificate_issuance(
@@ -129,7 +129,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_serial_get", return_value="serial")
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
-    def test_004_log_revocation_db_error(self, mock_san, mock_cn, mock_serial):
+    def test_006_log_revocation_db_error(self, mock_san, mock_cn, mock_serial):
         self.mock_repository.certificate_lookup.side_effect = Exception("DB error")
         with self.assertLogs("test_a2c", level="ERROR") as lcm:
             self.certlogger.log_certificate_revocation("cert_pem", 400)
@@ -142,7 +142,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
     @patch("acme_srv.certificate.cert_dates_get", return_value=(0, 1234567890))
-    def test_005_log_issuance_json_format(
+    def test_007_log_issuance_json_format(
         self, mock_san, mock_cn, mock_serial, mock_dates
     ):
         self.mock_repository.order_lookup.return_value = {
@@ -164,7 +164,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
     @patch("acme_srv.certificate.cert_dates_get", return_value=(0, 1234567890))
-    def test_006_log_issuance_with_reusage_and_kid(
+    def test_008_log_issuance_with_reusage_and_kid(
         self, mock_san, mock_cn, mock_serial, mock_dates
     ):
         self.mock_repository.order_lookup.return_value = {
@@ -185,7 +185,7 @@ class TestCertificateLogger(unittest.TestCase):
     @patch("acme_srv.certificate.cert_serial_get", return_value="serial")
     @patch("acme_srv.certificate.cert_cn_get", return_value="CN")
     @patch("acme_srv.certificate.cert_san_get", return_value=["SAN"])
-    def test_007_log_revocation_json_format(self, mock_san, mock_cn, mock_serial):
+    def test_009_log_revocation_json_format(self, mock_san, mock_cn, mock_serial):
         self.mock_repository.certificate_lookup.return_value = {
             "name": "cert_name",
             "order__account__name": "acc",
@@ -200,12 +200,12 @@ class TestCertificateLogger(unittest.TestCase):
             lcm.output,
         )
 
-    def test_008_log_as_json(self):
+    def test_010_log_as_json(self):
         with self.assertLogs("test_a2c", level="INFO") as lcm:
             self.certlogger._log_as_json({"foo": "bar"}, "op")
         self.assertIn('INFO:test_a2c:op: {"foo": "bar"}', lcm.output)
 
-    def test_009_log_issuance_as_text(self):
+    def test_011_log_issuance_as_text(self):
         data_dic = {
             "account_name": "acc",
             "account_contact": "contact",
@@ -224,7 +224,7 @@ class TestCertificateLogger(unittest.TestCase):
             lcm.output,
         )
 
-    def test_010_log_revocation_as_text(self):
+    def test_012_log_revocation_as_text(self):
         data_dic = {
             "certificate_name": "cert_name",
             "account_name": "acc",
@@ -282,7 +282,7 @@ class TestCertificate(unittest.TestCase):
             "serverinternal": "serverinternal",
         }
 
-    def test_011_load_hooks_configuration_success(self):
+    def test_013_load_hooks_configuration_success(self):
         with patch("acme_srv.certificate.hooks_load") as mock_hooks_load:
             mock_hooks = MagicMock()
             mock_hooks.Hooks.return_value = MagicMock()
@@ -290,7 +290,7 @@ class TestCertificate(unittest.TestCase):
             self.cert._load_hooks_configuration({"foo": "bar"})
             mock_hooks.Hooks.assert_called()
 
-    def test_012_load_hooks_configuration_failure(self):
+    def test_014_load_hooks_configuration_failure(self):
         with patch("acme_srv.certificate.hooks_load", return_value=None):
             with self.assertLogs("test_a2c", level="DEBUG") as lcm:
                 self.cert._load_hooks_configuration({"foo": "bar"})
@@ -299,7 +299,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_013_load_hooks_configuration_hooks_exception(self):
+    def test_015_load_hooks_configuration_hooks_exception(self):
         # Simulate hooks_load returns a module, but Hooks raises exception
         mock_hooks = MagicMock()
         mock_hooks.Hooks.side_effect = Exception("fail")
@@ -311,7 +311,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_014_load_configuration(self):
+    def test_016_load_configuration(self):
         parser = configparser.ConfigParser()
         parser["foo1"] = {"foo": "bar"}
         with (
@@ -332,7 +332,7 @@ class TestCertificate(unittest.TestCase):
                 "DEBUG:test_a2c:Certificate._load_configuration() ended.", lcm.output
             )
 
-    def test_015_load_configuration_no_ca_handler_logs_critical(self):
+    def test_017_load_configuration_no_ca_handler_logs_critical(self):
         """Test that logger.critical is called if ca_handler_load returns None in _load_configuration."""
         parser = configparser.ConfigParser()
         parser["CAhandler"] = {"foo": "bar"}
@@ -344,7 +344,7 @@ class TestCertificate(unittest.TestCase):
                 self.cert._load_configuration()
             self.assertIn("CRITICAL:test_a2c:No ca_handler loaded", lcm.output)
 
-    def test_016_load_and_validate_identifiers_tnauth(self):
+    def test_018_load_and_validate_identifiers_tnauth(self):
         self.cert.config.tnauthlist_support = True
         with (
             patch.object(self.cert, "_check_for_tnauth_identifiers", return_value=True),
@@ -360,7 +360,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["ok"])
 
-    def test_017_load_and_validate_identifiers_sans(self):
+    def test_019_load_and_validate_identifiers_sans(self):
         self.cert.config.tnauthlist_support = False
         with (
             patch("acme_srv.certificate.csr_san_get", return_value=["DNS:foo"]),
@@ -373,7 +373,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["ok"])
 
-    def test_018_validate_csr_against_order_success(self):
+    def test_020_validate_csr_against_order_success(self):
         with (
             patch.object(
                 self.cert, "_get_certificate_info", return_value={"order": "order"}
@@ -387,7 +387,7 @@ class TestCertificate(unittest.TestCase):
         ):
             self.assertTrue(self.cert._validate_csr_against_order("cert", "csr"))
 
-    def test_019_validate_csr_against_order_failure(self):
+    def test_021_validate_csr_against_order_failure(self):
         with (
             patch.object(
                 self.cert, "_get_certificate_info", return_value={"order": "order"}
@@ -401,7 +401,7 @@ class TestCertificate(unittest.TestCase):
         ):
             self.assertFalse(self.cert._validate_csr_against_order("cert", "csr"))
 
-    def test_020_process_certificate_enrollment_reuse(self):
+    def test_022_process_certificate_enrollment_reuse(self):
         self.cert.config.cert_reusage_timeframe = True
         # _check_certificate_reusability should return 4 values
         with patch.object(
@@ -413,7 +413,7 @@ class TestCertificate(unittest.TestCase):
             # Should return 5 values, last is cert_reusage True
             self.assertEqual(result, (None, "cert", "raw", "poll", True))
 
-    def test_021_process_certificate_enrollment_new(self):
+    def test_023_process_certificate_enrollment_new(self):
         self.cert.config.cert_reusage_timeframe = False
         mock_ca = MagicMock()
         mock_ca.__enter__.return_value = mock_ca
@@ -422,7 +422,7 @@ class TestCertificate(unittest.TestCase):
         result = self.cert._process_certificate_enrollment("csr")
         self.assertEqual(result, (None, "cert", "raw", "poll", False))
 
-    def test_022_get_certificate_renewal_info(self):
+    def test_024_get_certificate_renewal_info(self):
         with (
             patch("acme_srv.certificate.pembundle_to_list", return_value=["a", "b"]),
             patch("acme_srv.certificate.certid_asn1_get", return_value="hex"),
@@ -430,7 +430,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._get_certificate_renewal_info("cert")
             self.assertEqual(result, "hex")
 
-    def test_023_store_certificate_and_update_order_success(self):
+    def test_025_store_certificate_and_update_order_success(self):
         with (
             patch.object(self.cert, "_store_certificate_in_database", return_value=1),
             patch.object(self.cert, "_update_order_status"),
@@ -441,7 +441,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, 1)
 
-    def test_024_certificate_and_update_order_error_handling(self):
+    def test_026_certificate_and_update_order_error_handling(self):
         with patch.object(
             self.cert,
             "_store_certificate_in_database",
@@ -461,12 +461,12 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_025_check_identifier_match(self):
+    def test_027_check_identifier_match(self):
         identifiers = [{"type": "dns", "value": "foo"}]
         result = self.cert._check_identifier_match("dns", "foo", identifiers, False)
         self.assertTrue(result)
 
-    def test_026_validate_identifiers_against_sans(self):
+    def test_028_validate_identifiers_against_sans(self):
         with patch.object(
             self.cert, "_check_identifier_match", return_value=True
         ) as mock_check:
@@ -475,7 +475,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, [True])
 
-    def test_027_validate_identifiers_against_sans_unknown(self):
+    def test_029_validate_identifiers_against_sans_unknown(self):
         with (
             patch.object(
                 self.cert, "_check_identifier_match", return_value=True
@@ -492,7 +492,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(args[1], "unkownsan")
             self.assertIsInstance(args[2], ValueError)
 
-    def test_028_validate_identifiers_against_nosans(self):
+    def test_030_validate_identifiers_against_nosans(self):
         with (
             patch.object(self.cert, "_check_identifier_match") as mock_check,
             patch.object(self.cert.logger, "error") as mock_logger_error,
@@ -505,13 +505,13 @@ class TestCertificate(unittest.TestCase):
             args, kwargs = mock_logger_error.call_args
             self.assertEqual(args[0], "No SANs found in certificate")
 
-    def test_029_check_tnauth_identifier_match(self):
+    def test_031_check_tnauth_identifier_match(self):
         identifier = {"type": "tnauthlist", "value": "abc"}
         tnauthlist = ["abc"]
         result = self.cert._check_tnauth_identifier_match(identifier, tnauthlist)
         self.assertTrue(result)
 
-    def test_030_validate_identifiers_against_tnauthlist(self):
+    def test_032_validate_identifiers_against_tnauthlist(self):
         identifier_dic = {"identifiers": '[{"type": "tnauthlist", "value": "abc"}]'}
         tnauthlist = ["abc"]
         result = self.cert._validate_identifiers_against_tnauthlist(
@@ -519,7 +519,7 @@ class TestCertificate(unittest.TestCase):
         )
         self.assertEqual(result, [True])
 
-    def test_031_validate_identifiers_against_tnauthlist_tnauthlist_and_not_identifier_dic(
+    def test_033_validate_identifiers_against_tnauthlist_tnauthlist_and_not_identifier_dic(
         self,
     ):
         # Covers lines 1078-1079: tnauthlist and not identifier_dic
@@ -530,7 +530,7 @@ class TestCertificate(unittest.TestCase):
         )
         self.assertEqual(result, [False])
 
-    def test_032_validate_identifiers_against_tnauthlist_identifiers_and_tnauthlist(
+    def test_034_validate_identifiers_against_tnauthlist_identifiers_and_tnauthlist(
         self,
     ):
         # Covers line 1082: identifiers and tnauthlist
@@ -544,7 +544,7 @@ class TestCertificate(unittest.TestCase):
         )
         self.assertEqual(result, [True, False])
 
-    def test_033_validate_identifiers_against_tnauthlist_else_branch(self):
+    def test_035_validate_identifiers_against_tnauthlist_else_branch(self):
         # Covers line 1089: else branch (no identifiers, no tnauthlist)
         identifier_dic = {"identifiers": "[]"}
         tnauthlist = []
@@ -553,16 +553,16 @@ class TestCertificate(unittest.TestCase):
         )
         self.assertEqual(result, [False])
 
-    def test_034_get_certificate_info_success(self):
+    def test_036_get_certificate_info_success(self):
         self.cert.repository.certificate_lookup.return_value = {"foo": "bar"}
         result = self.cert._get_certificate_info("cert")
         self.assertEqual(result, {"foo": "bar"})
 
-    def test_035_update_order_status(self):
+    def test_037_update_order_status(self):
         self.cert._update_order_status({"name": "order", "status": "valid"})
         self.cert.repository.order_update.assert_called()
 
-    def test_036_update_order_status_exception(self):
+    def test_038_update_order_status_exception(self):
         # Covers the exception branch in _update_order_status (lines 1118-1119)
         self.cert.repository.order_update.side_effect = Exception("fail")
         with patch.object(self.cert.logger, "critical") as mock_critical:
@@ -571,11 +571,11 @@ class TestCertificate(unittest.TestCase):
             args, _ = mock_critical.call_args
             self.assertIn("Database error: failed to update order", args[0])
 
-    def test_037_validate_revocation_reason(self):
+    def test_039_validate_revocation_reason(self):
         result = self.cert._validate_revocation_reason(0)
         self.assertEqual(result, "unspecified")
 
-    def test_038_validate_revocation_request_success(self):
+    def test_040_validate_revocation_request_success(self):
         self.cert.repository.certificate_account_check.return_value = "order"
         self.cert.repository.order_lookup.return_value = {"identifiers": "[]"}
         with patch.object(
@@ -585,7 +585,7 @@ class TestCertificate(unittest.TestCase):
             code, error = self.cert._validate_revocation_request("acc", payload)
             self.assertEqual(code, 200)
 
-    def test_039_store_certificate_in_database_success(self):
+    def test_041_store_certificate_in_database_success(self):
         with (
             patch("acme_srv.certificate.cert_serial_get", return_value="serial"),
             patch("acme_srv.certificate.cert_aki_get", return_value="aki"),
@@ -599,24 +599,24 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, 1)
 
-    def test_040_store_certificate_error_success(self):
+    def test_042_store_certificate_error_success(self):
         self.mock_repository.certificate_add.return_value = 1
         result = self.cert._store_certificate_error("cert", "err", "poll")
         self.assertEqual(result, 1)
 
-    def test_041_check_for_tnauth_identifiers(self):
+    def test_043_check_for_tnauth_identifiers(self):
         identifiers = [{"type": "tnauthlist", "value": "abc"}]
         result = self.cert._check_for_tnauth_identifiers(identifiers)
         self.assertTrue(result)
 
-    def test_042_certlist_search(self):
+    def test_044_certlist_search(self):
         self.mock_certificate_manager.search_certificates.return_value = {
             "certificates": [{"foo": "bar"}]
         }
         result = self.cert.certlist_search("name", "cert")
         self.assertEqual(result, [{"foo": "bar"}])
 
-    def test_043_cleanup(self):
+    def test_045_cleanup(self):
         self.mock_certificate_manager.cleanup_certificates.return_value = (
             ["field"],
             ["report"],
@@ -624,7 +624,7 @@ class TestCertificate(unittest.TestCase):
         result = self.cert.cleanup(123, True)
         self.assertEqual(result, (["field"], ["report"]))
 
-    def test_044_cleanup(self):
+    def test_046_cleanup(self):
         self.mock_certificate_manager.cleanup_certificates.return_value = (
             ["field"],
             ["report"],
@@ -634,7 +634,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, (["field"], ["report"]))
             mock_uts_now.assert_called()
 
-    def test_045_update_certificate_dates(self):
+    def test_047_update_certificate_dates(self):
         cert = {
             "name": "cert",
             "cert": "cert",
@@ -653,7 +653,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_046_dates_update(self):
+    def test_048_dates_update(self):
         with (
             patch.object(
                 self.cert,
@@ -673,29 +673,29 @@ class TestCertificate(unittest.TestCase):
             self.cert.dates_update()
             mock_update.assert_called()
 
-    def test_047_validate_input_parameters_all_valid(self):
+    def test_049_validate_input_parameters_all_valid(self):
         params = {"a": "x", "b": "y"}
         result = self.cert._validate_input_parameters(**params)
         self.assertEqual(result, {})
 
-    def test_048_validate_input_parameters_some_invalid(self):
+    def test_050_validate_input_parameters_some_invalid(self):
         params = {"a": "", "b": None, "c": "ok"}
         result = self.cert._validate_input_parameters(**params)
         self.assertIn("a", result)
         self.assertIn("b", result)
         self.assertNotIn("c", result)
 
-    def test_049_create_error_response(self):
+    def test_051_create_error_response(self):
         resp = self.cert._create_error_response(400, "msg", "detail")
         self.assertEqual(resp, {"code": 400, "data": "msg", "detail": "detail"})
 
-    def test_050_validate_certificate_account_ownership_success(self):
+    def test_052_validate_certificate_account_ownership_success(self):
         self.cert.repository.certificate_account_check.return_value = True
         self.assertTrue(
             self.cert._validate_certificate_account_ownership("acc", "cert")
         )
 
-    def test_051_validate_certificate_account_ownership_db_error(self):
+    def test_053_validate_certificate_account_ownership_db_error(self):
         self.cert.repository.certificate_account_check.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as lcm:
             self.assertIsNone(
@@ -706,7 +706,7 @@ class TestCertificate(unittest.TestCase):
             lcm.output,
         )
 
-    def test_052_validate_certificate_authorization_tnauthlist(self):
+    def test_054_validate_certificate_authorization_tnauthlist(self):
         self.cert.config.tnauthlist_support = True
         with (
             patch.object(self.cert, "_check_for_tnauth_identifiers", return_value=True),
@@ -724,7 +724,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["ok"])
 
-    def test_053_validate_certificate_authorization_sans(self):
+    def test_055_validate_certificate_authorization_sans(self):
         self.cert.config.tnauthlist_support = False
         with (
             patch("acme_srv.certificate.cert_san_get", return_value=["DNS:foo"]),
@@ -738,7 +738,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["ok"])
 
-    def test_054_certificate_authorization_json_decode_error(self):
+    def test_056_certificate_authorization_json_decode_error(self):
         # Covers exception in json.loads(identifier_dic["identifiers"].lower()) (lines 454-455)
         self.cert.config.tnauthlist_support = False
         with (
@@ -756,7 +756,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["ok"])
 
-    def test_055_certificate_authorization_tnauthlist_cert_extensions_get_exception(
+    def test_057_certificate_authorization_tnauthlist_cert_extensions_get_exception(
         self,
     ):
         # Covers exception in cert_extensions_get (lines 466-469)
@@ -783,7 +783,7 @@ class TestCertificate(unittest.TestCase):
                 unittest.mock.ANY,
             )
 
-    def test_056_certificate_authorization_debug_log(self):
+    def test_058_certificate_authorization_debug_log(self):
         # Covers the debug log at the end (lines 479-481)
         self.cert.config.tnauthlist_support = False
         with (
@@ -798,21 +798,21 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["ok"])
 
-    def test_057_validate_order_authorization_success(self):
+    def test_059_validate_order_authorization_success(self):
         self.cert.repository.order_lookup.return_value = {"identifiers": "[]"}
         with patch.object(
             self.cert, "_validate_certificate_authorization", return_value=[True]
         ):
             self.assertTrue(self.cert._validate_order_authorization("order", "cert"))
 
-    def test_058_validate_order_authorization_failure(self):
+    def test_060_validate_order_authorization_failure(self):
         self.cert.repository.order_lookup.return_value = {"identifiers": "[]"}
         with patch.object(
             self.cert, "_validate_certificate_authorization", return_value=[False]
         ):
             self.assertFalse(self.cert._validate_order_authorization("order", "cert"))
 
-    def test_059_validate_order_authorization_db_error(self):
+    def test_061_validate_order_authorization_db_error(self):
         self.cert.repository.order_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as lcm:
             self.assertFalse(self.cert._validate_order_authorization("order", "cert"))
@@ -821,7 +821,7 @@ class TestCertificate(unittest.TestCase):
             lcm.output,
         )
 
-    def test_060_check_certificate_reusability_found(self):
+    def test_062_check_certificate_reusability_found(self):
         self.cert.repository.search_certificates.return_value = [
             {
                 "expire_uts": 9999999999,
@@ -836,7 +836,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._check_certificate_reusability("csr")
             self.assertIsInstance(result, tuple)
 
-    def test_061_check_certificate_reusability_db_error(self):
+    def test_063_check_certificate_reusability_db_error(self):
         self.cert.repository.search_certificates.side_effect = Exception("fail")
         with patch("acme_srv.certificate.uts_now", return_value=2):
             with self.assertLogs("test_a2c", level="CRITICAL") as lcm:
@@ -847,18 +847,18 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_062_check_certificate_reusability_none_found(self):
+    def test_064_check_certificate_reusability_none_found(self):
         self.cert.repository.search_certificates.return_value = None
         with patch("acme_srv.certificate.uts_now", return_value=2):
             result = self.cert._check_certificate_reusability("csr")
             self.assertIsInstance(result, tuple)
 
-    def test_063_handle_enrollment_error(self):
+    def test_065_handle_enrollment_error(self):
         # _handle_enrollment_error returns a tuple (None, msg, detail)
         result = self.cert._handle_enrollment_error("msg", "detail", "order", "cert")
         self.assertEqual(result, (None, "msg", "detail"))
 
-    def test_064_enrollment_error_poll_identifier(self):
+    def test_066_enrollment_error_poll_identifier(self):
         with patch.object(self.cert, "_store_certificate_error") as mock_store_error:
             result, error, detail = self.cert._handle_enrollment_error(
                 "error", "poll", "order", "cert_name"
@@ -867,14 +867,14 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(detail, "poll")
             mock_store_error.assert_called()
 
-    def test_065_execute_pre_enrollment_hooks(self):
+    def test_067_execute_pre_enrollment_hooks(self):
         self.cert.hook_handler = MagicMock()
         self.cert.hook_handler.execute_pre_enrollment_hooks.return_value = []
         # _execute_pre_enrollment_hooks returns a list (possibly empty)
         result = self.cert._execute_pre_enrollment_hooks("order", "csr", None)
         self.assertIsInstance(result, list)
 
-    def test_066_pre_enrollment_hooks_with_hooks(self):
+    def test_068_pre_enrollment_hooks_with_hooks(self):
         self.cert.hooks = MagicMock()
         self.cert.hooks.execute.side_effect = [None]
         hook_errors = self.cert._execute_pre_enrollment_hooks(
@@ -882,7 +882,7 @@ class TestCertificate(unittest.TestCase):
         )
         self.assertEqual(hook_errors, [])
 
-    def test_067_execute_post_enrollment_hooks(self):
+    def test_069_execute_post_enrollment_hooks(self):
         # Test normal post_hook execution logs debug (line 915)
         self.cert.hooks = MagicMock()
         self.cert.hooks.post_hook.return_value = True
@@ -895,7 +895,7 @@ class TestCertificate(unittest.TestCase):
                 "Certificate._execute_post_enrollment_hooks(): post_hook successful"
             )
 
-    def test_068_post_enrollment_hooks_with_error(self):
+    def test_070_post_enrollment_hooks_with_error(self):
         """Test _execute_post_enrollment_hooks with error - checks logger.error call"""
         self.cert.hooks = MagicMock()
         self.cert.hooks.post_hook.side_effect = Exception("Hook error")
@@ -910,13 +910,13 @@ class TestCertificate(unittest.TestCase):
             self.assertIn("Hook error", mock_logger_error.call_args[0][1].args[0])
             self.assertIsInstance(hook_errors, list)
 
-    def test_069_handle_processing_certificate(self):
+    def test_071_handle_processing_certificate(self):
         # Ensure 'ratelimited' key exists in err_msg_dic to avoid KeyError
         self.cert.err_msg_dic["ratelimited"] = "ratelimited"
         result = self.cert._handle_processing_certificate()
         self.assertIsInstance(result, dict)
 
-    def test_070_handle_valid_certificate(self):
+    def test_072_handle_valid_certificate(self):
         cert_info = {
             "certificate": "cert",
             "order_name": "order",
@@ -926,7 +926,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._handle_valid_certificate(cert_info)
             self.assertIsInstance(result, dict)
 
-    def test_071_handle_valid_certificate_db_error(self):
+    def test_073_handle_valid_certificate_db_error(self):
         cert_info = {
             "certificate": "cert",
             "order_name": "order",
@@ -938,7 +938,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._handle_valid_certificate(cert_info)
             self.assertIsInstance(result, dict)
 
-    def test_072_determine_certificate_response_valid(self):
+    def test_074_determine_certificate_response_valid(self):
         # Patch _handle_valid_certificate to return {'code': 200} for 'valid' status
         with patch.object(
             self.cert, "_handle_valid_certificate", return_value={"code": 200}
@@ -952,7 +952,7 @@ class TestCertificate(unittest.TestCase):
                     result, {"code": 500, "data": "serverinternal", "detail": None}
                 )
 
-    def test_073_determine_certificate_response_processing(self):
+    def test_075_determine_certificate_response_processing(self):
         # Patch _handle_processing_certificate to return {'code': 202} for 'processing' status
         with patch.object(
             self.cert, "_handle_processing_certificate", return_value={"code": 202}
@@ -966,11 +966,11 @@ class TestCertificate(unittest.TestCase):
                     result, {"code": 500, "data": "serverinternal", "detail": None}
                 )
 
-    def test_074_determine_certificate_response_invalid(self):
+    def test_076_determine_certificate_response_invalid(self):
         result = self.cert._determine_certificate_response({"status": "invalid"})
         self.assertIsInstance(result, dict)
 
-    def test_075_validate_input_parameters_invalid(self):
+    def test_077_validate_input_parameters_invalid(self):
         with patch.object(
             self.cert, "_validate_input_parameters", return_value=["error"]
         ):
@@ -984,7 +984,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_076_poll_certificate_status_success(self):
+    def test_078_poll_certificate_status_success(self):
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value=None),
             patch.object(self.cert, "cahandler") as mock_cahandler,
@@ -999,7 +999,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, 123)
             mock_success.assert_called()
 
-    def test_077_poll_certificate_status_failure(self):
+    def test_079_poll_certificate_status_failure(self):
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value=None),
             patch.object(self.cert, "cahandler") as mock_cahandler,
@@ -1012,7 +1012,7 @@ class TestCertificate(unittest.TestCase):
             self.assertIsNone(result)
             mock_failed.assert_called()
 
-    def test_078_poll_certificate_status_failure(self):
+    def test_080_poll_certificate_status_failure(self):
         # Patch logger.error to check the error message from line 1819
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value=None),
@@ -1031,7 +1031,7 @@ class TestCertificate(unittest.TestCase):
             args, _ = mock_logger_error.call_args
             self.assertIn("Error polling certificate from CA handler", args[0])
 
-    def test_079_store_certificate_signing_request_success(self):
+    def test_081_store_certificate_signing_request_success(self):
         self.mock_certificate_manager.validate_and_store_csr.return_value = (
             True,
             "cert",
@@ -1039,14 +1039,14 @@ class TestCertificate(unittest.TestCase):
         result = self.cert.store_certificate_signing_request("order", "csr", "header")
         self.assertEqual(result, "cert")
 
-    def test_080_store_certificate_signing_request_failure(self):
+    def test_082_store_certificate_signing_request_failure(self):
         self.mock_certificate_manager.validate_and_store_csr.return_value = (
             False,
             None,
         )
         self.cert.store_certificate_signing_request("order", "csr", "header")
 
-    def test_081_store_certificate_signing_request_exception(self):
+    def test_083_store_certificate_signing_request_exception(self):
         self.mock_certificate_manager.validate_and_store_csr.side_effect = Exception(
             "fail"
         )
@@ -1061,7 +1061,7 @@ class TestCertificate(unittest.TestCase):
             log.output,
         )
 
-    def test_082_handle_successful_certificate_poll_db_error(self):
+    def test_084_handle_successful_certificate_poll_db_error(self):
         with patch.object(
             self.cert, "_store_certificate_in_database", side_effect=Exception("fail")
         ):
@@ -1075,7 +1075,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_083_handle_failed_certificate_poll_db_error(self):
+    def test_085_handle_failed_certificate_poll_db_error(self):
         with patch.object(
             self.cert, "_store_certificate_error", side_effect=Exception("fail")
         ):
@@ -1088,7 +1088,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_084_handle_failed_certificate_poll_order_update_error(self):
+    def test_086_handle_failed_certificate_poll_order_update_error(self):
         self.cert.repository.order_update.side_effect = Exception("fail")
         with self.assertLogs(self.cert.logger, level="CRITICAL") as log:
             self.cert._handle_failed_certificate_poll(
@@ -1099,7 +1099,7 @@ class TestCertificate(unittest.TestCase):
             log.output,
         )
 
-    def test_085_enroll_and_store_legacy(self):
+    def test_087_enroll_and_store_legacy(self):
         with patch.object(
             self.cert,
             "process_certificate_enrollment_request",
@@ -1109,7 +1109,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, ("cert", "order"))
             mock_proc.assert_called()
 
-    def test_086_new_get_legacy(self):
+    def test_088_new_get_legacy(self):
         with patch.object(
             self.cert, "get_certificate_details", return_value={"foo": "bar"}
         ) as mock_get:
@@ -1117,7 +1117,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, {"foo": "bar"})
             mock_get.assert_called()
 
-    def test_087_new_post_legacy(self):
+    def test_089_new_post_legacy(self):
         with patch.object(
             self.cert, "process_certificate_request", return_value={"foo": "bar"}
         ) as mock_post:
@@ -1125,7 +1125,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, {"foo": "bar"})
             mock_post.assert_called()
 
-    def test_088_revoke_legacy(self):
+    def test_090_revoke_legacy(self):
         with patch.object(
             self.cert, "revoke_certificate", return_value={"foo": "bar"}
         ) as mock_revoke:
@@ -1133,7 +1133,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, {"foo": "bar"})
             mock_revoke.assert_called()
 
-    def test_089_poll_legacy(self):
+    def test_091_poll_legacy(self):
         with patch.object(
             self.cert, "poll_certificate_status", return_value=123
         ) as mock_poll:
@@ -1141,7 +1141,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, 123)
             mock_poll.assert_called()
 
-    def test_090_store_csr_legacy(self):
+    def test_092_store_csr_legacy(self):
         with patch.object(
             self.cert, "store_certificate_signing_request", return_value="cert"
         ) as mock_store:
@@ -1149,7 +1149,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, "cert")
             mock_store.assert_called()
 
-    def test_091_validate_certificate_account_ownership_exception(self):
+    def test_093_validate_certificate_account_ownership_exception(self):
         self.cert.repository.certificate_account_check.side_effect = Exception(
             "Database error"
         )
@@ -1162,7 +1162,7 @@ class TestCertificate(unittest.TestCase):
             log.output,
         )
 
-    def test_092_validate_certificate_authorization_exception(self):
+    def test_094_validate_certificate_authorization_exception(self):
         with patch(
             "acme_srv.certificate.cert_san_get", side_effect=Exception("SAN error")
         ):
@@ -1176,7 +1176,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_093_validate_order_authorization_exception(self):
+    def test_095_validate_order_authorization_exception(self):
         self.cert.repository.order_lookup.side_effect = Exception("Order lookup error")
         with self.assertLogs(self.cert.logger, level="CRITICAL") as log:
             result = self.cert._validate_order_authorization("order", "certificate")
@@ -1186,7 +1186,7 @@ class TestCertificate(unittest.TestCase):
             log.output,
         )
 
-    def test_094_check_certificate_reusability_exception(self):
+    def test_096_check_certificate_reusability_exception(self):
         self.cert.repository.search_certificates.side_effect = Exception(
             "Reusability error"
         )
@@ -1198,7 +1198,7 @@ class TestCertificate(unittest.TestCase):
             log.output,
         )
 
-    def test_095_process_certificate_enrollment_exception(self):
+    def test_097_process_certificate_enrollment_exception(self):
         self.cert.config.cert_reusage_timeframe = True
         with patch.object(
             self.cert,
@@ -1209,7 +1209,7 @@ class TestCertificate(unittest.TestCase):
                 self.cert._process_certificate_enrollment("csr")
             self.assertEqual(str(context.exception), "Enrollment error")
 
-    def test_096_store_certificate_and_update_order_exception(self):
+    def test_098_store_certificate_and_update_order_exception(self):
         with patch.object(
             self.cert,
             "_store_certificate_in_database",
@@ -1227,7 +1227,7 @@ class TestCertificate(unittest.TestCase):
             )
 
     # Tests for missing methods
-    def test_097_dates_update(self):
+    def test_099_dates_update(self):
         """Test dates_update method"""
         with (
             patch.object(
@@ -1248,7 +1248,7 @@ class TestCertificate(unittest.TestCase):
             self.cert.dates_update()
             mock_update.assert_called()
 
-    def test_098_update_certificate_dates_with_dates(self):
+    def test_100_update_certificate_dates_with_dates(self):
         """Test _update_certificate_dates with existing dates"""
         cert = {
             "name": "cert",
@@ -1264,7 +1264,7 @@ class TestCertificate(unittest.TestCase):
             lcm.output,
         )
 
-    def test_099_update_certificate_dates_zero_dates(self):
+    def test_101_update_certificate_dates_zero_dates(self):
         """Test _update_certificate_dates with zero dates"""
         cert = {
             "name": "cert",
@@ -1287,7 +1287,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_100_handle_enrollment_thread_execution_success(self):
+    def test_102_handle_enrollment_thread_execution_success(self):
         """Test _handle_enrollment_thread_execution success case"""
         with patch("acme_srv.certificate.ThreadWithReturnValue") as mock_thread:
             mock_thread_instance = MagicMock()
@@ -1299,7 +1299,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, (None, "detail"))
 
-    def test_101_handle_enrollment_thread_execution_timeout(self):
+    def test_103_handle_enrollment_thread_execution_timeout(self):
         """Test _handle_enrollment_thread_execution timeout case"""
         with patch("acme_srv.certificate.ThreadWithReturnValue") as mock_thread:
             mock_thread_instance = MagicMock()
@@ -1311,7 +1311,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ("timeout", "Enrollment process timed out"))
 
-    def test_102_handle_enrollment_thread_execution_exception(self):
+    def test_104_handle_enrollment_thread_execution_exception(self):
         """Test _handle_enrollment_thread_execution exception case"""
         with patch(
             "acme_srv.certificate.ThreadWithReturnValue",
@@ -1322,17 +1322,17 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result[0], "serverinternal")
 
-    def test_103_parse_enrollment_result_valid_tuple(self):
+    def test_105_parse_enrollment_result_valid_tuple(self):
         """Test _parse_enrollment_result with valid tuple"""
         result = self.cert._parse_enrollment_result((1, "error", "detail"))
         self.assertEqual(result, ("error", "detail"))
 
-    def test_104_parse_enrollment_result_invalid_format(self):
+    def test_106_parse_enrollment_result_invalid_format(self):
         """Test _parse_enrollment_result with invalid format"""
         result = self.cert._parse_enrollment_result("invalid")
         self.assertEqual(result[0], "serverinternal")
 
-    def test_105_process_certificate_enrollment_request_invalid_input(self):
+    def test_107_process_certificate_enrollment_request_invalid_input(self):
         """Test process_certificate_enrollment_request with invalid input"""
         with patch.object(
             self.cert, "_validate_input_parameters", return_value={"cert": "error"}
@@ -1347,7 +1347,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_106_process_certificate_enrollment_request_csr_validation_error(self):
+    def test_108_process_certificate_enrollment_request_csr_validation_error(self):
         """Test process_certificate_enrollment_request with CSR validation error"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1365,7 +1365,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_107_process_certificate_enrollment_request_csr_validation_failed(self):
+    def test_109_process_certificate_enrollment_request_csr_validation_failed(self):
         """Test process_certificate_enrollment_request with failed CSR validation"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1379,7 +1379,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_108_process_certificate_enrollment_request_enrollment_success(self):
+    def test_110_process_certificate_enrollment_request_enrollment_success(self):
         """Test process_certificate_enrollment_request successful enrollment"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1393,7 +1393,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.process_certificate_enrollment_request("cert", "csr")
             self.assertEqual(result, (None, "detail"))
 
-    def test_109_process_certificate_enrollment_request_unexpected_error(self):
+    def test_111_process_certificate_enrollment_request_unexpected_error(self):
         """Test process_certificate_enrollment_request with unexpected error"""
         with patch.object(
             self.cert, "_validate_input_parameters", side_effect=Exception("Unexpected")
@@ -1406,12 +1406,12 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_110_determine_certificate_response_no_cert_info(self):
+    def test_112_determine_certificate_response_no_cert_info(self):
         """Test _determine_certificate_response with no cert info"""
         result = self.cert._determine_certificate_response({})
         self.assertEqual(result["code"], 500)
 
-    def test_111_determine_certificate_response_valid_order(self):
+    def test_113_determine_certificate_response_valid_order(self):
         """Test _determine_certificate_response with valid order"""
         cert_info = {
             "order__status_id": self.cert.ORDER_STATUS_VALID,
@@ -1423,7 +1423,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._determine_certificate_response(cert_info)
             mock_handle.assert_called_with(cert_info)
 
-    def test_112_determine_certificate_response_processing_order(self):
+    def test_114_determine_certificate_response_processing_order(self):
         """Test _determine_certificate_response with processing order"""
         cert_info = {"order__status_id": self.cert.ORDER_STATUS_PROCESSING}
         with patch.object(
@@ -1432,21 +1432,21 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._determine_certificate_response(cert_info)
             mock_handle.assert_called()
 
-    def test_113_determine_certificate_response_invalid_order(self):
+    def test_115_determine_certificate_response_invalid_order(self):
         """Test _determine_certificate_response with invalid order"""
         cert_info = {"order__status_id": 99}
         self.cert.err_msg_dic["ordernotready"] = "order not ready"  # Add missing key
         result = self.cert._determine_certificate_response(cert_info)
         self.assertEqual(result["code"], 403)
 
-    def test_114_handle_valid_certificate_with_cert(self):
+    def test_116_handle_valid_certificate_with_cert(self):
         """Test _handle_valid_certificate with certificate present"""
         cert_info = {"cert": "certificate_data"}
         result = self.cert._handle_valid_certificate(cert_info)
         self.assertEqual(result["code"], 200)
         self.assertEqual(result["data"], "certificate_data")
 
-    def test_115_and_validate_identifiers_json_decode_error(self):
+    def test_117_and_validate_identifiers_json_decode_error(self):
         """Covers identifiers JSON decode error (lines 663-664)."""
         identifier_dic = {"identifiers": "not-a-json"}
         csr = "irrelevant"
@@ -1457,7 +1457,7 @@ class TestCertificate(unittest.TestCase):
                 self.assertEqual(result, [False])
             self.assertIn("ERROR:test_a2c:No SANs found in certificate", lcm.output)
 
-    def test_116_and_validate_identifiers_tnauthlist_extension_error(self):
+    def test_118_and_validate_identifiers_tnauthlist_extension_error(self):
         """Covers tnauthlist extension error (lines 676-678)."""
 
         self.cert.config.tnauthlist_support = True
@@ -1477,7 +1477,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_117_and_validate_identifiers_san_extraction_error(self):
+    def test_119_and_validate_identifiers_san_extraction_error(self):
         """Covers SAN extraction error (lines 688-690)."""
         self.cert.config.tnauthlist_support = False
         identifier_dic = {"identifiers": '[{"type": "dns", "value": "example.com"}]'}
@@ -1496,13 +1496,13 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_118_handle_valid_certificate_no_cert(self):
+    def test_120_handle_valid_certificate_no_cert(self):
         """Test _handle_valid_certificate with no certificate"""
         cert_info = {}
         result = self.cert._handle_valid_certificate(cert_info)
         self.assertEqual(result["code"], 500)
 
-    def test_119_handle_processing_certificate(self):
+    def test_121_handle_processing_certificate(self):
         """Test _handle_processing_certificate"""
         self.cert.err_msg_dic["ratelimited"] = "rate_limited"
         result = self.cert._handle_processing_certificate()
@@ -1510,7 +1510,7 @@ class TestCertificate(unittest.TestCase):
         self.assertEqual(result["data"], "rate_limited")
         self.assertIn("Retry-After", result["header"])
 
-    def test_120_get_certificate_details_invalid_url(self):
+    def test_122_get_certificate_details_invalid_url(self):
         """Test get_certificate_details with invalid URL"""
         with patch.object(
             self.cert, "_validate_input_parameters", return_value={"url": "error"}
@@ -1518,7 +1518,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.get_certificate_details("")
             self.assertEqual(result["code"], 400)
 
-    def test_121_get_certificate_details_manager_error(self):
+    def test_123_get_certificate_details_manager_error(self):
         """Test get_certificate_details with manager error"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1531,7 +1531,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.get_certificate_details("http://test.com/cert/123")
             self.assertEqual(result["code"], 500)
 
-    def test_122_get_certificate_details_success(self):
+    def test_124_get_certificate_details_success(self):
         """Test get_certificate_details success case"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1547,7 +1547,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.get_certificate_details("http://test.com/cert/123")
             mock_determine.assert_called()
 
-    def test_123_get_certificate_details_unexpected_error(self):
+    def test_125_get_certificate_details_unexpected_error(self):
         """Test get_certificate_details with unexpected error"""
         with patch.object(
             self.cert, "_validate_input_parameters", side_effect=Exception("Unexpected")
@@ -1560,7 +1560,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_124_validate_certificate_request_message_success(self):
+    def test_126_validate_certificate_request_message_success(self):
         """Test _validate_certificate_request_message success"""
         with patch.object(
             self.cert.message,
@@ -1570,7 +1570,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._validate_certificate_request_message("content")
             self.assertEqual(result[0], 200)
 
-    def test_125_validate_certificate_request_message_error(self):
+    def test_127_validate_certificate_request_message_error(self):
         """Test _validate_certificate_request_message with error"""
         with patch.object(
             self.cert.message, "check", side_effect=Exception("Message error")
@@ -1578,7 +1578,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._validate_certificate_request_message("content")
             self.assertEqual(result[0], 400)
 
-    def test_126_prepare_certificate_response_success(self):
+    def test_128_prepare_certificate_response_success(self):
         """Test _prepare_certificate_response success"""
         with patch.object(
             self.cert.message,
@@ -1590,7 +1590,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result["code"], 200)
 
-    def test_127_prepare_certificate_response_with_dict_data(self):
+    def test_129_prepare_certificate_response_with_dict_data(self):
         """Test _prepare_certificate_response with dict data"""
         with patch.object(
             self.cert.message,
@@ -1602,7 +1602,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertIsInstance(result["data"], str)  # Should be JSON string
 
-    def test_128_prepare_certificate_response_error(self):
+    def test_130_prepare_certificate_response_error(self):
         """Test _prepare_certificate_response with error"""
         with patch.object(
             self.cert.message,
@@ -1614,7 +1614,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result["code"], 500)
 
-    def test_129_process_certificate_request_invalid_content(self):
+    def test_131_process_certificate_request_invalid_content(self):
         """Test process_certificate_request with invalid content"""
         with (
             patch.object(
@@ -1629,7 +1629,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.process_certificate_request("")
             self.assertEqual(result["code"], 400)
 
-    def test_130_process_certificate_request_message_validation_error(self):
+    def test_132_process_certificate_request_message_validation_error(self):
         """Test process_certificate_request with message validation error"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1645,7 +1645,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.process_certificate_request("content")
             self.assertIn("code", result)
 
-    def test_131_process_certificate_request_success_with_url(self):
+    def test_133_process_certificate_request_success_with_url(self):
         """Test process_certificate_request success with URL in protected header"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1666,7 +1666,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.process_certificate_request("content")
             mock_prepare.assert_called()
 
-    def test_132_process_certificate_request_success_with_url(self):
+    def test_134_process_certificate_request_success_with_url(self):
         """Test process_certificate_request success with URL in protected header"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1689,7 +1689,7 @@ class TestCertificate(unittest.TestCase):
                 {"code": 400, "data": "data", "detail": "error"}, 400, "data", "error"
             )
 
-    def test_133_process_certificate_request_missing_url(self):
+    def test_135_process_certificate_request_missing_url(self):
         """Test process_certificate_request with missing URL in protected header"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1705,7 +1705,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.process_certificate_request("content")
             mock_prepare.assert_called()
 
-    def test_134_process_certificate_request_get_details_error(self):
+    def test_136_process_certificate_request_get_details_error(self):
         """Test process_certificate_request with get_certificate_details error"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1732,7 +1732,7 @@ class TestCertificate(unittest.TestCase):
             )
             mock_prepare.assert_called()
 
-    def test_135_process_certificate_request_unexpected_error(self):
+    def test_137_process_certificate_request_unexpected_error(self):
         """Test process_certificate_request with unexpected error"""
         with (
             patch.object(
@@ -1752,7 +1752,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_136_validate_revocation_message_success(self):
+    def test_138_validate_revocation_message_success(self):
         """Test _validate_revocation_message success"""
         with patch.object(
             self.cert.message,
@@ -1762,7 +1762,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._validate_revocation_message("content")
             self.assertEqual(result[0], 200)
 
-    def test_137_validate_revocation_message_error(self):
+    def test_139_validate_revocation_message_error(self):
         """Test _validate_revocation_message with error"""
         with patch.object(
             self.cert.message, "check", side_effect=Exception("Message error")
@@ -1770,7 +1770,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._validate_revocation_message("content")
             self.assertEqual(result[0], 400)
 
-    def test_138_process_certificate_revocation_validation_error(self):
+    def test_140_process_certificate_revocation_validation_error(self):
         """Test _process_certificate_revocation with validation error"""
         with patch.object(
             self.cert, "_validate_revocation_request", return_value=(400, "error")
@@ -1778,7 +1778,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._process_certificate_revocation("account", {})
             self.assertEqual(result, (400, "error", None))
 
-    def test_139_process_certificate_revocation_success(self):
+    def test_141_process_certificate_revocation_success(self):
         """Test _process_certificate_revocation success"""
         payload = {"certificate": "cert"}
         with (
@@ -1796,7 +1796,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._process_certificate_revocation("account", payload)
             self.assertEqual(result, (200, "revoked", "detail"))
 
-    def test_140_process_certificate_revocation_with_logging(self):
+    def test_142_process_certificate_revocation_with_logging(self):
         """Test _process_certificate_revocation with operations logging"""
         payload = {"certificate": "cert"}
         self.cert.config.cert_operations_log = "json"
@@ -1818,7 +1818,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._process_certificate_revocation("account", payload)
             mock_log.assert_called_with("cert", 200)
 
-    def test_141_process_certificate_revocation_logging_error(self):
+    def test_143_process_certificate_revocation_logging_error(self):
         """Test _process_certificate_revocation with logging error"""
         payload = {"certificate": "cert"}
         self.cert.config.cert_operations_log = "json"
@@ -1844,7 +1844,7 @@ class TestCertificate(unittest.TestCase):
                 result, (200, "revoked", "detail")
             )  # Should still succeed despite log error
 
-    def test_142_process_certificate_revocation_exception(self):
+    def test_144_process_certificate_revocation_exception(self):
         """Test _process_certificate_revocation with exception"""
         with patch.object(
             self.cert,
@@ -1854,7 +1854,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert._process_certificate_revocation("account", {})
             self.assertEqual(result[0], 500)
 
-    def test_143_revoke_certificate_invalid_content(self):
+    def test_145_revoke_certificate_invalid_content(self):
         """Test revoke_certificate with invalid content"""
         with (
             patch.object(
@@ -1869,7 +1869,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.revoke_certificate("")
             self.assertIn("code", result)
 
-    def test_144_revoke_certificate_message_validation_error(self):
+    def test_146_revoke_certificate_message_validation_error(self):
         """Test revoke_certificate with message validation error"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1885,7 +1885,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.revoke_certificate("content")
             self.assertIn("code", result)
 
-    def test_145_revoke_certificate_success(self):
+    def test_147_revoke_certificate_success(self):
         """Test revoke_certificate success"""
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -1906,7 +1906,7 @@ class TestCertificate(unittest.TestCase):
             result = self.cert.revoke_certificate("content")
             mock_prepare.assert_called()
 
-    def test_146_revoke_certificate_unexpected_error(self):
+    def test_148_revoke_certificate_unexpected_error(self):
         """Test revoke_certificate with unexpected error"""
         with (
             patch.object(
@@ -1926,7 +1926,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_147_process_enrollment_and_store_certificate_success(self):
+    def test_149_process_enrollment_and_store_certificate_success(self):
         # Pre-enrollment hooks return empty (no error)
         with (
             patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
@@ -1952,7 +1952,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, ("result", None, None))
             mock_log.assert_called_with("cert_name", "raw", "order_name", False)
 
-    def test_148_process_enrollment_and_store_certificate_enrollment_error(self):
+    def test_150_process_enrollment_and_store_certificate_enrollment_error(self):
         # Enrollment returns no certificate, triggers error handling
         with (
             patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
@@ -1974,7 +1974,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, ("result", "error", "detail"))
             mock_handle.assert_called()
 
-    def test_149_process_enrollment_and_store_certificate_pre_hook_error(self):
+    def test_151_process_enrollment_and_store_certificate_pre_hook_error(self):
         # Pre-enrollment hook returns error, should return early
         with patch.object(
             self.cert, "_execute_pre_enrollment_hooks", return_value=["pre_hook_error"]
@@ -1984,7 +1984,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["pre_hook_error"])
 
-    def test_150_process_enrollment_and_store_certificate_post_hook_error(self):
+    def test_152_process_enrollment_and_store_certificate_post_hook_error(self):
         # Post-enrollment hook returns error, should return early
         with (
             patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
@@ -2010,7 +2010,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ["post_hook_error"])
 
-    def test_151_process_enrollment_and_store_certificate_store_error(self):
+    def test_153_process_enrollment_and_store_certificate_store_error(self):
         # _store_certificate_and_update_order returns error, should return error
         with (
             patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
@@ -2030,7 +2030,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, "error")
 
-    def test_152_process_enrollment_and_store_certificate_logger_exception(self):
+    def test_154_process_enrollment_and_store_certificate_logger_exception(self):
         # Exception in logger should not crash method
         with (
             patch.object(self.cert, "_execute_pre_enrollment_hooks", return_value=[]),
@@ -2056,7 +2056,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, ("result", None, None))
 
-    def test_153_get_certificate_info_success(self):
+    def test_155_get_certificate_info_success(self):
         # Covers: _get_certificate_info normal DB lookup (line 1106)
         cert = self.cert
         cert.repository.certificate_lookup.return_value = {"foo": "bar"}
@@ -2066,7 +2066,7 @@ class TestCertificate(unittest.TestCase):
             "name", "cert_name", ("name", "csr", "cert", "order__name")
         )
 
-    def test_154_get_certificate_info_db_error(self):
+    def test_156_get_certificate_info_db_error(self):
         # Covers: _get_certificate_info exception/critical branch (lines 1118-1119)
         self.cert.repository.certificate_lookup.side_effect = Exception("fail")
         with self.assertLogs(self.cert.logger, level="CRITICAL") as lcm:
@@ -2077,7 +2077,7 @@ class TestCertificate(unittest.TestCase):
             lcm.output,
         )
 
-    def test_155_process_certificate_request_code_200_no_url(self):
+    def test_157_process_certificate_request_code_200_no_url(self):
         # Covers: process_certificate_request else branch for missing url in protected
         with patch(
             "acme_srv.certificate.error_dic_get",
@@ -2098,7 +2098,7 @@ class TestCertificate(unittest.TestCase):
                 )
                 self.assertEqual(result, {"code": 400, "data": "error"})
 
-    def test_156_store_certificate_signing_request_unexpected_exception(self):
+    def test_158_store_certificate_signing_request_unexpected_exception(self):
         # Covers: store_certificate_signing_request exception branch (lines 1824-1826)
         with patch(
             "acme_srv.certificate.error_dic_get",
@@ -2125,7 +2125,7 @@ class TestCertificate(unittest.TestCase):
                     log.output,
                 )
 
-    def test_157_poll_certificate_status_unexpected_exception(self):
+    def test_159_poll_certificate_status_unexpected_exception(self):
         # Covers: poll_certificate_status except branch for unexpected exception
         with (
             patch.object(
@@ -2139,7 +2139,7 @@ class TestCertificate(unittest.TestCase):
                 "Unexpected error in poll_certificate_status: %s", unittest.mock.ANY
             )
 
-    def test_158_handle_successful_certificate_poll_order_update_exception(self):
+    def test_160_handle_successful_certificate_poll_order_update_exception(self):
         # Covers: _handle_successful_certificate_poll except branch for order_update
         with (
             patch.object(self.cert, "_store_certificate_in_database", return_value=123),
@@ -2157,7 +2157,7 @@ class TestCertificate(unittest.TestCase):
                 unittest.mock.ANY,
             )
 
-    def test_159_process_certificate_request_get_certificate_details_exception(self):
+    def test_161_process_certificate_request_get_certificate_details_exception(self):
         # Covers: process_certificate_request except block for get_certificate_details
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -2177,7 +2177,7 @@ class TestCertificate(unittest.TestCase):
             mock_prepare.assert_called()
             self.assertEqual(result["code"], 500)
 
-    def test_160_process_certificate_request_outer_exception(self):
+    def test_162_process_certificate_request_outer_exception(self):
         # Covers: process_certificate_request outer except block
         with (
             patch.object(
@@ -2195,7 +2195,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_161_process_certificate_request_url_missing(self):
+    def test_163_process_certificate_request_url_missing(self):
         # Covers: process_certificate_request else branch for missing url in protected
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -2212,7 +2212,7 @@ class TestCertificate(unittest.TestCase):
             mock_prepare.assert_called()
             self.assertEqual(result["code"], 400)
 
-    def test_162_process_certificate_revocation_logger_warning(self):
+    def test_164_process_certificate_revocation_logger_warning(self):
         # Covers: _process_certificate_revocation logger.warning branch
         payload = {"certificate": "cert"}
         self.cert.config.cert_operations_log = "json"
@@ -2240,7 +2240,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_163_revoke_certificate_payload_missing_certificate(self):
+    def test_165_revoke_certificate_payload_missing_certificate(self):
         # Covers: revoke_certificate branch where payload is missing 'certificate'
         with (
             patch.object(self.cert, "_validate_input_parameters", return_value={}),
@@ -2257,7 +2257,7 @@ class TestCertificate(unittest.TestCase):
             mock_prepare.assert_called()
             self.assertEqual(result["code"], 400)
 
-    def test_164_revoke_certificate_outer_exception(self):
+    def test_166_revoke_certificate_outer_exception(self):
         # Covers: revoke_certificate outer except block
         with (
             patch.object(
@@ -2275,7 +2275,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_165_store_certificate_signing_request_unexpected_exception(self):
+    def test_167_store_certificate_signing_request_unexpected_exception(self):
         # Covers: store_certificate_signing_request unexpected exception/critical
         # Patch logger.debug after the nested try/except to raise an exception
         self.cert.certificate_manager.validate_and_store_csr.side_effect = Exception(
@@ -2291,7 +2291,7 @@ class TestCertificate(unittest.TestCase):
         )
         self.assertIn("ERROR:test_a2c:Failed to store CSR for order order", lcm.output)
 
-    def test_166_poll_certificate_status_unexpected_exception(self):
+    def test_168_poll_certificate_status_unexpected_exception(self):
         # Covers: poll_certificate_status exception/critical branch (line 1825)
         self.cert._validate_input_parameters = MagicMock(side_effect=Exception("fail"))
         with self.assertLogs(self.cert.logger, level="CRITICAL") as lcm:
@@ -2306,7 +2306,7 @@ class TestCertificate(unittest.TestCase):
 
     @patch("acme_srv.certificate.cert_serial_get", return_value="serial")
     @patch("acme_srv.certificate.cert_aki_get", return_value="aki")
-    def test_167_store_certificate_in_database_exception(
+    def test_169_store_certificate_in_database_exception(
         self, mock_aki_get, mock_serial_get
     ):
         # Covers: _store_certificate_in_database exception/critical branch
@@ -2322,7 +2322,7 @@ class TestCertificate(unittest.TestCase):
                 lcm.output,
             )
 
-    def test_168_store_certificate_error_exception(self):
+    def test_170_store_certificate_error_exception(self):
         # Covers: _store_certificate_error exception/critical branch
         self.cert.repository.certificate_add.side_effect = Exception("fail")
 
@@ -2334,7 +2334,7 @@ class TestCertificate(unittest.TestCase):
             lcm.output,
         )
 
-    def test_169_check_tnauth_identifier_match_true(self):
+    def test_171_check_tnauth_identifier_match_true(self):
         # Covers: _check_tnauth_identifier_match type/value match (lines 1245-1246)
         cert = self.cert
         identifier = {"type": "tnauthlist", "value": "abc"}
@@ -2342,7 +2342,7 @@ class TestCertificate(unittest.TestCase):
         result = cert._check_tnauth_identifier_match(identifier, tnauthlist)
         self.assertTrue(result)
 
-    def test_170_check_tnauth_identifier_match_false(self):
+    def test_172_check_tnauth_identifier_match_false(self):
         # Covers: _check_tnauth_identifier_match no match (lines 1245-1246)
         cert = self.cert
         identifier = {"type": "tnauthlist", "value": "xyz"}
@@ -2350,7 +2350,7 @@ class TestCertificate(unittest.TestCase):
         result = cert._check_tnauth_identifier_match(identifier, tnauthlist)
         self.assertFalse(result)
 
-    def test_171_check_identifier_match_true(self):
+    def test_173_check_identifier_match_true(self):
         # Covers: _check_identifier_match for-loop/if-branch (line 1221)
         cert = self.cert
         identifiers = [
@@ -2360,7 +2360,7 @@ class TestCertificate(unittest.TestCase):
         result = cert._check_identifier_match("dns", "foo", identifiers, False)
         self.assertTrue(result)
 
-    def test_172_check_identifier_match_false(self):
+    def test_174_check_identifier_match_false(self):
         # Covers: _check_identifier_match return (line 1223) when no match
         cert = self.cert
         identifiers = [
@@ -2370,7 +2370,7 @@ class TestCertificate(unittest.TestCase):
         result = cert._check_identifier_match("dns", "foo", identifiers, False)
         self.assertFalse(result)
 
-    def test_173_validate_revocation_request_unauthorized_forced(self):
+    def test_175_validate_revocation_request_unauthorized_forced(self):
         # Force coverage for line 1171 by using a custom err_msg_dic with a side effect
         self.cert.err_msg_dic = {
             "badrevocationreason": "badreason",
@@ -2398,7 +2398,7 @@ class TestCertificate(unittest.TestCase):
                 log.output,
             )
 
-    def test_174_validate_revocation_request_unauthorized_minimal(self):
+    def test_176_validate_revocation_request_unauthorized_minimal(self):
         # Isolated test to guarantee coverage for line 1171 (unauthorized branch)
         self.cert.err_msg_dic = {
             "badrevocationreason": "badreason",
@@ -2421,7 +2421,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(code, 403)
             self.assertEqual(error, "unauth")
 
-    def test_175_validate_revocation_request_bad_reason(self):
+    def test_177_validate_revocation_request_bad_reason(self):
         # Covers line 1159: error = self.err_msg_dic["badrevocationreason"]
         payload = {"reason": 99, "certificate": "cert"}  # 99 is not a valid reason
         self.cert.err_msg_dic = {
@@ -2433,7 +2433,7 @@ class TestCertificate(unittest.TestCase):
         self.assertEqual(code, 400)
         self.assertEqual(error, "badreason")
 
-    def test_176_validate_revocation_request_no_reason(self):
+    def test_178_validate_revocation_request_no_reason(self):
         # Covers line 1162: rev_reason = "unspecified"
         payload = {"certificate": "cert"}
         self.cert.err_msg_dic = {
@@ -2448,7 +2448,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(code, 403)
             self.assertEqual(error, "unauth")
 
-    def test_177_validate_revocation_request_unauthorized(self):
+    def test_179_validate_revocation_request_unauthorized(self):
         # Explicitly cover line 1171: error = self.err_msg_dic["unauthorized"]
         payload = {"reason": 0, "certificate": "cert"}
         self.cert.err_msg_dic = {
@@ -2474,7 +2474,7 @@ class TestCertificate(unittest.TestCase):
             mock_own.assert_called_once_with("acc", "cert")
             mock_auth.assert_called_once_with("order", "cert")
 
-    def test_178_validate_revocation_request_success(self):
+    def test_180_validate_revocation_request_success(self):
         # Covers line 1183: code = 200
         payload = {"reason": 0, "certificate": "cert"}
         self.cert.err_msg_dic = {
@@ -2494,7 +2494,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(code, 200)
             self.assertEqual(error, "unspecified")
 
-    def test_179_validate_revocation_request_nocert(self):
+    def test_181_validate_revocation_request_nocert(self):
         # Explicitly cover line 1171: error = self.err_msg_dic["unauthorized"] and check logger
         payload = {"reason": 0, "foo": "bar"}
         self.cert.err_msg_dic = {
@@ -2523,7 +2523,7 @@ class TestCertificate(unittest.TestCase):
                 "Certificate._validate_revocation_request(): Revocation request missing 'certificate' field"
             )
 
-    def test_180_validate_csr_against_order_order_lookup_exception(self):
+    def test_182_validate_csr_against_order_order_lookup_exception(self):
         # Covers exception branch at line 720 in _validate_csr_against_order
         cert_dic = {"order": "order1"}
         with (
@@ -2542,7 +2542,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertFalse(result)
 
-    def test_181_store_certificate_and_update_order_success_hook(self):
+    def test_183_store_certificate_and_update_order_success_hook(self):
         # Covers success_hook execution and debug log
         self.cert.hooks = MagicMock()
         self.cert.hooks.success_hook.return_value = None
@@ -2563,7 +2563,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, 1)
             self.assertIsNone(error)
 
-    def test_182_store_certificate_and_update_order_success_hook_exception(self):
+    def test_184_store_certificate_and_update_order_success_hook_exception(self):
         # Covers exception in success_hook and error logging
         self.cert.hooks = MagicMock()
         self.cert.hooks.success_hook.side_effect = Exception("success_hook failed")
@@ -2581,7 +2581,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(error, (None, "success_hook_error", "success_hook failed"))
 
-    def test_183_store_certificate_and_update_order_success_hook_exception_ignore(self):
+    def test_185_store_certificate_and_update_order_success_hook_exception_ignore(self):
         # Covers exception in success_hook with ignore_success_hook_failure True (no error returned)
         self.cert.hooks = MagicMock()
         self.cert.hooks.success_hook.side_effect = Exception("success_hook failed")
@@ -2600,7 +2600,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, 1)
             self.assertIsNone(error)
 
-    def test_184_execute_pre_enrollment_hooks_exception(self):
+    def test_186_execute_pre_enrollment_hooks_exception(self):
         # Covers exception branch when pre_hook raises and ignore_pre_hook_failure is False
         mock_hooks = MagicMock()
         mock_hooks.pre_hook.side_effect = Exception("pre_hook failed")
@@ -2615,8 +2615,10 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertEqual(result, (None, "pre_hook_error", "pre_hook failed"))
 
-    def test_185_handle_enrollment_error_no_poll_identifier(self):
+    def test_187_handle_enrollment_error_no_poll_identifier(self):
         # Covers branch where poll_identifier is None and error is not special string
+        from acme_srv.helpers.global_variables import ENROLLMENT_FAILED_DETAIL
+
         self.cert.err_msg_dic = {
             "serverinternal": "serverinternal",
             "rejectedidentifier": "rejectedidentifier",
@@ -2630,9 +2632,11 @@ class TestCertificate(unittest.TestCase):
             )
             mock_update.assert_called_with({"name": "order1", "status": "invalid"})
             mock_store.assert_called_with("cert1", "some_error", None)
-            self.assertEqual(result, (None, "serverinternal", None))
+            self.assertEqual(
+                result, (None, "serverinternal", ENROLLMENT_FAILED_DETAIL)
+            )
 
-    def test_186_handle_enrollment_error_with_poll_identifier(self):
+    def test_188_handle_enrollment_error_with_poll_identifier(self):
         # Covers branch where poll_identifier is set
         with (
             patch.object(self.cert, "_update_order_status") as mock_update,
@@ -2646,7 +2650,7 @@ class TestCertificate(unittest.TestCase):
             mock_store.assert_called_with("cert1", "some_error", "pollid")
             self.assertEqual(result, (None, "some_error", "pollid"))
 
-    def test_187_handle_enrollment_error_rejected_identifier(self):
+    def test_189_handle_enrollment_error_rejected_identifier(self):
         # Covers branch where error is 'Either CN or SANs are not allowed by configuration'
         self.cert.err_msg_dic = {
             "serverinternal": "serverinternal",
@@ -2675,8 +2679,10 @@ class TestCertificate(unittest.TestCase):
                 ),
             )
 
-    def test_188_handle_enrollment_error_exception(self):
+    def test_190_handle_enrollment_error_exception(self):
         # Covers exception branch
+        from acme_srv.helpers.global_variables import ENROLLMENT_FAILED_DETAIL
+
         self.cert.err_msg_dic = {
             "serverinternal": "serverinternal",
             "rejectedidentifier": "rejectedidentifier",
@@ -2694,9 +2700,45 @@ class TestCertificate(unittest.TestCase):
                 "some_error", None, "order1", "cert1"
             )
             mock_critical.assert_called()
-            self.assertEqual(result, (None, "serverinternal", None))
+            self.assertEqual(
+                result,
+                (None, "serverinternal", ENROLLMENT_FAILED_DETAIL),
+            )
 
-    def test_189_validate_certificate_authorization_sans_exception(self):
+    def test_191_handle_enrollment_error_forwards_ca_detail(self):
+        from acme_srv.helpers.global_variables import ENROLLMENT_FAILED_DETAIL
+
+        self.cert.config.ca_error_details_forward = True
+        self.cert.err_msg_dic = {
+            "serverinternal": "serverinternal",
+            "rejectedidentifier": "rejectedidentifier",
+        }
+        with (
+            patch.object(self.cert, "_update_order_status") as mock_update,
+            patch.object(self.cert, "_store_certificate_error") as mock_store,
+        ):
+            result = self.cert._handle_enrollment_error(
+                "upstream CAA policy rejected", None, "order1", "cert1"
+            )
+            mock_update.assert_called_with({"name": "order1", "status": "invalid"})
+            mock_store.assert_called_with(
+                "cert1", "upstream CAA policy rejected", None
+            )
+            self.assertEqual(
+                result,
+                (None, "serverinternal", "upstream CAA policy rejected"),
+            )
+
+    def test_192_resolve_client_enrollment_error_empty_ca_error(self):
+        from acme_srv.helpers.global_variables import ENROLLMENT_FAILED_DETAIL
+
+        self.cert.config.ca_error_details_forward = True
+        self.cert.err_msg_dic = {"serverinternal": "serverinternal"}
+        error, detail = self.cert._resolve_client_enrollment_error("", None)
+        self.assertEqual(error, "serverinternal")
+        self.assertEqual(detail, ENROLLMENT_FAILED_DETAIL)
+
+    def test_193_validate_certificate_authorization_sans_exception(self):
         # Explicitly covers lines 477-481: exception in cert_san_get triggers warning and returns []
         self.cert.config.tnauthlist_support = False
         with (
@@ -2716,14 +2758,14 @@ class TestCertificate(unittest.TestCase):
                 "Certificate._validate_certificate_authorization() ended"
             )
 
-    def test_190_enter_calls_load_configuration_and_returns_self(self):
+    def test_194_enter_calls_load_configuration_and_returns_self(self):
         cert = self.cert
         with patch.object(cert, "_load_configuration") as mock_load_config:
             result = cert.__enter__()
             mock_load_config.assert_called_once()
             self.assertIs(result, cert)
 
-    def test_191_validate_certificate_authorization_cn2san_add(self):
+    def test_195_validate_certificate_authorization_cn2san_add(self):
         # Covers the branch where tnauthlist_support is False and cn2san_add is True
         self.cert.config.tnauthlist_support = False
         self.cert.config.cn2san_add = True
@@ -2745,7 +2787,7 @@ class TestCertificate(unittest.TestCase):
             mock_validate.assert_called_with([], ["DNS:mycn"])
             self.assertEqual(result, ["ok"])
 
-    def test_192_validate_certificate_authorization_sans_exception(self):
+    def test_196_validate_certificate_authorization_sans_exception(self):
         # Covers lines 477-481: exception in cert_san_get triggers warning and returns []
         self.cert.config.tnauthlist_support = False
         with (
@@ -2765,7 +2807,7 @@ class TestCertificate(unittest.TestCase):
                 "Certificate._validate_certificate_authorization() ended"
             )
 
-    def test_193_handle_enrollment_thread_execution_async_mode(self):
+    def test_197_handle_enrollment_thread_execution_async_mode(self):
         """Test _handle_enrollment_thread_execution with async_mode True (lines 1305-1306)."""
         self.cert.config.async_mode = True
         self.cert.config.enrollment_timeout = 5
@@ -2779,7 +2821,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(result, (None, "asynchronous enrollment started"))
             mock_thread_instance.join.assert_not_called()
 
-    def test_194_check_certificate_reusability_reused_values(self):
+    def test_198_check_certificate_reusability_reused_values(self):
         """Test _check_certificate_reusability returns correct cert, cert_raw, and message when reused."""
         cert_data = {
             "expire_uts": 9999999999,
@@ -2797,7 +2839,7 @@ class TestCertificate(unittest.TestCase):
             self.assertEqual(cert_raw, "raw_value")
             self.assertIn("reused certificate from id: 42", message)
 
-    def test_195_process_enrollment_and_store_certificate_log_exception(self):
+    def test_199_process_enrollment_and_store_certificate_log_exception(self):
         """Test _process_enrollment_and_store_certificate covers log_certificate_issuance exception branch (lines 930-933)."""
         self.cert._execute_pre_enrollment_hooks = MagicMock(return_value=[])
         self.cert._process_certificate_enrollment = MagicMock(
@@ -2822,7 +2864,7 @@ class TestCertificate(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_196_load_configuration_defaults(self):
+    def test_200_load_configuration_defaults(self):
         """Test _load_configuration uses defaults when config is empty."""
         config = configparser.ConfigParser()
         with patch("acme_srv.certificate.load_config", return_value=config):
@@ -2839,7 +2881,7 @@ class TestCertificate(unittest.TestCase):
                 self.assertFalse(self.cert.config.ignore_success_hook_failure)
             self.assertIn("CRITICAL:test_a2c:No ca_handler loaded", lcm.output)
 
-    def test_197_load_configuration_full_config(self):
+    def test_201_load_configuration_full_config(self):
         """Test _load_configuration with all config sections and values overridden."""
         config = configparser.ConfigParser()
         config.add_section("Certificate")
@@ -2869,7 +2911,7 @@ class TestCertificate(unittest.TestCase):
             self.assertFalse(self.cert.config.ignore_post_hook_failure)
             self.assertTrue(self.cert.config.ignore_success_hook_failure)
 
-    def test_198_configuration_partial_config(self):
+    def test_202_configuration_partial_config(self):
         """Test _load_configuration with some config sections missing."""
         config = configparser.ConfigParser()
         config.add_section("Certificate")
@@ -2885,7 +2927,7 @@ class TestCertificate(unittest.TestCase):
                 self.assertFalse(self.cert.config.cn2san_add)
             self.assertIn("CRITICAL:test_a2c:No ca_handler loaded", lcm.output)
 
-    def test_199_configuration_directory_url_prefix(self):
+    def test_203_configuration_directory_url_prefix(self):
         """Test _load_configuration applies url_prefix to path_dic."""
         config = configparser.ConfigParser()
         config.add_section("Directory")
@@ -2897,7 +2939,7 @@ class TestCertificate(unittest.TestCase):
                 self.assertEqual(self.cert.path_dic["cert_path"], "/api/acme/cert/")
             self.assertIn("CRITICAL:test_a2c:No ca_handler loaded", lcm.output)
 
-    def test_200_load_configuration_type_conversion_and_fallback(self):
+    def test_204_load_configuration_type_conversion_and_fallback(self):
         """Test _load_configuration handles type conversion and fallback logic."""
         config = configparser.ConfigParser()
         config.add_section("Certificate")
@@ -2924,7 +2966,7 @@ class TestCertificate(unittest.TestCase):
             )
             self.assertIn("CRITICAL:test_a2c:No ca_handler loaded", lcm.output)
 
-    def test_201_load_configuration_logging(self):
+    def test_205_load_configuration_logging(self):
         """Test _load_configuration logs debug message."""
         config = configparser.ConfigParser()
         with patch("acme_srv.certificate.load_config", return_value=config):
@@ -2934,7 +2976,7 @@ class TestCertificate(unittest.TestCase):
                 "DEBUG:test_a2c:Certificate._load_configuration()", lcm.output
             )
 
-    def test_202_cert_operations_log_config_applied_to_logger(self):
+    def test_206_cert_operations_log_config_applied_to_logger(self):
         """Test that cert_operations_log configuration is applied to CertificateLogger."""
         config = configparser.ConfigParser()
         config.add_section("Certificate")
@@ -2952,7 +2994,7 @@ class TestCertificate(unittest.TestCase):
                 "DEBUG:test_a2c:Certificate._load_configuration()", log.output
             )
 
-    def test_203_cert_operations_log_with_context_manager(self):
+    def test_207_cert_operations_log_with_context_manager(self):
         """Test that cert_operations_log is properly applied when using context manager."""
         config = configparser.ConfigParser()
         config.add_section("Certificate")
@@ -2970,7 +3012,7 @@ class TestCertificate(unittest.TestCase):
             )
 
     # Move the new tests after setUp to fix indentation
-    def test_204_validate_csr_against_order_profile_logging_and_dryrun(self):
+    def test_208_validate_csr_against_order_profile_logging_and_dryrun(self):
         # Setup: profile present, matches dryrun_profilename
         self.cert.config.dryrun_profilename = "dryrun-profile"
         self.cert.config.dryrun = False
@@ -3000,7 +3042,7 @@ class TestCertificate(unittest.TestCase):
         # Check that dryrun was set
         self.assertTrue(self.cert.config.dryrun)
 
-    def test_205_validate_csr_against_order_profile_logging_no_dryrun(self):
+    def test_209_validate_csr_against_order_profile_logging_no_dryrun(self):
         # Setup: profile present, does NOT match dryrun_profilename
         self.cert.config.dryrun_profilename = "dryrun-profile"
         self.cert.config.dryrun = False
@@ -3030,7 +3072,7 @@ class TestCertificate(unittest.TestCase):
         self.assertFalse(any(dryrun_msgs))
         self.assertFalse(self.cert.config.dryrun)
 
-    def test_206_process_certificate_enrollment_request_dryrun(self):
+    def test_210_process_certificate_enrollment_request_dryrun(self):
         # Setup: dryrun enabled
         self.cert.config.dryrun = True
         self.cert.err_msg_dic["unauthorized"] = "unauthorized"

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -2632,9 +2632,7 @@ class TestCertificate(unittest.TestCase):
             )
             mock_update.assert_called_with({"name": "order1", "status": "invalid"})
             mock_store.assert_called_with("cert1", "some_error", None)
-            self.assertEqual(
-                result, (None, "serverinternal", ENROLLMENT_FAILED_DETAIL)
-            )
+            self.assertEqual(result, (None, "serverinternal", ENROLLMENT_FAILED_DETAIL))
 
     def test_188_handle_enrollment_error_with_poll_identifier(self):
         # Covers branch where poll_identifier is set
@@ -2721,9 +2719,7 @@ class TestCertificate(unittest.TestCase):
                 "upstream CAA policy rejected", None, "order1", "cert1"
             )
             mock_update.assert_called_with({"name": "order1", "status": "invalid"})
-            mock_store.assert_called_with(
-                "cert1", "upstream CAA policy rejected", None
-            )
+            mock_store.assert_called_with("cert1", "upstream CAA policy rejected", None)
             self.assertEqual(
                 result,
                 (None, "serverinternal", "upstream CAA policy rejected"),

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -1677,12 +1677,27 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_109_finalize_csr_enrollment_failed_else_branch(self):
-        # Else branch: message set to certificate_name and detail='enrollment failed'
+    def test_109_finalize_csr_else_branch_preserves_ca_detail(self):
+        # Else branch: the CA handler's real failure detail is preserved and
+        # reaches the client instead of being replaced by a generic string.
 
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
         self.order._process_csr = MagicMock(return_value=(400, "error", "d"))
+        with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+            result = self.order._finalize_csr("order1", {"csr": "csrval"})
+            self.assertEqual(result, (400, "error", "d", "error"))
+            self.order.repository.order_update.assert_not_called()
+        self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
+        self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
+
+    def test_109a_finalize_csr_else_branch_generic_fallback(self):
+        # Else branch: fall back to the generic detail only when the handler
+        # provided none.
+
+        self.order.repository.order_update = MagicMock()
+        self.order._header_info_lookup = MagicMock(return_value={})
+        self.order._process_csr = MagicMock(return_value=(400, "error", None))
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             result = self.order._finalize_csr("order1", {"csr": "csrval"})
             self.assertEqual(result, (400, "error", "enrollment failed", "error"))

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -1678,23 +1678,34 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
     def test_109_finalize_csr_else_branch_preserves_ca_detail(self):
-        # Else branch: the CA handler's real failure detail is preserved and
-        # reaches the client instead of being replaced by a generic string.
-
+        #  CA handler's real failure detail gets forwarded as config.ca_error_details_forward is True
+        self.order.config.ca_error_details_forward = True
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
-        self.order._process_csr = MagicMock(return_value=(400, "error", "d"))
+        self.order._process_csr = MagicMock(return_value=(400, "error", "ca_detail"))
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             result = self.order._finalize_csr("order1", {"csr": "csrval"})
-            self.assertEqual(result, (400, "error", "d", "error"))
+            self.assertEqual(result, (400, "error", "ca_detail", "error"))
             self.order.repository.order_update.assert_not_called()
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_109a_finalize_csr_else_branch_generic_fallback(self):
-        # Else branch: fall back to the generic detail only when the handler
-        # provided none.
+    def test_109a_finalize_csr_else_branch_overwrite_ca_error(self):
+        # CA handler's real failure detail gets overwritten with generic fallback
+        self.order.repository.order_update = MagicMock()
+        self.order._header_info_lookup = MagicMock(return_value={})
+        self.order._process_csr = MagicMock(return_value=(400, "error", "ca_detail"))
+        with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+            result = self.order._finalize_csr("order1", {"csr": "csrval"})
+            self.assertEqual(result, (400, "error", "enrollment failed", "error"))
+            self.order.repository.order_update.assert_not_called()
+        self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
+        self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
+    def test_109b_finalize_csr_else_branch_generic_fallback(self):
+        # back to the generic detail only when the handler
+        # provided none.
+        self.order.config.ca_error_details_forward = True
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
         self.order._process_csr = MagicMock(return_value=(400, "error", None))

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -1702,7 +1702,12 @@ class TestOrderClass(unittest.TestCase):
             result = self.order._finalize_csr("order1", {"csr": "csrval"})
             self.assertEqual(
                 result,
-                (500, "urn:ietf:params:acme:error:serverInternal", "ca_detail", "urn:ietf:params:acme:error:serverInternal"),
+                (
+                    500,
+                    "urn:ietf:params:acme:error:serverInternal",
+                    "ca_detail",
+                    "urn:ietf:params:acme:error:serverInternal",
+                ),
             )
             self.order.repository.order_update.assert_not_called()
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -105,7 +105,21 @@ class TestOrderRepository(unittest.TestCase):
             self.order_repository.order_lookup("name", "order1"), {"name": "order1"}
         )
 
-    def test_008_order_lookup_failure(self):
+    def test_008_order_lookup_with_vlist(self):
+        self.order_repository.dbstore.order_lookup.return_value = {
+            "account__name": "acc1"
+        }
+        self.assertEqual(
+            self.order_repository.order_lookup(
+                "name", "order1", vlist=["account__name"]
+            ),
+            {"account__name": "acc1"},
+        )
+        self.order_repository.dbstore.order_lookup.assert_called_with(
+            "name", "order1", ["account__name"]
+        )
+
+    def test_009_order_lookup_failure(self):
         self.order_repository.dbstore.order_lookup.side_effect = Exception("fail")
         with self.assertRaises(Exception) as context:
             with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -119,11 +133,11 @@ class TestOrderRepository(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_009_order_update_success(self):
+    def test_010_order_update_success(self):
         self.order_repository.dbstore.order_update.return_value = "ok"
         self.assertEqual(self.order_repository.order_update({"foo": "bar"}), "ok")
 
-    def test_010_order_update_failure(self):
+    def test_011_order_update_failure(self):
         self.order_repository.dbstore.order_update.side_effect = Exception("fail")
         with self.assertRaises(Exception) as context:
             with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -137,7 +151,7 @@ class TestOrderRepository(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_011_authorization_lookup_success(self):
+    def test_012_authorization_lookup_success(self):
         self.order_repository.dbstore.authorization_lookup.return_value = [
             {"name": "auth1"}
         ]
@@ -146,7 +160,7 @@ class TestOrderRepository(unittest.TestCase):
             [{"name": "auth1"}],
         )
 
-    def test_012_authorization_lookup_failure(self):
+    def test_013_authorization_lookup_failure(self):
         self.order_repository.dbstore.authorization_lookup.side_effect = Exception(
             "fail"
         )
@@ -162,7 +176,7 @@ class TestOrderRepository(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_013_certificate_lookup_success(self):
+    def test_014_certificate_lookup_success(self):
         self.order_repository.dbstore.certificate_lookup.return_value = {
             "name": "cert1"
         }
@@ -170,7 +184,7 @@ class TestOrderRepository(unittest.TestCase):
             self.order_repository.certificate_lookup("key", "val"), {"name": "cert1"}
         )
 
-    def test_014_certificate_lookup_failure(self):
+    def test_015_certificate_lookup_failure(self):
         self.order_repository.dbstore.certificate_lookup.side_effect = Exception("fail")
         with self.assertRaises(Exception) as context:
             with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -184,11 +198,11 @@ class TestOrderRepository(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_015_hkparameter_get_success(self):
+    def test_016_hkparameter_get_success(self):
         self.order_repository.dbstore.hkparameter_get.return_value = "profiles"
         self.assertEqual(self.order_repository.hkparameter_get("profiles"), "profiles")
 
-    def test_016_hkparameter_get_failure(self):
+    def test_017_hkparameter_get_failure(self):
         self.order_repository.dbstore.hkparameter_get.side_effect = Exception("fail")
         with self.assertRaises(Exception) as context:
             with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -202,14 +216,14 @@ class TestOrderRepository(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_017_orders_invalid_search_success(self):
+    def test_018_orders_invalid_search_success(self):
         self.order_repository.dbstore.orders_invalid_search.return_value = ["order1"]
         self.assertEqual(
             self.order_repository.orders_invalid_search("expires", 0, [], "<="),
             ["order1"],
         )
 
-    def test_018_orders_invalid_search_failure(self):
+    def test_019_orders_invalid_search_failure(self):
         self.order_repository.dbstore.orders_invalid_search.side_effect = Exception(
             "fail"
         )
@@ -225,13 +239,13 @@ class TestOrderRepository(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_019_account_lookup_success(self):
+    def test_020_account_lookup_success(self):
         self.order_repository.dbstore.account_lookup.return_value = {"name": "acct1"}
         self.assertEqual(
             self.order_repository.account_lookup("name", "acct1"), {"name": "acct1"}
         )
 
-    def test_020_account_lookup_failure(self):
+    def test_021_account_lookup_failure(self):
         self.order_repository.dbstore.account_lookup.side_effect = Exception("fail")
         with self.assertRaises(Exception) as context:
             with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -247,7 +261,7 @@ class TestOrderRepository(unittest.TestCase):
 
 
 class TestOrderClass(unittest.TestCase):
-    def test_021_process_csr_dryrun_skipped(self):
+    def test_022_process_csr_dryrun_skipped(self):
         # Covers: enroll_and_store returns dryrun skipped, triggers code=401, message=error, detail preserved
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             self.order._get_order_info = MagicMock(return_value={"name": "order1"})
@@ -291,15 +305,15 @@ class TestOrderClass(unittest.TestCase):
         self.order = Order(debug=True, server_name="test", logger=self.logger)
         self.order.repository = MagicMock()
 
-    def test_022__enter_(self):
+    def test_023__enter_(self):
         """test enter"""
         self.order.__enter__()
 
-    def test_023__enter_(self):
+    def test_024__enter_(self):
         """test enter"""
         self.order.__exit__()
 
-    def test_024_are_identifiers_allowed_logging(self):
+    def test_025_are_identifiers_allowed_logging(self):
 
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             self.order.are_identifiers_allowed([{"type": "foo", "value": "bar"}])
@@ -309,13 +323,13 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_025_is_profile_valid_profile_check_disabled(self):
+    def test_026_is_profile_valid_profile_check_disabled(self):
         self.order.config.profiles_check_disable = False
         self.order.config.profiles = {"foo": {}}
         result = self.order.is_profile_valid("foo")
         self.assertIsNone(result)
 
-    def test_026_is_profile_valid_invalid(self):
+    def test_027_is_profile_valid_invalid(self):
         self.order.config.profiles_check_disable = False
         self.order.config.profiles = {"bar": True, "baz": True}
         with self.assertLogs("test_a2c", level="WARNING") as log_cm:
@@ -328,7 +342,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_027_is_profile_valid_invalid_override(self):
+    def test_028_is_profile_valid_invalid_override(self):
         self.order.config.profiles_check_disable = False
         self.order.config.profiles = {"bar": True}
         with self.assertLogs("test_a2c", level="INFO") as log_cm:
@@ -342,7 +356,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_028_is_profile_valid_valid_profile(self):
+    def test_029_is_profile_valid_valid_profile(self):
 
         self.order.config.profiles_check_disable = True
         self.order.config.profiles = {"foo": {}}
@@ -362,7 +376,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_029_add_profile_to_order_valid(self):
+    def test_030_add_profile_to_order_valid(self):
         self.order.config.profiles = {"foo": {}}
         self.order.config.profiles_check_disable = False
         data_dic = {}
@@ -371,7 +385,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(updated_dic["profile"], "foo")
 
-    def test_030_add_profile_to_order_invalid(self):
+    def test_031_add_profile_to_order_invalid(self):
         self.order.config.profiles = {}
         self.order.config.profiles_check_disable = False
         data_dic = {}
@@ -380,7 +394,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(error, "urn:ietf:params:acme:error:invalidProfile")
         self.assertNotIn("profile", updated_dic)
 
-    def test_031_add_profile_to_order_no_profiles_configured(self):
+    def test_032_add_profile_to_order_no_profiles_configured(self):
         self.order.config.profiles = {}
         self.order.config.profiles_check_disable = False
         data_dic = {}
@@ -396,7 +410,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_032_add_profile_to_order_single_profile_overwrite(self):
+    def test_033_add_profile_to_order_single_profile_overwrite(self):
         self.order.config.profiles = {"bar": True}
         self.order.config.profiles_check_disable = False
         self.order.config.dryrun_profilename = None
@@ -414,7 +428,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_033_process_order_request_db_error_logging(self):
+    def test_034_process_order_request_db_error_logging(self):
         self.order.repository.certificate_lookup.side_effect = Exception("DB error")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
             result = self.order._process_order_request(
@@ -425,7 +439,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_034_edge_case_empty_identifiers(self):
+    def test_035_edge_case_empty_identifiers(self):
         # _check_identifiers_validity with empty list
         result = self.order._check_identifiers_validity(
             []
@@ -435,7 +449,7 @@ class TestOrderClass(unittest.TestCase):
             (self.order.error_msg_dic["malformed"], "malformed identifiers list"),
         )
 
-    def test_035_edge_case_too_many_identifiers(self):
+    def test_036_edge_case_too_many_identifiers(self):
         # _check_identifiers_validity with too many identifiers
         self.order.config.identifier_limit = 1  # Set identifier limit to 1 for testing
         result = self.order._check_identifiers_validity(
@@ -449,7 +463,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_036_edge_case_invalid_identifier_type(self):
+    def test_037_edge_case_invalid_identifier_type(self):
         # are_identifiers_allowed with unsupported type
         self.order.config.tnauthlist_support = False
         self.order.config.email_identifier_support = False
@@ -462,7 +476,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_037_edge_case_missing_type(self):
+    def test_038_edge_case_missing_type(self):
         # are_identifiers_allowed with missing type
         result = self.order.are_identifiers_allowed([{"value": "bar"}])
         self.assertEqual(
@@ -470,13 +484,13 @@ class TestOrderClass(unittest.TestCase):
             (self.order.error_msg_dic["malformed"], "Identifier type is missing"),
         )
 
-    def test_038_edge_case_invalid_profile_config(self):
+    def test_039_edge_case_invalid_profile_config(self):
         # _set_profiles_from_db with invalid JSON
         with patch.object(self.order.logger, "error") as mock_log:
             self.order._set_profiles_from_db("notjson")
             mock_log.assert_called()
 
-    def test_039_order_dic_create_all_fields(self):
+    def test_040_order_dic_create_all_fields(self):
         # test _order_dic_create with all fields
         tmp_dic = {
             "status": "pending",
@@ -492,7 +506,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(result["notAfter"], "2009-02-13T23:31:32Z")
         self.assertIsInstance(result["identifiers"], list)
 
-    def test_040_order_dic_create_invalid_identifiers(self):
+    def test_041_order_dic_create_invalid_identifiers(self):
         # test _order_dic_create with invalid JSON in identifiers
         tmp_dic = {"identifiers": "notjson"}
         with patch.object(self.order.logger, "error") as mock_log:
@@ -501,7 +515,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertIn("identifiers", tmp_dic)
             mock_log.assert_called()
 
-    def test_041_get_authorization_list_db_error(self):
+    def test_042_get_authorization_list_db_error(self):
         # test _get_authorization_list with DB error
         self.order.repository.authorization_lookup.side_effect = Exception("DB error")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -511,7 +525,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_042_update_validity_list_ready(self):
+    def test_043_update_validity_list_ready(self):
         # test _update_validity_list sets order to ready
         authz_list = [{"name": "auth1", "status__name": "valid"}]
         order_dic = {"status": "pending", "authorizations": []}
@@ -519,7 +533,7 @@ class TestOrderClass(unittest.TestCase):
             self.order._update_validity_list(authz_list, order_dic, "_")
             mock_update.assert_called_with({"name": "_", "status": "ready"})
 
-    def test_043_update_validity_list_not_ready(self):
+    def test_044_update_validity_list_not_ready(self):
         # test _update_validity_list does not set order to ready
         authz_list = [{"name": "auth1", "status__name": "pending"}]
         order_dic = {"status": "pending", "authorizations": []}
@@ -527,7 +541,7 @@ class TestOrderClass(unittest.TestCase):
             self.order._update_validity_list(authz_list, order_dic, "_")
             mock_update.assert_not_called()
 
-    def test_044_get_order_details_with_authz(self):
+    def test_045_get_order_details_with_authz(self):
         # test get_order_details with authorizations
         self.order.repository.order_lookup.return_value = {
             "status": "pending",
@@ -541,7 +555,7 @@ class TestOrderClass(unittest.TestCase):
             mock_update.assert_called()
             self.assertIn("status", result)
 
-    def test_045_invalidate_expired_orders(self):
+    def test_046_invalidate_expired_orders(self):
         # test invalidate_expired_orders with valid and invalid orders
         self.order.repository.orders_invalid_search.return_value = [
             {"name": "order1", "status__name": "pending"},
@@ -553,7 +567,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertNotIn("order2", [o["name"] for o in output])
             mock_update.assert_called_once_with({"name": "order1", "status": "invalid"})
 
-    def test_046_create_from_content_success(self):
+    def test_047_create_from_content_success(self):
         # test create_from_content with successful order creation
         with patch.object(
             self.order.message,
@@ -587,7 +601,7 @@ class TestOrderClass(unittest.TestCase):
                     self.assertIn("header", result)
                     self.assertIn("data", result)
 
-    def test_047_create_from_content_rejected(self):
+    def test_048_create_from_content_rejected(self):
         # test create_from_content with rejected identifier
         with patch.object(
             self.order.message,
@@ -622,7 +636,7 @@ class TestOrderClass(unittest.TestCase):
                         "data" not in result or result.get("data", {}) == {}
                     )
 
-    def test_048_create_from_content_error(self):
+    def test_049_create_from_content_error(self):
         # test create_from_content with generic error
         with patch.object(
             self.order.message,
@@ -657,7 +671,7 @@ class TestOrderClass(unittest.TestCase):
                         "data" not in result or result.get("data", {}) == {}
                     )
 
-    def test_049_create_from_content_check_fail(self):
+    def test_050_create_from_content_check_fail(self):
         # test create_from_content with check returning error
         with patch.object(
             self.order.message,
@@ -672,7 +686,7 @@ class TestOrderClass(unittest.TestCase):
                 result = self.order.create_from_content("content")
                 self.assertIsInstance(result, dict)
 
-    def test_050_parse_order_message_all_paths(self):
+    def test_051_parse_order_message_all_paths(self):
         # test _parse_order_message for all code paths
         # url in protected, order_name, order_dic, process_order_request
         with patch.object(self.order, "_name_get", return_value="order"):
@@ -715,7 +729,7 @@ class TestOrderClass(unittest.TestCase):
         )
         self.assertEqual(code, 400)
 
-    def test_051_parse_order_content_success(self):
+    def test_052_parse_order_content_success(self):
         # test parse_order_content with code 200 and status processing
         with patch.object(
             self.order.message,
@@ -741,7 +755,7 @@ class TestOrderClass(unittest.TestCase):
                         self.assertIn("header", result)
                         self.assertIn("data", result)
 
-    def test_052_parse_order_content_expiry_disabled(self):
+    def test_053_parse_order_content_expiry_disabled(self):
         # test parse_order_content with expiry_check_disable True
         self.order.config.expiry_check_disable = True
         with patch.object(
@@ -768,7 +782,7 @@ class TestOrderClass(unittest.TestCase):
                         self.assertIn("header", result)
                         self.assertIn("data", result)
 
-    def test_053_legacy_api_compatibility(self):
+    def test_054_legacy_api_compatibility(self):
         # test legacy API wrappers
         with patch.object(
             self.order, "invalidate_expired_orders", return_value=([], [])
@@ -783,7 +797,7 @@ class TestOrderClass(unittest.TestCase):
         ):
             self.assertEqual(self.order.parse("content"), {"foo": "bar"})
 
-    def test_054_add_order_and_authorizations_success(self):
+    def test_055_add_order_and_authorizations_success(self):
         # Order and authorizations added successfully
         self.order.repository.add_order.return_value = "oid"
         self.order.repository.add_authorization.return_value = None
@@ -811,7 +825,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_called_once()
 
-    def test_055_add_order_and_authorizations_order_db_error(self):
+    def test_056_add_order_and_authorizations_order_db_error(self):
         # Adding order raises DB error
         self.order.repository.add_order.side_effect = Exception("fail")
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -840,7 +854,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_called_once_with(None, payload, auth_dic)
 
-    def test_056_add_order_and_authorizations_authz_db_error(self):
+    def test_057_add_order_and_authorizations_authz_db_error(self):
         # Adding authorization raises DB error
         self.order.repository.add_order.return_value = "oid"
         self.order.repository.add_authorization.side_effect = Exception("fail")
@@ -869,7 +883,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_called_once()
 
-    def test_057_add_order_and_authorizations_with_error_input(self):
+    def test_058_add_order_and_authorizations_with_error_input(self):
         # If error is already set, should skip adding order/authorizations
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
         data_dic = {"foo": "bar"}
@@ -896,7 +910,7 @@ class TestOrderClass(unittest.TestCase):
             )
             mock_add_authz.assert_not_called()
 
-    def test_058_add_order_and_authorizations_logging(self):
+    def test_059_add_order_and_authorizations_logging(self):
         self.order.repository.add_order.return_value = "oid"
         self.order.repository.add_authorization.return_value = None
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -914,25 +928,25 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_059_load_header_info_config_valid(self):
+    def test_060_load_header_info_config_valid(self):
         config_dic = {"Order": {"header_info_list": '["X-Header1", "X-Header2"]'}}
         self.order.config.header_info_list = []
         self.order._load_header_info_config(config_dic)
         self.assertEqual(self.order.config.header_info_list, ["X-Header1", "X-Header2"])
 
-    def test_060_load_header_info_config_invalid_json(self):
+    def test_061_load_header_info_config_invalid_json(self):
         config_dic = {"Order": {"header_info_list": "notjson"}}
         with patch.object(self.order.logger, "warning") as mock_warn:
             self.order._load_header_info_config(config_dic)
             mock_warn.assert_called()
 
-    def test_061_load_header_info_config_missing_key(self):
+    def test_062_load_header_info_config_missing_key(self):
         config_dic = {"Order": {}}
         self.order.config.header_info_list = ["shouldnotchange"]
         self.order._load_header_info_config(config_dic)
         self.assertEqual(self.order.config.header_info_list, ["shouldnotchange"])
 
-    def test_062_load_header_info_config_logging(self):
+    def test_063_load_header_info_config_logging(self):
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             config_dic = {"Order": {"header_info_list": '["X-Header1"]'}}
             self.order._load_header_info_config(config_dic)
@@ -948,7 +962,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_063_load_order_config_all_options(self):
+    def test_064_load_order_config_all_options(self):
         import configparser
 
         config_dic = configparser.ConfigParser()
@@ -974,7 +988,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(self.order.config.validity, 456)
         self.assertEqual(self.order.config.identifier_limit, 7)
 
-    def test_064_load_order_config_invalid_ints(self):
+    def test_065_load_order_config_invalid_ints(self):
         import configparser
 
         config_dic = configparser.ConfigParser()
@@ -999,7 +1013,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_065_load_order_config_missing_sections(self):
+    def test_066_load_order_config_missing_sections(self):
         import configparser
 
         config_dic = configparser.ConfigParser()
@@ -1010,7 +1024,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(self.order.config.validity, 86400)
         self.assertEqual(self.order.config.identifier_limit, 20)
 
-    def test_066_create_order_invalid_identifiers(self):
+    def test_067_create_order_invalid_identifiers(self):
         # Identifiers are invalid, triggers error path
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
         account_name = "acct"
@@ -1031,7 +1045,7 @@ class TestOrderClass(unittest.TestCase):
             mock_check.assert_called_once()
             mock_add_order_authz.assert_called_once()
 
-    def test_067_create_order_profile_invalid(self):
+    def test_068_create_order_profile_invalid(self):
         # Profile is present but invalid, triggers error path
         payload = {
             "identifiers": [{"type": "dns", "value": "example.com"}],
@@ -1068,7 +1082,7 @@ class TestOrderClass(unittest.TestCase):
             mock_add_profile.assert_called_once()
             mock_add_order_authz.assert_called_once()
 
-    def test_068_create_order_add_order_and_authz_error(self):
+    def test_069_create_order_add_order_and_authz_error(self):
         # Error occurs in _add_order_and_authorizations
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
         account_name = "acct"
@@ -1087,7 +1101,7 @@ class TestOrderClass(unittest.TestCase):
             mock_check.assert_called_once()
             mock_add_order_authz.assert_called_once()
 
-    def test_069_create_order_no_identifiers(self):
+    def test_070_create_order_no_identifiers(self):
         # Payload missing 'identifiers', triggers unsupportedidentifier error
         payload = {"profile": "foo"}
         account_name = "acct"
@@ -1104,7 +1118,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertEqual(expires, "2009-02-14T23:31:30Z")
             self.assertFalse(detail)
 
-    def test_070_create_order_logging(self):
+    def test_071_create_order_logging(self):
         # Check all log messages with severity INFO and higher
         # Use unified logger and log_stream
         with (
@@ -1151,20 +1165,6 @@ class TestOrderClass(unittest.TestCase):
                     "DEBUG:test_a2c:Order.create_order() ended", log_cm.output
                 )
 
-    def test_071_load_profile_config_all_paths(self):
-        with patch.object(self.order, "_load_profiles_from_config") as m1:
-            with patch.object(self.order, "_load_profiles_from_db_if_sync") as m2:
-                with patch.object(self.order, "_maybe_disable_profile_check") as m3:
-                    with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
-                        self.order._load_profile_config({"Order": {}, "CAhandler": {}})
-                        m1.assert_called_once()
-                        m2.assert_called_once()
-                        m3.assert_called_once()
-        self.assertIn("DEBUG:test_a2c:Order._load_profile_config()", log_cm.output)
-        self.assertIn(
-            "DEBUG:test_a2c:Order._load_profile_config() ended", log_cm.output
-        )
-
     def test_072_load_profile_config_all_paths(self):
         with patch.object(self.order, "_load_profiles_from_config") as m1:
             with patch.object(self.order, "_load_profiles_from_db_if_sync") as m2:
@@ -1174,13 +1174,27 @@ class TestOrderClass(unittest.TestCase):
                         m1.assert_called_once()
                         m2.assert_called_once()
                         m3.assert_called_once()
+        self.assertIn("DEBUG:test_a2c:Order._load_profile_config()", log_cm.output)
+        self.assertIn(
+            "DEBUG:test_a2c:Order._load_profile_config() ended", log_cm.output
+        )
+
+    def test_073_load_profile_config_all_paths(self):
+        with patch.object(self.order, "_load_profiles_from_config") as m1:
+            with patch.object(self.order, "_load_profiles_from_db_if_sync") as m2:
+                with patch.object(self.order, "_maybe_disable_profile_check") as m3:
+                    with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
+                        self.order._load_profile_config({"Order": {}, "CAhandler": {}})
+                        m1.assert_called_once()
+                        m2.assert_called_once()
+                        m3.assert_called_once()
 
         self.assertIn("DEBUG:test_a2c:Order._load_profile_config()", log_cm.output)
         self.assertIn(
             "DEBUG:test_a2c:Order._load_profile_config() ended", log_cm.output
         )
 
-    def test_073_load_profiles_from_config_with_profiles(self):
+    def test_074_load_profiles_from_config_with_profiles(self):
         # Should load profiles and set profiles_check_disable to False
         config_dic = {
             "Order": {
@@ -1198,7 +1212,7 @@ class TestOrderClass(unittest.TestCase):
             },
         )
 
-    def test_074_load_profiles_from_config_no_profiles(self):
+    def test_075_load_profiles_from_config_no_profiles(self):
         # Should not set profiles or change profiles_check_disable
         config_dic = {"Order": {}}
         self.order.config.profiles = {"bar": {}}
@@ -1207,7 +1221,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(self.order.config.profiles, {"bar": {}})
         self.assertTrue(self.order.config.profiles_check_disable)
 
-    def test_075_load_profiles_from_db_if_sync_profiles_sync_true(self):
+    def test_076_load_profiles_from_db_if_sync_profiles_sync_true(self):
         # Should load profiles from DB if profiles_sync is set and True
         import configparser
 
@@ -1224,7 +1238,7 @@ class TestOrderClass(unittest.TestCase):
             '{"profiles": {"foo": {}}}'
         )
 
-    def test_076_load_profiles_from_db_if_sync_profiles_sync_false(self):
+    def test_077_load_profiles_from_db_if_sync_profiles_sync_false(self):
         # Should not load profiles from DB if profiles_sync is False
         import configparser
 
@@ -1237,7 +1251,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertFalse(self.order.config.profiles_sync)
         self.order._set_profiles_from_db.assert_not_called()
 
-    def test_077_load_profiles_from_db_if_sync_no_profiles_sync(self):
+    def test_078_load_profiles_from_db_if_sync_no_profiles_sync(self):
         # Should not load profiles from DB if profiles_sync key is missing
 
         config_dic = {"CAhandler": {}}
@@ -1250,7 +1264,7 @@ class TestOrderClass(unittest.TestCase):
         )
         self.order._set_profiles_from_db.assert_not_called()
 
-    def test_078_load_profiles_from_db_if_sync_db_error(self):
+    def test_079_load_profiles_from_db_if_sync_db_error(self):
         # Should log and handle DB error
         import configparser
 
@@ -1268,18 +1282,18 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_079_set_profiles_from_db_valid_json(self):
+    def test_080_set_profiles_from_db_valid_json(self):
         # Should set profiles from valid JSON string
         self.order._set_profiles_from_db('{"profiles": {"foo": {}}}')
         self.assertEqual(self.order.config.profiles, {"foo": {}})
 
-    def test_080_set_profiles_from_db_invalid_json(self):
+    def test_081_set_profiles_from_db_invalid_json(self):
         # Should log error on invalid JSON
         with patch.object(self.order.logger, "error") as mock_log:
             self.order._set_profiles_from_db("notjson")
             mock_log.assert_called()
 
-    def test_081_maybe_disable_profile_check_true(self):
+    def test_082_maybe_disable_profile_check_true(self):
         # Should set profiles_check_disable to True if config says so
         import configparser
 
@@ -1290,7 +1304,7 @@ class TestOrderClass(unittest.TestCase):
         self.order._maybe_disable_profile_check(config_dic)
         self.assertTrue(self.order.config.profiles_check_disable)
 
-    def test_082_maybe_disable_profile_check_false(self):
+    def test_083_maybe_disable_profile_check_false(self):
         # Should set profiles_check_disable to False if config says so
         import configparser
 
@@ -1301,7 +1315,7 @@ class TestOrderClass(unittest.TestCase):
         self.order._maybe_disable_profile_check(config_dic)
         self.assertFalse(self.order.config.profiles_check_disable)
 
-    def test_083_maybe_disable_profile_check_no_profiles(self):
+    def test_084_maybe_disable_profile_check_no_profiles(self):
         # Should not change profiles_check_disable if no profiles
         import configparser
 
@@ -1313,7 +1327,7 @@ class TestOrderClass(unittest.TestCase):
         self.order._maybe_disable_profile_check(config_dic)
         self.assertFalse(self.order.config.profiles_check_disable)
 
-    def test_084_load_configuration_authz_validity_error(self):
+    def test_085_load_configuration_authz_validity_error(self):
         # Test _load_configuration with invalid Authorization validity (should log warning)
         # Use unified logger and log_stream
         import configparser
@@ -1335,7 +1349,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_085_load_configuration_without_ordersection(self):
+    def test_086_load_configuration_without_ordersection(self):
         # Test _load_configuration without oder section in config (should use defaults and log warnings for missing options)
         import configparser
 
@@ -1350,14 +1364,14 @@ class TestOrderClass(unittest.TestCase):
             self.assertEqual(self.order.config.validity, 86400)
             self.assertEqual(self.order.config.identifier_limit, 20)
 
-    def test_086_name_get_logging(self):
+    def test_087_name_get_logging(self):
         with patch(
             "acme_srv.order.parse_url", return_value={"path": "/acme/order/ord123"}
         ):
             result = self.order._name_get("/acme/order/ord123")
             self.assertEqual(result, "ord123")
 
-    def test_087_name_get_with_slash(self):
+    def test_088_name_get_with_slash(self):
         # Should split and return first part if slash in order name
         with patch(
             "acme_srv.order.parse_url",
@@ -1366,7 +1380,7 @@ class TestOrderClass(unittest.TestCase):
             result = self.order._name_get("/acme/order/ord456/extra")
             self.assertEqual(result, "ord456")
 
-    def test_088_name_get_logging(self):
+    def test_089_name_get_logging(self):
         # Should log debug messages using central logger and log_stream
         with patch(
             "acme_srv.order.parse_url", return_value={"path": "/acme/order/ord789"}
@@ -1378,7 +1392,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertIn("DEBUG:test_a2c:Order._name_get() ended", log_cm.output)
 
-    def test_089_are_identifiers_allowed_valid(self):
+    def test_090_are_identifiers_allowed_valid(self):
         # Should return None for valid identifiers
         with patch("acme_srv.order.validate_identifier", return_value=True):
             result = self.order.are_identifiers_allowed(
@@ -1386,7 +1400,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_090_are_identifiers_allowed_invalid_type(self):
+    def test_091_are_identifiers_allowed_invalid_type(self):
         # Should return unsupportedidentifier for unknown type
         with patch("acme_srv.order.validate_identifier", return_value=True):
             result = self.order.are_identifiers_allowed(
@@ -1400,7 +1414,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_091_are_identifiers_allowed_invalid_value(self):
+    def test_092_are_identifiers_allowed_invalid_value(self):
         # Should return rejectedidentifier if validate_identifier returns False
         with patch("acme_srv.order.validate_identifier", return_value=False):
             result = self.order.are_identifiers_allowed(
@@ -1414,7 +1428,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_092_are_identifiers_allowed_missing_type(self):
+    def test_093_are_identifiers_allowed_missing_type(self):
         # Should return malformed if type is missing
         result = self.order.are_identifiers_allowed([{"value": "foo.com"}])
         result = self.order.are_identifiers_allowed([{"value": "foo.com"}])
@@ -1423,7 +1437,7 @@ class TestOrderClass(unittest.TestCase):
             (self.order.error_msg_dic["malformed"], "Identifier type is missing"),
         )
 
-    def test_093_are_identifiers_allowed_tnauthlist_and_email(self):
+    def test_094_are_identifiers_allowed_tnauthlist_and_email(self):
         # Should allow tnauthlist and email if config enabled
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.tnauthlist_support = True
@@ -1436,7 +1450,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_094_are_identifiers_allowed_wildcard_rejected_when_disabled(self):
+    def test_095_are_identifiers_allowed_wildcard_rejected_when_disabled(self):
         # Should reject wildcard DNS identifiers when wildcard support is disabled
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.wildcard_certificate_disable = True
@@ -1451,7 +1465,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_095_are_identifiers_allowed_wildcard_allowed_when_not_disabled(self):
+    def test_096_are_identifiers_allowed_wildcard_allowed_when_not_disabled(self):
         # Should allow wildcard DNS identifiers when wildcard support is enabled
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.wildcard_certificate_disable = False
@@ -1460,7 +1474,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_096_rewrite_email_identifiers_basic(self):
+    def test_097_rewrite_email_identifiers_basic(self):
         # Should rewrite DNS with @ to email
         self.order.config.email_identifier_support = True
         self.order.config.email_identifier_rewrite = True
@@ -1471,7 +1485,7 @@ class TestOrderClass(unittest.TestCase):
             result[0]["value"], "foo@bar.com"
         )  # Additional assertion to differentiate
 
-    def test_097_rewrite_email_identifiers_no_rewrite(self):
+    def test_098_rewrite_email_identifiers_no_rewrite(self):
         # Should not rewrite if no @ in value
         input_list = [{"type": "dns", "value": "foobar.com"}]
         result = self.order._rewrite_email_identifiers(input_list)
@@ -1480,7 +1494,7 @@ class TestOrderClass(unittest.TestCase):
             result[0]["value"], "foobar.com"
         )  # Additional assertion to differentiate
 
-    def test_098_rewrite_email_identifiers_other_types(self):
+    def test_099_rewrite_email_identifiers_other_types(self):
         # Should not rewrite if type is not dns
         input_list = [{"type": "email", "value": "foo@bar.com"}]
         result = self.order._rewrite_email_identifiers(input_list)
@@ -1489,7 +1503,7 @@ class TestOrderClass(unittest.TestCase):
             result[0]["value"], "foo@bar.com"
         )  # Additional assertion to differentiate
 
-    def test_099_rewrite_email_identifiers_logging(self):
+    def test_100_rewrite_email_identifiers_logging(self):
         # Should log info and debug messages using the unified logger
         self.order.config.email_identifier_support = True
         self.order.config.email_identifier_rewrite = True
@@ -1507,7 +1521,7 @@ class TestOrderClass(unittest.TestCase):
             "DEBUG:test_a2c:Order._rewrite_email_identifiers() ended", log_cm.output
         )
 
-    def test_100_name_get_basic(self):
+    def test_101_name_get_basic(self):
         # Should log debug messages using central logger and log_stream
         with patch(
             "acme_srv.order.parse_url", return_value={"path": "/acme/order/ord123"}
@@ -1520,7 +1534,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertIn("DEBUG:test_a2c:Order._name_get() ended", log_cm.output)
 
-    def test_101_process_csr_all_paths(self):
+    def test_102_process_csr_all_paths(self):
         # Covers: found, not found, error, logging
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             # Found path
@@ -1546,7 +1560,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_102_process_csr_rejected_identifier(self):
+    def test_103_process_csr_rejected_identifier(self):
         # Covers: enroll_and_store returns rejectedIdentifier leading to 401
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             self.order._get_order_info = MagicMock(return_value={"name": "order1"})
@@ -1568,7 +1582,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_103_process_csr_serverinternal_error(self):
+    def test_104_process_csr_serverinternal_error(self):
         # Covers: enroll_and_store returns serverinternal leading to 500
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
 
@@ -1596,7 +1610,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_104_process_csr_certificate_store_failure(self):
+    def test_105_process_csr_certificate_store_failure(self):
         # Covers: store_csr returns falsy leading to 500 and CSR processing failed detail
         with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
             self.order._get_order_info = MagicMock(return_value={"name": "order1"})
@@ -1620,7 +1634,7 @@ class TestOrderClass(unittest.TestCase):
                     log_cm.output,
                 )
 
-    def test_105_finalize_order_all_paths(self):
+    def test_106_finalize_order_all_paths(self):
         # Covers: ready, valid/idempotent, not ready, logging
 
         # Ready path
@@ -1642,7 +1656,7 @@ class TestOrderClass(unittest.TestCase):
         result = self.order._finalize_order("order1", {"csr": "csrval"})
         self.assertEqual(result[0], 403)
 
-    def test_106_finalize_csr_updates_status_when_no_detail(self):
+    def test_107_finalize_csr_updates_status_when_no_detail(self):
         # When code==200 and no detail, order_status should update to valid
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
@@ -1653,7 +1667,7 @@ class TestOrderClass(unittest.TestCase):
             {"name": "order1", "status": "valid"}
         )
 
-    def test_107_finalize_csr_handles_timeout(self):
+    def test_108_finalize_csr_handles_timeout(self):
         # When certificate_name=='timeout', code is set to 200 and message=timeout
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
@@ -1665,7 +1679,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_108_finalize_csr_handles_rejected_identifier(self):
+    def test_109_finalize_csr_handles_rejected_identifier(self):
         # When certificate_name=='urn:ietf:params:acme:error:rejectedIdentifier', code=401 and message set
         self.order._header_info_lookup = MagicMock(return_value={})
         rej = "urn:ietf:params:acme:error:rejectedIdentifier"
@@ -1677,46 +1691,77 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_109_finalize_csr_else_branch_preserves_ca_detail(self):
-        #  CA handler's real failure detail gets forwarded as config.ca_error_details_forward is True
-        self.order.config.ca_error_details_forward = True
+    def test_110_finalize_csr_else_branch_passes_through_detail(self):
+        # Enrollment detail is resolved upstream; finalize passes it through.
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
-        self.order._process_csr = MagicMock(return_value=(400, "error", "ca_detail"))
+        self.order._process_csr = MagicMock(
+            return_value=(500, "urn:ietf:params:acme:error:serverInternal", "ca_detail")
+        )
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             result = self.order._finalize_csr("order1", {"csr": "csrval"})
-            self.assertEqual(result, (400, "error", "ca_detail", "error"))
+            self.assertEqual(
+                result,
+                (500, "urn:ietf:params:acme:error:serverInternal", "ca_detail", "urn:ietf:params:acme:error:serverInternal"),
+            )
             self.order.repository.order_update.assert_not_called()
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_109a_finalize_csr_else_branch_overwrite_ca_error(self):
-        # CA handler's real failure detail gets overwritten with generic fallback
+    def test_111_finalize_csr_else_branch_generic_fallback(self):
+        # Safety net when upstream detail is missing.
+        from acme_srv.helpers.global_variables import ENROLLMENT_FAILED_DETAIL
+
         self.order.repository.order_update = MagicMock()
         self.order._header_info_lookup = MagicMock(return_value={})
-        self.order._process_csr = MagicMock(return_value=(400, "error", "ca_detail"))
+        self.order._process_csr = MagicMock(
+            return_value=(500, "urn:ietf:params:acme:error:serverInternal", None)
+        )
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             result = self.order._finalize_csr("order1", {"csr": "csrval"})
-            self.assertEqual(result, (400, "error", "enrollment failed", "error"))
+            self.assertEqual(
+                result,
+                (
+                    500,
+                    "urn:ietf:params:acme:error:serverInternal",
+                    ENROLLMENT_FAILED_DETAIL,
+                    "urn:ietf:params:acme:error:serverInternal",
+                ),
+            )
             self.order.repository.order_update.assert_not_called()
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
 
-    def test_109b_finalize_csr_else_branch_generic_fallback(self):
-        # back to the generic detail only when the handler
-        # provided none.
-        self.order.config.ca_error_details_forward = True
-        self.order.repository.order_update = MagicMock()
-        self.order._header_info_lookup = MagicMock(return_value={})
-        self.order._process_csr = MagicMock(return_value=(400, "error", None))
-        with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
-            result = self.order._finalize_csr("order1", {"csr": "csrval"})
-            self.assertEqual(result, (400, "error", "enrollment failed", "error"))
-            self.order.repository.order_update.assert_not_called()
-        self.assertIn("DEBUG:test_a2c:Order._finalize_csr(order1)", log_cm.output)
-        self.assertIn("DEBUG:test_a2c:Order._finalize_csr() ended", log_cm.output)
+    def test_112_process_csr_applies_eab_profile_and_forwards_flag(self):
+        with patch("acme_srv.helper.b64_url_recode", return_value="csrval"):
+            self.order.config.eab_profiling = True
+            self.order.config.eab_handler = MagicMock()
+            self.order.config.ca_error_details_forward = False
+            self.order._get_order_info = MagicMock(return_value={"name": "order1"})
+            self.order._get_order_account_name = MagicMock(return_value="acc1")
+            self.order._apply_eab_profile = MagicMock(
+                side_effect=lambda _account: setattr(
+                    self.order.config, "ca_error_details_forward", True
+                )
+            )
+            cert_mock = MagicMock()
+            cert_mock.store_csr.return_value = "cert1"
+            cert_mock.enroll_and_store.return_value = (
+                self.order.error_msg_dic["serverinternal"],
+                "upstream failure",
+            )
+            with patch("acme_srv.order.Certificate") as cert_class:
+                cert_instance = cert_class.return_value.__enter__.return_value
+                cert_instance.config = MagicMock()
+                cert_instance.store_csr = cert_mock.store_csr
+                cert_instance.enroll_and_store = cert_mock.enroll_and_store
+                result = self.order._process_csr("order1", "csr", "header")
+                self.order._apply_eab_profile.assert_called_once_with("acc1")
+                self.assertTrue(cert_instance.config.ca_error_details_forward)
+                self.assertEqual(result[0], 500)
+                self.assertEqual(result[2], "upstream failure")
 
-    def test_110_order_dic_create_all_paths(self):
+    def test_113_order_dic_create_all_paths(self):
         # Covers: all fields, parse error, logging
         tmp_dic = {
             "status": "pending",
@@ -1743,7 +1788,7 @@ class TestOrderClass(unittest.TestCase):
             "ERROR:test_a2c:Error while parsing the identifier notjson", log_cm.output
         )
 
-    def test_111_get_authorization_list_all_paths(self):
+    def test_114_get_authorization_list_all_paths(self):
         self.order.repository.authorization_lookup.return_value = [
             {"name": "auth1", "status__name": "valid"}
         ]
@@ -1752,7 +1797,7 @@ class TestOrderClass(unittest.TestCase):
             [{"name": "auth1", "status__name": "valid"}],
         )
 
-    def test_112_get_authorization_list_all_paths(self):
+    def test_115_get_authorization_list_all_paths(self):
         # DB error path
         self.order.repository.authorization_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
@@ -1770,7 +1815,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_113_update_validity_list_all_paths(self):
+    def test_116_update_validity_list_all_paths(self):
         # Covers: all code paths, logging
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             # All valid
@@ -1788,7 +1833,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order._update_validity_list()", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order.get_order_details() ended", log_cm.output)
 
-    def test_114_get_order_details_all_paths(self):
+    def test_117_get_order_details_all_paths(self):
         # Covers: found, not found, logging
 
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
@@ -1803,7 +1848,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertIn("DEBUG:test_a2c:Order.get_order_details(order1)", log_cm.output)
         self.assertIn("DEBUG:test_a2c:Order.get_order_details() ended", log_cm.output)
 
-    def test_115_invalidate_expired_orders_all_paths(self):
+    def test_118_invalidate_expired_orders_all_paths(self):
         # Covers: success, db error, logging
         self.order.repository.orders_invalid_search.return_value = [
             {"name": "order1", "status__name": "pending"}
@@ -1828,7 +1873,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_116_invalidate_expired_orders_all_paths(self):
+    def test_119_invalidate_expired_orders_all_paths(self):
         # DB error path
         self.order.repository.orders_invalid_search.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -1839,7 +1884,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_117_process_order_request_all_paths(self):
+    def test_120_process_order_request_all_paths(self):
         # Covers: finalize, polling, cert found, cert not found, url missing, logging
 
         self.order._finalize_order = MagicMock(return_value=(200, "msg", None, "cert"))
@@ -1879,7 +1924,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_118_check_identifiers_validity_all_paths(self):
+    def test_121_check_identifiers_validity_all_paths(self):
         # Covers: valid, too many, malformed, email rewrite, allowed, rejected, and logging
         with patch("acme_srv.order.validate_identifier", return_value=True):
             self.order.config.identifier_limit = 2
@@ -1906,7 +1951,7 @@ class TestOrderClass(unittest.TestCase):
                 (self.order.error_msg_dic["malformed"], "malformed identifiers list"),
             )
 
-    def test_119_check_identifiers_validity_all_paths(self):
+    def test_122_check_identifiers_validity_all_paths(self):
         with patch("acme_srv.order.validate_identifier", return_value=False):
             self.order.config.identifier_limit = 2
             self.order.config.email_identifier_support = True
@@ -1921,13 +1966,13 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_120_get_order_info_all_paths(self):
+    def test_123_get_order_info_all_paths(self):
         # Covers: successful lookup, DB error, logging
         self.order.repository.order_lookup.return_value = {"name": "order1"}
         result = self.order._get_order_info("order1")
         self.assertEqual(result, {"name": "order1"})
 
-    def test_121_get_order_info_all_paths(self):
+    def test_124_get_order_info_all_paths(self):
         # Clear log buffer before error path
         self.order.repository.order_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -1938,7 +1983,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_122_header_info_lookup_all_paths(self):
+    def test_125_header_info_lookup_all_paths(self):
         # Covers: header present, header missing, header_info_list missing, logging
         # Use central logger and log_stream from setUp
 
@@ -1956,14 +2001,14 @@ class TestOrderClass(unittest.TestCase):
         result = self.order._header_info_lookup({"X-Test": "foo"})
         self.assertIsNone(result)
 
-    def test_123_enter_loads_configuration_and_returns_self(self):
+    def test_126_enter_loads_configuration_and_returns_self(self):
         # Covers __enter__: should call _load_configuration and return self
         with patch.object(self.order, "_load_configuration") as mock_load_config:
             result = self.order.__enter__()
             mock_load_config.assert_called_once()
             self.assertIs(result, self.order)
 
-    def test_124_parse_order_content_adds_certificate(self):
+    def test_127_parse_order_content_adds_certificate(self):
         # Covers lines 976-978: certificate_name and status valid adds certificate path
         with patch.object(
             self.order.message,
@@ -1992,7 +2037,7 @@ class TestOrderClass(unittest.TestCase):
                             "https://example.com/acme/cert/cert123",
                         )
 
-    def test_125_invalidate_expired_orders_update_error_logging(self):
+    def test_128_invalidate_expired_orders_update_error_logging(self):
         # Covers lines 831-840: order_update raises OrderDatabaseError and logs CRITICAL
         self.order.repository.orders_invalid_search = MagicMock(
             return_value=[{"name": "order1", "status__name": "pending"}]
@@ -2006,7 +2051,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_126_process_csr_generic_error(self):
+    def test_129_process_csr_generic_error(self):
         # Covers lines 681-684: error is not rejectedIdentifier or serverinternal
         with patch.object(
             self.order, "_get_order_info", return_value={"name": "order1"}
@@ -2020,7 +2065,7 @@ class TestOrderClass(unittest.TestCase):
                 self.assertEqual(result[0], 400)
                 self.assertEqual(result[1], "someerror")
 
-    def test_127_process_csr_serverinternal_error(self):
+    def test_130_process_csr_serverinternal_error(self):
         # Covers lines 684-689: error == serverinternal triggers code=500
         with patch.object(
             self.order, "_get_order_info", return_value={"name": "order1"}
@@ -2037,7 +2082,7 @@ class TestOrderClass(unittest.TestCase):
                 self.assertEqual(result[0], 500)
                 self.assertEqual(result[1], "urn:ietf:params:acme:error:serverInternal")
 
-    def test_128_process_order_request_db_error_logging(self):
+    def test_131_process_order_request_db_error_logging(self):
         # Covers: OrderDatabaseError in certificate_lookup and CRITICAL log
         self.order.repository.certificate_lookup.side_effect = Exception("fail")
         with self.assertLogs("test_a2c", level="CRITICAL") as log_cm:
@@ -2052,7 +2097,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_129_process_order_request_no_url(self):
+    def test_132_process_order_request_no_url(self):
         # Covers lines 634-638: protected dict missing 'url' and checks log
         with patch.object(self.order.logger, "debug") as mock_debug:
             result = self.order._process_order_request("ordername", {}, {}, None)
@@ -2068,7 +2113,7 @@ class TestOrderClass(unittest.TestCase):
                 "url is missing in protected",
             )
 
-    def test_130_finalize_order_valid_OrderDatabaseError(self):
+    def test_133_finalize_order_valid_OrderDatabaseError(self):
         # Covers lines 593-597: status not ready
         self.order.repository.order_lookup.return_value = {"status": "valid"}
         self.order.config.idempotent_finalize = True
@@ -2085,7 +2130,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_131_finalize_order_ready_nocsr(self):
+    def test_134_finalize_order_ready_nocsr(self):
         # Covers lines 593-597: status not ready
         self.order.repository.order_lookup.return_value = {"status": "ready"}
         result = self.order._finalize_order("ordername", {}, None)
@@ -2094,7 +2139,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(result[2], "csr is missing in payload")
         self.assertIsNone(result[3])
 
-    def test_132_finalize_csr_timeout(self):
+    def test_135_finalize_csr_timeout(self):
         # Patch _process_csr to return (200, 'timeout', 'not_none') so the elif branch is taken
         with patch.object(
             self.order, "_process_csr", return_value=(400, "timeout", "not_none")
@@ -2107,7 +2152,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertEqual(result[2], "not_none")
             self.assertEqual(result[3], "timeout")
 
-    def test_133_from_content_rejectedidentifier_with_detail(self):
+    def test_136_from_content_rejectedidentifier_with_detail(self):
         # Ensure the 'rejectedidentifier' error branch is covered
         rejected = self.order.error_msg_dic["rejectedidentifier"]
         with patch.object(
@@ -2137,7 +2182,7 @@ class TestOrderClass(unittest.TestCase):
                     self.assertEqual(result["type"], rejected)
                     self.assertEqual(result["detail"], "detail")
 
-    def test_134_from_content_rejectedidentifier_without_detail(self):
+    def test_137_from_content_rejectedidentifier_without_detail(self):
         # Ensure the 'rejectedidentifier' error branch is covered
         rejected = self.order.error_msg_dic["rejectedidentifier"]
         with patch.object(
@@ -2170,7 +2215,7 @@ class TestOrderClass(unittest.TestCase):
                         "Some of the requested identifiers got rejected",
                     )
 
-    def test_135_apply_eab_profile_eab_profiling_disabled(self):
+    def test_138_apply_eab_profile_eab_profiling_disabled(self):
         self.order.config.eab_profiling = False
         with patch.object(self.order, "_apply_eab_profile") as mock_apply_eab:
             payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -2186,14 +2231,14 @@ class TestOrderClass(unittest.TestCase):
                 self.order.create_order(payload, account_name)
                 mock_apply_eab.assert_not_called()
 
-    def test_136_apply_eab_profile_account_lookup_db_error(self):
+    def test_139_apply_eab_profile_account_lookup_db_error(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.side_effect = Exception("fail")
         with patch.object(self.order.logger, "critical") as mock_critical:
             self.order._apply_eab_profile("acct")
             mock_critical.assert_called()
 
-    def test_137_apply_eab_profile_no_eab_kid(self):
+    def test_140_apply_eab_profile_no_eab_kid(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {}
         with patch.object(self.order.logger, "debug") as mock_debug:
@@ -2203,7 +2248,7 @@ class TestOrderClass(unittest.TestCase):
                 "acct",
             )
 
-    def test_138_apply_eab_profile_allowed_domainlist_order_section(self):
+    def test_141_apply_eab_profile_allowed_domainlist_order_section(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid1"}
         mock_eab_handler = MagicMock()
@@ -2218,7 +2263,7 @@ class TestOrderClass(unittest.TestCase):
             )
         self.assertEqual(self.order.config.allowed_domainlist, ["example.com"])
 
-    def test_139_apply_eab_profile_allowed_domainlist_cahandler_section(self):
+    def test_142_apply_eab_profile_allowed_domainlist_cahandler_section(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid2"}
         mock_eab_handler = MagicMock()
@@ -2233,7 +2278,7 @@ class TestOrderClass(unittest.TestCase):
             )
         self.assertEqual(self.order.config.allowed_domainlist, ["test.com"])
 
-    def test_140_apply_eab_profile_wildcard_disable_false_order_section(self):
+    def test_143_apply_eab_profile_wildcard_disable_false_order_section(self):
         self.order.config.eab_profiling = True
         self.order.config.wildcard_certificate_disable = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid_false"}
@@ -2246,7 +2291,7 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertFalse(self.order.config.wildcard_certificate_disable)
 
-    def test_141_load_eab_profile_param_false_cahandler_section(self):
+    def test_144_load_eab_profile_param_false_cahandler_section(self):
         profile_dic = {
             "kid_false": {"cahandler": {"wildcard_certificate_disable": False}}
         }
@@ -2261,21 +2306,21 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_142_load_eab_profile_param_empty_list_in_order_section(self):
+    def test_145_load_eab_profile_param_empty_list_in_order_section(self):
         profile_dic = {"kid_list": {"order": {"allowed_domainlist": []}}}
         value = self.order._load_eab_profile_param(
             profile_dic, "kid_list", "allowed_domainlist", ["default.com"]
         )
         self.assertEqual(value, [])
 
-    def test_143_load_eab_profile_param_empty_string_in_order_section(self):
+    def test_146_load_eab_profile_param_empty_string_in_order_section(self):
         profile_dic = {"kid_str": {"order": {"custom_key": ""}}}
         value = self.order._load_eab_profile_param(
             profile_dic, "kid_str", "custom_key", "fallback"
         )
         self.assertEqual(value, "")
 
-    def test_144_load_eab_profile_param_order_section_has_precedence(self):
+    def test_147_load_eab_profile_param_order_section_has_precedence(self):
         profile_dic = {
             "kid_precedence": {
                 "order": {"wildcard_certificate_disable": False},
@@ -2287,14 +2332,14 @@ class TestOrderClass(unittest.TestCase):
         )
         self.assertFalse(value)
 
-    def test_145_load_eab_profile_param_returns_default_if_param_missing(self):
+    def test_148_load_eab_profile_param_returns_default_if_param_missing(self):
         profile_dic = {"kid_missing": {"order": {}, "cahandler": {}}}
         value = self.order._load_eab_profile_param(
             profile_dic, "kid_missing", "wildcard_certificate_disable", True
         )
         self.assertTrue(value)
 
-    def test_146_apply_eab_profile_generic_exception(self):
+    def test_149_apply_eab_profile_generic_exception(self):
         self.order.config.eab_profiling = True
         self.order.repository.account_lookup.return_value = {"eab_kid": "kid3"}
         mock_eab_handler = MagicMock()
@@ -2309,7 +2354,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_147_create_order_eab_profiling_branch(self):
+    def test_150_create_order_eab_profiling_branch(self):
         # Covers: if self.config.eab_profiling and self.config.eab_handler
         self.order.config.eab_profiling = True
         self.order.config.eab_handler = MagicMock()
@@ -2327,7 +2372,7 @@ class TestOrderClass(unittest.TestCase):
                 self.order.create_order(payload, account_name)
                 mock_apply_eab.assert_called_once_with(account_name)
 
-    def test_148_create_order_invalid_profile_detail(self):
+    def test_151_create_order_invalid_profile_detail(self):
         # Covers: if error == self.error_msg_dic["invalidprofile"]: detail = "Invalid profile specified"
         self.order.config.eab_profiling = False
         self.order.config.eab_handler = None
@@ -2356,7 +2401,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertIsNone(error)
             self.assertEqual(detail, "Invalid profile specified")
 
-    def test_149_are_identifiers_allowed_fqdn_not_whitelisted(self):
+    def test_152_are_identifiers_allowed_fqdn_not_whitelisted(self):
         # Covers: FQDN/SAN not allowed by configuration (lines 551-566)
         with (
             patch("acme_srv.order.validate_identifier", return_value=True),
@@ -2374,7 +2419,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_150_check_single_identifier_wildcard_flag_reconstructs_for_domainlist(
+    def test_153_check_single_identifier_wildcard_flag_reconstructs_for_domainlist(
         self,
     ):
         # Covers wildcard-intent fallback for normalized identifiers against wildcard-only policy
@@ -2402,7 +2447,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_151_check_single_identifier_non_wildcard_skips_reconstruct_and_rejects(
+    def test_154_check_single_identifier_non_wildcard_skips_reconstruct_and_rejects(
         self,
     ):
         # Covers non-wildcard guard: wildcard reconstruction must not broaden policy
@@ -2426,7 +2471,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_152_apply_eab_profile_disabled(self):
+    def test_155_apply_eab_profile_disabled(self):
         # Covers: logger.critical branch in _apply_eab_profile (line 270)
         self.order.config.eab_profiling = False
         self.order.config.eab_handler = MagicMock()
@@ -2440,7 +2485,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertFalse(mock_account_lookup.called)
             self.assertFalse(mock_critical.called)
 
-    def test_153_check_single_identifier_missing_type(self):
+    def test_156_check_single_identifier_missing_type(self):
         # Covers error message for missing 'type' (line 556)
         identifier = {"value": "bar"}
         allowed_identifiers = ["dns", "ip"]
@@ -2452,7 +2497,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(detail, "Identifier type is missing")
         self.assertIn("ERROR:test_a2c:Identifier type is missing", log_cm.output)
 
-    def test_154_check_single_identifier_wrong_type(self):
+    def test_157_check_single_identifier_wrong_type(self):
         # Covers error message for missing 'type' (line 556)
         identifier = {"type": "unknown", "value": "bar"}
         allowed_identifiers = ["dns", "ip"]
@@ -2466,7 +2511,7 @@ class TestOrderClass(unittest.TestCase):
             "ERROR:test_a2c:Identifier type unknown not supported", log_cm.output
         )
 
-    def test_155_check_single_identifier_invalid_value(self):
+    def test_158_check_single_identifier_invalid_value(self):
         # Covers error message for invalid value (line 571)
         identifier = {"type": "dns", "value": "foo"}
         allowed_identifiers = ["dns", "ip"]
@@ -2482,7 +2527,7 @@ class TestOrderClass(unittest.TestCase):
                 log_cm.output,
             )
 
-    def test_156_add_authorizations_to_db_success(self):
+    def test_159_add_authorizations_to_db_success(self):
         # Test normal case: authorizations added successfully
         self.order.repository.add_authorization.return_value = None
         self.order.config.authz_validity = 1000
@@ -2503,7 +2548,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(payload["identifiers"][0]["status"], "pending")
         self.assertIn(list(auth_dic.keys())[0], auth_dic)
 
-    def test_157_add_authorizations_to_db_malformed(self):
+    def test_160_add_authorizations_to_db_malformed(self):
         # Test malformed case: oid is None
         oid = None
         payload = {"identifiers": [{"type": "dns", "value": "example.com"}]}
@@ -2519,7 +2564,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_158_add_authorizations_to_db_db_error(self):
+    def test_161_add_authorizations_to_db_db_error(self):
         # Test DB error: add_authorization raises exception
         self.order.repository.add_authorization.side_effect = Exception("fail")
         oid = "order123"
@@ -2533,7 +2578,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_159_add_authorizations_to_db_sectigo_sim(self):
+    def test_162_add_authorizations_to_db_sectigo_sim(self):
         # Covers sectigo_sim branch: status set to valid and update_authorization called
         self.order.config.sectigo_sim = True
         self.order.repository.add_authorization.return_value = None
@@ -2556,7 +2601,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_160_create_from_content_malformed_identifier(self):
+    def test_163_create_from_content_malformed_identifier(self):
         # Covers the branch where error == self.order.error_msg_dic["malformed"] and detail is None
         malformed_error = self.order.error_msg_dic["malformed"]
         with (
@@ -2589,7 +2634,7 @@ class TestOrderClass(unittest.TestCase):
                 response["detail"], "One of the requested identifiers is not supported"
             )
 
-    def test_161_load_configuration_directory_url_prefix(self):
+    def test_164_load_configuration_directory_url_prefix(self):
         # Covers the Directory/url_prefix branch in _load_configuration (line 513)
         import configparser
 
@@ -2609,7 +2654,7 @@ class TestOrderClass(unittest.TestCase):
                 all(v.startswith("/prefix/") for v in self.order.path_dic.values())
             )
 
-    def test_162_check_single_identifier_missing_value(self):
+    def test_165_check_single_identifier_missing_value(self):
         # Covers lines 578-579: missing 'value' in identifier
         identifier = {"type": "dns"}
         allowed_identifiers = ["dns", "ip"]
@@ -2621,7 +2666,7 @@ class TestOrderClass(unittest.TestCase):
         self.assertEqual(detail, "Identifier value is missing")
         self.assertIn("ERROR:test_a2c:Identifier value is missing", log_cm.output)
 
-    def test_163_is_profile_valid_dryrun_profile_logging(self):
+    def test_166_is_profile_valid_dryrun_profile_logging(self):
         # Set up dryrun profile
         self.order.config.dryrun_profilename = "dryrun-profile"
         self.order.config.profiles_check_disable = False
@@ -2635,7 +2680,7 @@ class TestOrderClass(unittest.TestCase):
         )
         self.assertIsNone(result)
 
-    def test_164_add_profile_to_order_dryrun_profile_logging(self):
+    def test_167_add_profile_to_order_dryrun_profile_logging(self):
         # Set up dryrun profile and no profiles configured
         self.order.config.profiles = {}
         self.order.config.dryrun_profilename = "dryrun-profile"
@@ -2653,8 +2698,10 @@ class TestOrderClass(unittest.TestCase):
         self.assertIsNone(error)
         self.assertEqual(updated_dic["profile"], "dryrun-profile")
 
-    def test_165_finalize_csr_handles_dryrun_skipped(self):
-        # When detail is 'Dry run mode - enrollment skipped', message should be unauthorized error
+    def test_168_finalize_csr_handles_dryrun_skipped(self):
+        # When detail is DRYRUN_ENROLLMENT_SKIPPED_DETAIL, message should be unauthorized error
+        from acme_srv.helpers.global_variables import DRYRUN_ENROLLMENT_SKIPPED_DETAIL
+
         self.order._header_info_lookup = MagicMock(return_value={})
         self.order._process_csr = MagicMock(
             return_value=(400, "certX", "Dry run mode - enrollment skipped")
@@ -2670,7 +2717,7 @@ class TestOrderClass(unittest.TestCase):
             ),
         )
 
-    def test_166_are_identifiers_allowed_ip_not_whitelisted(self):
+    def test_169_are_identifiers_allowed_ip_not_whitelisted(self):
         # Setup: allowed_iplist is set, is_ip_whitelisted returns False
         self.order.config.allowed_iplist = ["192.168.1.0/24"]
         identifier = {"type": "ip", "value": "10.0.0.1"}
@@ -2688,7 +2735,7 @@ class TestOrderClass(unittest.TestCase):
             self.assertIsNone(error)
             self.assertIsNone(msg)
 
-    def test_167_are_identifiers_allowed_ip_whitelisted(self):
+    def test_170_are_identifiers_allowed_ip_whitelisted(self):
         # Should allow IP if in allowed_iplist
         with (
             patch("acme_srv.order.validate_identifier", return_value=True),
@@ -2700,7 +2747,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_168_are_identifiers_allowed_ip_not_whitelisted(self):
+    def test_171_are_identifiers_allowed_ip_not_whitelisted(self):
         # Should reject IP if not in allowed_iplist
         with (
             patch("acme_srv.order.validate_identifier", return_value=True),
@@ -2718,7 +2765,7 @@ class TestOrderClass(unittest.TestCase):
                 ),
             )
 
-    def test_169_are_identifiers_allowed_iplist_empty(self):
+    def test_172_are_identifiers_allowed_iplist_empty(self):
         # Should allow any IP if allowed_iplist is empty
         with (
             patch("acme_srv.order.validate_identifier", return_value=True),
@@ -2730,7 +2777,7 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_170_are_identifiers_allowed_multiple_ips(self):
+    def test_173_are_identifiers_allowed_multiple_ips(self):
         # Should reject on first non-whitelisted IP, allow if all whitelisted
         with (
             patch("acme_srv.order.validate_identifier", return_value=True),
@@ -2763,11 +2810,11 @@ class TestOrderClass(unittest.TestCase):
             )
             self.assertEqual(result, (None, None))
 
-    def test_171_load_profile_mapping_field_returns_none_without_module(self):
+    def test_174_load_profile_mapping_field_returns_none_without_module(self):
         with patch("acme_srv.order.ca_handler_load", return_value=None):
             self.assertIsNone(self.order._load_profile_mapping_field({}))
 
-    def test_172_load_profile_mapping_field_from_module_attribute(self):
+    def test_175_load_profile_mapping_field_from_module_attribute(self):
         ca_module = types.SimpleNamespace(profile_mapping_field="module_profile")
 
         with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
@@ -2775,7 +2822,7 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertEqual(result, "module_profile")
 
-    def test_173_load_profile_mapping_field_from_instance_attribute(self):
+    def test_176_load_profile_mapping_field_from_instance_attribute(self):
         class DummyCAhandler:
             def __init__(self, logger=None):
                 self.logger = logger
@@ -2788,7 +2835,7 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertEqual(result, "instance_profile")
 
-    def test_174_load_profile_mapping_field_from_noarg_instance_fallback(self):
+    def test_177_load_profile_mapping_field_from_noarg_instance_fallback(self):
         class DummyCAhandler:
             def __init__(self):
                 self.profile_mapping_field = "noarg_instance_profile"
@@ -2800,7 +2847,7 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertEqual(result, "noarg_instance_profile")
 
-    def test_175_load_profile_mapping_field_from_class_attribute(self):
+    def test_178_load_profile_mapping_field_from_class_attribute(self):
         class DummyCAhandler:
             profile_mapping_field = "class_profile"
 
@@ -2814,13 +2861,13 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertEqual(result, "class_profile")
 
-    def test_176_load_profile_mapping_field_returns_none_without_handler_class(self):
+    def test_179_load_profile_mapping_field_returns_none_without_handler_class(self):
         ca_module = types.SimpleNamespace()
 
         with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
             self.assertIsNone(self.order._load_profile_mapping_field({}))
 
-    def test_177_load_profile_mapping_field_class_fallback_after_empty_instance(self):
+    def test_180_load_profile_mapping_field_class_fallback_after_empty_instance(self):
         class DummyCAhandler:
             profile_mapping_field = "class_profile"
 
@@ -2836,7 +2883,7 @@ class TestOrderClass(unittest.TestCase):
 
         self.assertEqual(result, "class_profile")
 
-    def test_178_load_profile_mapping_field_returns_none_when_not_defined(self):
+    def test_181_load_profile_mapping_field_returns_none_when_not_defined(self):
         class DummyCAhandler:
             def __init__(self, logger=None):
                 self.logger = logger
@@ -2847,7 +2894,7 @@ class TestOrderClass(unittest.TestCase):
         with patch("acme_srv.order.ca_handler_load", return_value=ca_module):
             self.assertIsNone(self.order._load_profile_mapping_field({}))
 
-    def test_179_load_profile_mapping_field_warns_when_noarg_fallback_fails(self):
+    def test_182_load_profile_mapping_field_warns_when_noarg_fallback_fails(self):
         class DummyCAhandler:
             def __init__(self):
                 raise RuntimeError("noarg constructor failed")
@@ -2866,7 +2913,7 @@ class TestOrderClass(unittest.TestCase):
             )
         )
 
-    def test_180_load_profile_mapping_field_warns_when_logger_init_fails(self):
+    def test_183_load_profile_mapping_field_warns_when_logger_init_fails(self):
         class DummyCAhandler:
             def __init__(self, logger=None):
                 raise RuntimeError("logger constructor failed")
@@ -2885,28 +2932,28 @@ class TestOrderClass(unittest.TestCase):
             )
         )
 
-    def test_181_profile_mapping_to_dict_none(self):
+    def test_184_profile_mapping_to_dict_none(self):
         self.assertEqual(self.order._profile_mapping_to_dict(None), {})
 
-    def test_182_profile_mapping_to_dict_string(self):
+    def test_185_profile_mapping_to_dict_string(self):
         self.assertEqual(
             self.order._profile_mapping_to_dict("  profile_a  "),
             {"profile_a": True},
         )
         self.assertEqual(self.order._profile_mapping_to_dict("   "), {})
 
-    def test_183_profile_mapping_to_dict_list(self):
+    def test_186_profile_mapping_to_dict_list(self):
         value = [" profile_a ", "profile_b", "", None, 123]
         self.assertEqual(
             self.order._profile_mapping_to_dict(value),
             {"profile_a": True, "profile_b": True, "123": True},
         )
 
-    def test_184_profile_mapping_to_dict_dict_passthrough(self):
+    def test_187_profile_mapping_to_dict_dict_passthrough(self):
         value = {"profile_a": True, "profile_b": False}
         self.assertEqual(self.order._profile_mapping_to_dict(value), value)
 
-    def test_185_profile_mapping_to_dict_unsupported_type(self):
+    def test_188_profile_mapping_to_dict_unsupported_type(self):
         with self.assertLogs("test_a2c", level="WARNING") as log_cm:
             self.assertEqual(self.order._profile_mapping_to_dict(42.0), {})
         self.assertIn(
@@ -2914,11 +2961,11 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_186_load_eab_profile_mapping_without_mapping_field(self):
+    def test_189_load_eab_profile_mapping_without_mapping_field(self):
         self.order.config.profile_mapping_field = None
         self.assertEqual(self.order._load_eab_profile_mapping({"kid": {}}, "kid"), {})
 
-    def test_187_load_eab_profile_mapping_uses_param_and_normalizer(self):
+    def test_190_load_eab_profile_mapping_uses_param_and_normalizer(self):
         self.order.config.profile_mapping_field = "template"
         with (
             patch.object(
@@ -2938,7 +2985,7 @@ class TestOrderClass(unittest.TestCase):
         mock_to_dict.assert_called_once_with("profile-a")
         self.assertEqual(result, {"profile-a": True})
 
-    def test_188_apply_eab_profile_mapping_updates_profiles(self):
+    def test_191_apply_eab_profile_mapping_updates_profiles(self):
         self.order.config.profiles = {"old": True}
         with self.assertLogs("test_a2c", level="DEBUG") as log_cm:
             self.order._apply_eab_profile_mapping("acct1", {"new": True})
@@ -2949,7 +2996,7 @@ class TestOrderClass(unittest.TestCase):
             log_cm.output,
         )
 
-    def test_189_apply_eab_profile_mapping_noop_for_empty_mapping(self):
+    def test_192_apply_eab_profile_mapping_noop_for_empty_mapping(self):
         self.order.config.profiles = {"keep": True}
         self.order._apply_eab_profile_mapping("acct1", {})
         self.assertEqual(self.order.config.profiles, {"keep": True})


### PR DESCRIPTION
Surfaces real CA enrollment failures to ACME clients (instead of a generic "enrollment failed"), with an optional opt-in to forward CA detail text, plus LE-style indented JSON responses.

- Finalize detail preservation: Order._finalize_csr() keeps the CA handler’s failure detail and only falls back to "enrollment failed" when none was provided (e.g. CAA / upstream ACME problem text is no longer dropped).
- ca_error_details_forward: New CAhandler boolean (default false). When enabled, enrollment failures return serverInternal with the raw CA error as detail; otherwise clients still get the generic enrollment-failed message. Also overridable via EAB profile (cahandler section); EAB profiling is applied at finalize so per-account settings take effect.
- Enrollment path cleanup: Certificate maps errors via _resolve_client_enrollment_error(); Order splits CSR enrollment into _enroll_certificate_for_order() / _map_csr_enrollment_result() and shares DRYRUN_ENROLLMENT_SKIPPED_DETAIL / ENROLLMENT_FAILED_DETAIL.
- JSON response formatting: WSGI and Django responses use indent=2 (Let’s Encrypt–style). Account-check workflow greps updated accordingly.