### PR TITLE
enable support for multiple handlers simultanously

### DIFF
--- a/acme_srv/certificate.py
+++ b/acme_srv/certificate.py
@@ -16,6 +16,7 @@ from acme_srv.helper import (
     cert_san_get,
     cert_serial_get,
     certid_asn1_get,
+    config_eab_profile_load,
     csr_san_get,
     csr_extensions_get,
     date_to_uts_utc,
@@ -29,6 +30,7 @@ from acme_srv.helper import (
     config_async_mode_load,
     config_dryrun_load,
 )
+from acme_srv.helpers.cahandler_registry import CAHandlerRegistry
 from acme_srv.db_handler import DBstore
 from acme_srv.message import Message
 from acme_srv.threadwithreturnvalue import ThreadWithReturnValue
@@ -283,6 +285,13 @@ class Certificate(object):
         self.err_msg_dic = error_dic_get(self.logger)
         self.hooks = None
         self.message = Message(self.debug, self.server_name, self.logger)
+
+        # Multi-handler support: registry resolves the handler class per
+        # enroll/revoke/poll; eab_handler_class is used to look up a per-kid
+        # cahandler_name selection directive when EAB profiling is active.
+        self.cahandler_registry = None
+        self.eab_handler_class = None
+        self.eab_profiling = False
 
         # Initialize the new architecture components with configuration
         self.certificate_manager = CertificateManager(
@@ -598,14 +607,27 @@ class Certificate(object):
         self.logger.debug("Certificate._load_configuration()")
         config_dic = load_config()
 
-        # load ca_handler according to configuration
-        ca_handler_module = ca_handler_load(self.logger, config_dic)
-
-        if ca_handler_module:
-            # store handler in variable
-            self.cahandler = ca_handler_module.CAhandler
+        # build the handler registry (single- or multi-handler mode)
+        self.cahandler_registry = CAHandlerRegistry(self.logger).load()
+        # store the default handler class for legacy callers and as a fallback
+        default_cls = self.cahandler_registry.default_handler()
+        if default_cls is not None:
+            self.cahandler = default_cls
         else:
-            self.logger.critical("No ca_handler loaded")
+            # fall back to the classical single-load path so existing behaviour
+            # (and error logs) are preserved when the registry could not load
+            ca_handler_module = ca_handler_load(self.logger, config_dic)
+            if ca_handler_module:
+                self.cahandler = ca_handler_module.CAhandler
+            else:
+                self.logger.critical("No ca_handler loaded")
+
+        # load EAB profiling so we can resolve a per-kid cahandler_name before
+        # a handler instance exists; the same classes are later attached to
+        # each handler instance by its own _config_load().
+        self.eab_profiling, self.eab_handler_class = config_eab_profile_load(
+            self.logger, config_dic
+        )
 
         # load hooks
         self._load_hooks_configuration(config_dic)
@@ -621,8 +643,47 @@ class Certificate(object):
             self.logger, config_dic
         )
 
-        self.logger.debug("ca_handler: %s", ca_handler_module)
+        self.logger.debug("ca_handler: %s", self.cahandler)
         self.logger.debug("Certificate._load_configuration() ended.")
+
+    def _resolve_cahandler(self, csr: str = None, revocation: bool = False):
+        """Resolve the CAhandler class for a single enroll/revoke/poll call.
+
+        In multi-handler mode the EAB kid's ``cahandler_name`` (looked up via
+        the EAB handler using the CSR or, for revocation, the cert) selects
+        the registered handler. Falls back to the registry default. Returns
+        the class (caller instantiates it as a context manager) or ``None``.
+        """
+        self.logger.debug("Certificate._resolve_cahandler()")
+        if self.cahandler_registry is None or not self.cahandler_registry.multi_handler:
+            return self.cahandler
+
+        cahandler_name = None
+        if self.eab_profiling and self.eab_handler_class is not None and csr:
+            try:
+                with self.eab_handler_class(self.logger) as eab_handler:
+                    if hasattr(eab_handler, "cahandler_name_get"):
+                        cahandler_name = eab_handler.cahandler_name_get(
+                            csr, revocation=revocation
+                        )
+            except Exception as err:
+                self.logger.warning(
+                    "Failed to look up cahandler_name via EAB handler: %s", err
+                )
+
+        handler_class = self.cahandler_registry.resolve(
+            cahandler_name=cahandler_name,
+            csr=csr,
+        )
+        if handler_class is None:
+            self.logger.error(
+                "Certificate._resolve_cahandler: no handler resolved "
+                "(cahandler_name=%s); falling back to default",
+                cahandler_name,
+            )
+            return self.cahandler
+        self.logger.debug("Certificate._resolve_cahandler() ended")
+        return handler_class
 
     def _load_and_validate_identifiers(
         self, identifier_dic: Dict[str, str], csr: str
@@ -746,7 +807,8 @@ class Certificate(object):
             self.logger.debug(
                 "Certificate._process_certificate_enrollment(): trigger enrollment"
             )
-            with self.cahandler(self.debug, self.logger) as ca_handler:
+            handler_class = self._resolve_cahandler(csr)
+            with handler_class(self.debug, self.logger) as ca_handler:
                 (
                     error,
                     certificate,
@@ -1682,7 +1744,10 @@ class Certificate(object):
 
             # Perform revocation
             rev_date = uts_to_date_utc(uts_now())
-            with self.cahandler(self.debug, self.logger) as ca_handler:
+            handler_class = self._resolve_cahandler(
+                csr=payload.get("certificate"), revocation=True
+            )
+            with handler_class(self.debug, self.logger) as ca_handler:
                 code, message, detail = ca_handler.revoke(
                     payload["certificate"], error, rev_date
                 )
@@ -1847,7 +1912,8 @@ class Certificate(object):
 
             # Poll certificate from CA handler
             try:
-                with self.cahandler(self.debug, self.logger) as ca_handler:
+                handler_class = self._resolve_cahandler(csr)
+                with handler_class(self.debug, self.logger) as ca_handler:
                     (
                         error,
                         certificate,

--- a/acme_srv/helper.py
+++ b/acme_srv/helper.py
@@ -126,6 +126,7 @@ from .helpers.config import (
     config_dns_server_list_load,
     config_dryrun_load,
     load_config,
+    load_config_section,
     header_info_jsonify,
     header_info_lookup,
     client_parameter_validate,

--- a/acme_srv/helpers/cahandler_registry.py
+++ b/acme_srv/helpers/cahandler_registry.py
@@ -1,0 +1,326 @@
+# -*- coding: utf-8 -*-
+"""CA handler registry for multi-handler mode.
+
+In multi-handler mode acme2certifier can serve several CA handlers from one
+instance. Selection precedence (highest first):
+
+1. EAB kid profile ``cahandler_name`` (sibling of the ``cahandler`` dict in the
+   kid keyfile entry, see docs/architecture/multi-cahandler-design.md).
+2. ``[Order] profile_cahandler`` map: order profile -> handler name.
+3. Domain-based auto-routing: the handler whose ``allowed_domainlist`` matches
+   all identifiers in the CSR (CN + DNS SANs) is selected. Each named handler
+   section may set ``allowed_domainlist`` (JSON list of regexes, same syntax as
+   the handler's own config) to participate in domain-based routing.
+4. ``[CAhandler] default_handler``.
+
+When ``multi_handler`` is absent or ``False`` the registry degrades to the
+classical single-handler behaviour and :py:meth:`resolve` always returns the
+default handler loaded from the global ``[CAhandler]`` section.
+
+Each named handler is configured in its own ``[CAhandler:<name>]`` section.
+Handler instances are tagged with ``config_section = "CAhandler:<name>"`` so
+they can read their own section via
+:py:func:`acme_srv.helpers.config.load_config_section`; the section's keys are
+also aliased under ``"CAhandler"`` so existing handler code keeps working
+without per-handler edits.
+"""
+
+import json
+import logging
+import re
+from typing import Dict, List, Optional
+
+from .config import load_config
+from .plugin_loader import ca_handler_load, ca_handler_load_by_file
+
+
+def _domain_matches(entry: str, patterns: List[str]) -> bool:
+    """Return True if ``entry`` matches any regex in ``patterns``.
+
+    Mirrors EABhandler._list_regex_check semantics: a pattern starting with
+    ``*.`` is treated as a suffix match (``*.`` -> ``.``).
+    """
+    if not entry or not patterns:
+        return False
+    for pattern in patterns:
+        regex = pattern
+        if regex.startswith("*."):
+            regex = regex.replace("*.", ".")
+        if re.search(regex, entry):
+            return True
+    return False
+
+
+class CAHandlerRegistry:
+    """Build and resolve CA handlers in single- or multi-handler mode."""
+
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+        self.multi_handler = False
+        self.default_name = None
+        # name -> {"module": <module>, "config_section": "CAhandler:<name>",
+        #           "allowed_domainlist": [<regex>, ...]}
+        self.handlers: Dict[str, Dict] = {}
+        # order profile -> handler name
+        self.profile_cahandler: Dict[str, str] = {}
+        # lazily-built default handler for single-handler mode
+        self._single_handler_class = None
+
+    # -- construction --------------------------------------------------------
+
+    def load(self) -> "CAHandlerRegistry":
+        """Parse acme_srv.cfg and populate the registry."""
+        self.logger.debug("CAHandlerRegistry.load()")
+        config_dic = load_config(self.logger)
+
+        if "CAhandler" not in config_dic:
+            self.logger.error("CAhandler configuration missing in config file")
+            return self
+
+        try:
+            self.multi_handler = config_dic.getboolean(
+                "CAhandler", "multi_handler", fallback=False
+            )
+        except Exception as err:
+            self.logger.warning("Failed to parse multi_handler: %s", err)
+            self.multi_handler = False
+
+        if not self.multi_handler:
+            # classical mode: load the single handler from [CAhandler]
+            module = ca_handler_load(self.logger, config_dic)
+            if module is not None:
+                self._single_handler_class = module.CAhandler
+            return self
+
+        self.default_name = config_dic.get("CAhandler", "default_handler", fallback=None)
+        if not self.default_name:
+            self.logger.error(
+                "multi_handler enabled but no default_handler configured"
+            )
+            return self
+
+        # profile_cahandler map (order profile -> handler name)
+        if "Order" in config_dic and "profile_cahandler" in config_dic["Order"]:
+            try:
+                self.profile_cahandler = json.loads(
+                    config_dic["Order"]["profile_cahandler"]
+                )
+            except Exception as err:
+                self.logger.warning("Failed to parse profile_cahandler: %s", err)
+
+        # load every [CAhandler:<name>] section
+        for section in config_dic.sections():
+            prefix = "CAhandler:"
+            if not section.startswith(prefix):
+                continue
+            name = section[len(prefix):]
+            handler_file = config_dic.get(section, "handler_file", fallback=None)
+            if not handler_file:
+                self.logger.error(
+                    "CAHandlerRegistry: [%s] has no handler_file; skipping",
+                    section,
+                )
+                continue
+            module = ca_handler_load_by_file(self.logger, handler_file)
+            if module is None:
+                self.logger.error(
+                    "CAHandlerRegistry: failed to load handler for [%s]; skipping",
+                    section,
+                )
+                continue
+            self.handlers[name] = {
+                "module": module,
+                "config_section": section,
+                "allowed_domainlist": self._allowed_domainlist_load(
+                    config_dic, section
+                ),
+            }
+            self.logger.debug(
+                "CAHandlerRegistry: registered handler '%s' -> %s (section %s, "
+                "allowed_domainlist=%s)",
+                name,
+                handler_file,
+                section,
+                self.handlers[name]["allowed_domainlist"],
+            )
+
+        if self.default_name not in self.handlers:
+            self.logger.error(
+                "CAHandlerRegistry: default_handler '%s' is not registered",
+                self.default_name,
+            )
+
+        self.logger.debug(
+            "CAHandlerRegistry.load() ended with %d handlers", len(self.handlers)
+        )
+        return self
+
+    def _allowed_domainlist_load(self, config_dic, section: str) -> List[str]:
+        """parse the ``allowed_domainlist`` JSON value from a handler section.
+
+        Returns an empty list when the key is absent (handler does not
+        participate in domain-based routing). Logs and returns [] on parse
+        errors so a malformed entry never silently matches everything.
+        """
+        if "allowed_domainlist" not in config_dic[section]:
+            return []
+        try:
+            return json.loads(config_dic.get(section, "allowed_domainlist"))
+        except Exception as err:
+            self.logger.warning(
+                "CAHandlerRegistry: failed to parse allowed_domainlist in [%s]: %s",
+                section,
+                err,
+            )
+            return []
+
+    # -- resolution ----------------------------------------------------------
+
+    def resolve(
+        self,
+        cahandler_name: Optional[str] = None,
+        order_profile: Optional[str] = None,
+        csr: Optional[str] = None,
+    ) -> Optional[type]:
+        """Return the CAhandler class to use for one enroll/revoke/poll.
+
+        Args:
+            cahandler_name: value of the EAB kid's ``cahandler_name`` field
+                (highest precedence). ``None`` if EAB profiling is inactive
+                or the kid has no ``cahandler_name``.
+            order_profile: profile string on the ACME order, looked up in the
+                ``profile_cahandler`` map.
+            csr: base64url CSR (as carried through the ACME flow). When set,
+                domain-based auto-routing applies: the handler whose
+                ``allowed_domainlist`` matches every identifier in the CSR
+                (CN + DNS SANs) is selected. This runs *after* cahandler_name
+                and order_profile, but before the default fallback, so an
+                explicit selector always wins and domain routing only picks
+                the handler when nothing else decided.
+
+        Returns the CAhandler class, or ``None`` if no handler could be
+        resolved (caller should treat this as a hard error).
+        """
+        self.logger.debug(
+            "CAHandlerRegistry.resolve(name=%s, profile=%s, csr=%s)",
+            cahandler_name,
+            order_profile,
+            bool(csr),
+        )
+
+        if not self.multi_handler:
+            return self._single_handler_class
+
+        name = None
+        if cahandler_name and cahandler_name in self.handlers:
+            name = cahandler_name
+        elif (
+            order_profile
+            and self.profile_cahandler
+            and order_profile in self.profile_cahandler
+            and self.profile_cahandler[order_profile] in self.handlers
+        ):
+            name = self.profile_cahandler[order_profile]
+        elif csr is not None:
+            name = self._resolve_by_csr(csr)
+
+        if name is None and self.default_name and self.default_name in self.handlers:
+            name = self.default_name
+
+        if name is None:
+            self.logger.error(
+                "CAHandlerRegistry.resolve: no handler matched "
+                "(cahandler_name=%s, order_profile=%s, default=%s)",
+                cahandler_name,
+                order_profile,
+                self.default_name,
+            )
+            return None
+
+        return self._bind(name)
+
+    def _resolve_by_csr(self, csr: str) -> Optional[str]:
+        """Pick a handler name by matching CSR identifiers against each
+        handler's ``allowed_domainlist``. Returns the handler name, or None if
+        no handler's domainlist matches all identifiers (caller falls back to
+        default). A handler with an empty allowed_domainlist never matches
+        here (it does not opt into domain routing).
+        """
+        self.logger.debug("CAHandlerRegistry._resolve_by_csr()")
+        # local import to avoid a circular dependency on acme_srv.helper at
+        # module import time (helper pulls in network/dns helpers)
+        from acme_srv.helper import csr_cn_get, csr_san_get  # pylint: disable=C0415
+
+        try:
+            identifiers = []
+            cn = csr_cn_get(self.logger, csr)
+            if cn:
+                identifiers.append(cn.lower())
+            for san in csr_san_get(self.logger, csr) or []:
+                # san entries look like "dns:foo.example.com"
+                try:
+                    san_type, san_value = san.lower().split(":", 1)
+                    if san_type == "dns":
+                        identifiers.append(san_value)
+                except ValueError:
+                    self.logger.debug(
+                        "CAHandlerRegistry._resolve_by_csr: skipping non-dns SAN %s",
+                        san,
+                    )
+        except Exception as err:
+            self.logger.warning(
+                "CAHandlerRegistry._resolve_by_csr: failed to parse CSR: %s", err
+            )
+            return None
+
+        if not identifiers:
+            self.logger.debug(
+                "CAHandlerRegistry._resolve_by_csr: no DNS identifiers in CSR"
+            )
+            return None
+
+        # A handler matches when *every* identifier matches its allowed list.
+        # The first matching handler wins; ordering follows dict insertion
+        # (i.e. the order sections appear in acme_srv.cfg).
+        for name, entry in self.handlers.items():
+            patterns = entry.get("allowed_domainlist") or []
+            if not patterns:
+                continue
+            if all(_domain_matches(i, patterns) for i in identifiers):
+                self.logger.debug(
+                    "CAHandlerRegistry._resolve_by_csr: identifiers %s matched "
+                    "handler '%s' (allowed_domainlist=%s)",
+                    identifiers,
+                    name,
+                    patterns,
+                )
+                return name
+
+        self.logger.debug(
+            "CAHandlerRegistry._resolve_by_csr: no handler matched identifiers %s",
+            identifiers,
+        )
+        return None
+
+    def _bind(self, name: str) -> Optional[type]:
+        """tag the named handler's class with its config_section and return it."""
+        entry = self.handlers[name]
+        handler_class = entry["module"].CAhandler
+        # tag the class with the config section so instances read the right
+        # [CAhandler:<name>] section in their _config_load()
+        handler_class.config_section = entry["config_section"]
+        self.logger.debug(
+            "CAHandlerRegistry.resolve() -> handler '%s' (section %s)",
+            name,
+            entry["config_section"],
+        )
+        return handler_class
+
+    # -- convenience ---------------------------------------------------------
+
+    def default_handler(self) -> Optional[type]:
+        """Return the default handler class (for directory/trigger/renewalinfo
+        operations that are not tied to a specific order)."""
+        if not self.multi_handler:
+            return self._single_handler_class
+        return self.resolve(cahandler_name=self.default_name)

--- a/acme_srv/helpers/config.py
+++ b/acme_srv/helpers/config.py
@@ -313,6 +313,44 @@ def load_config(
     return config
 
 
+def load_config_section(
+    logger: logging.Logger = None, section: str = "CAhandler"
+) -> configparser.ConfigParser:
+    """load the config file and expose the named handler section as "CAhandler".
+
+    In multi-handler mode each handler instance reads its own
+    ``[CAhandler:<name>]`` section, but existing handler code addresses the
+    section by the literal ``"CAhandler"``. To avoid editing every config read
+    in every handler this helper returns a ConfigParser where the keys of the
+    requested ``section`` are also reachable under the ``"CAhandler"`` alias.
+
+    Falls back to the classical ``"CAhandler"`` section when ``section`` is
+    ``"CAhandler"`` (single-handler mode) or when the named section is absent
+    in the config file, preserving full backwards compatibility.
+    """
+    logger.debug("load_config_section(%s)", section)
+    config = load_config(logger)
+
+    if section == "CAhandler":
+        return config
+
+    if not config.has_section(section):
+        logger.debug(
+            "load_config_section: section %s missing, falling back to CAhandler",
+            section,
+        )
+        return config
+
+    # alias: copy the named section's keys under "CAhandler" so that handlers'
+    # existing ``config_dic["CAhandler"]`` reads keep working unchanged.
+    if not config.has_section("CAhandler"):
+        config.add_section("CAhandler")
+    for key, value in config.items(section, raw=True):
+        if not config.has_option("CAhandler", key):
+            config.set("CAhandler", key, value)
+    return config
+
+
 def header_info_jsonify(logger: logging.Logger, header_info: str) -> Dict[str, str]:
     """jsonify header info"""
     logger.debug("Helper.header_info_json_parse()")

--- a/acme_srv/helpers/plugin_loader.py
+++ b/acme_srv/helpers/plugin_loader.py
@@ -18,18 +18,11 @@ def ca_handler_load(
         return None
 
     if "handler_file" in config_dic["CAhandler"]:
-        # try to load handler from file
-        try:
-            spec = importlib.util.spec_from_file_location(
-                "CAhandler", config_dic["CAhandler"]["handler_file"]
-            )
-            ca_handler_module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(ca_handler_module)
+        ca_handler_module = ca_handler_load_by_file(
+            logger, config_dic["CAhandler"]["handler_file"]
+        )
+        if ca_handler_module is not None:
             return ca_handler_module
-        except Exception as err_:
-            logger.critical(
-                "Loading CAhandler configured in cfg failed with err: %s", err_
-            )
 
     # if no 'handler_file' provided or loading was unsuccessful, try to load default handler
     try:
@@ -39,6 +32,28 @@ def ca_handler_load(
         ca_handler_module = None
 
     return ca_handler_module
+
+
+def ca_handler_load_by_file(
+    logger: logging.Logger, handler_file: str
+) -> importlib.import_module:
+    """load a ca_handler module from an arbitrary file path.
+
+    Used by the multi-handler registry to load each named handler module
+    independently of the global ``[CAhandler]`` section. Returns the loaded
+    module on success or ``None`` on failure (so callers can fall back).
+    """
+    logger.debug("Helper.ca_handler_load_by_file(%s)", handler_file)
+    try:
+        spec = importlib.util.spec_from_file_location("CAhandler", handler_file)
+        ca_handler_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(ca_handler_module)
+        return ca_handler_module
+    except Exception as err_:
+        logger.critical(
+            "Loading CAhandler from %s failed with err: %s", handler_file, err_
+        )
+        return None
 
 
 def eab_handler_load(

--- a/examples/ca_handler/acme_ca_handler.py
+++ b/examples/ca_handler/acme_ca_handler.py
@@ -36,6 +36,7 @@ from acme_srv.helper import (
     eab_profile_revocation_check,
     enrollment_config_log,
     load_config,
+    load_config_section,
     parse_url,
     url_get,
     sha256_hash,
@@ -48,6 +49,12 @@ from acme_srv.helper import (
 
 class CAhandler(object):
     """EST CA  handler"""
+
+    # config section to read; set by CAHandlerRegistry in multi-handler mode
+    # (on the class), defaults to the classical "CAhandler" section otherwise.
+    # Kept as a class attribute so the registry's per-handler override is not
+    # clobbered by __init__ setting an instance attribute.
+    config_section = "CAhandler"
 
     def __init__(self, _debug: bool = False, logger: object = None):
         self.logger = logger
@@ -222,7 +229,7 @@ class CAhandler(object):
     def _config_load(self):
         """ " load config from file"""
         self.logger.debug("CAhandler._config_load()")
-        config_dic = load_config()
+        config_dic = load_config_section(self.logger, self.config_section)
         if "CAhandler" in config_dic:
 
             # load account configuration and paramters

--- a/examples/ca_handler/openssl_ca_handler.py
+++ b/examples/ca_handler/openssl_ca_handler.py
@@ -25,6 +25,7 @@ from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 # pylint: disable=e0401
 from acme_srv.helper import (
     load_config,
+    load_config_section,
     build_pem_file,
     uts_now,
     uts_to_date_utc,
@@ -41,6 +42,12 @@ BLOCK_ALL_DOMAIN = "block.all"
 
 class CAhandler(object):
     """CA  handler"""
+
+    # config section to read; set by CAHandlerRegistry in multi-handler mode
+    # (on the class), defaults to the classical "CAhandler" section otherwise.
+    # Kept as a class attribute so the registry's per-handler override is not
+    # clobbered by __init__ setting an instance attribute.
+    config_section = "CAhandler"
 
     def __init__(self, debug: bool = False, logger: object = None):
         self.debug = debug
@@ -486,7 +493,7 @@ class CAhandler(object):
     def _config_load(self):
         """ " load config from file"""
         self.logger.debug("CAhandler._config_load()")
-        config_dic = load_config(self.logger, "CAhandler")
+        config_dic = load_config_section(self.logger, self.config_section)
 
         # load credentials
         self._config_credentials_load(config_dic)

--- a/examples/eab_handler/kid_profile_handler.py
+++ b/examples/eab_handler/kid_profile_handler.py
@@ -205,6 +205,29 @@ class EABhandler(object):
         )
         return profile_dic
 
+    def cahandler_name_get(self, csr: str, revocation=False) -> str:
+        """return the per-kid ``cahandler_name`` selection directive, or None.
+
+        ``cahandler_name`` is a sibling of the ``cahandler`` dict in the kid
+        keyfile entry and selects which registered handler (see
+        CAHandlerRegistry) serves this enrollment. It is deliberately *not*
+        part of the ``cahandler`` dict so the existing eab-profiling setattr
+        loop does not treat it as a handler attribute.
+        """
+        self.logger.debug("EABhandler.cahandler_name_get()")
+        name = None
+        profiles_dic = self.key_file_load()
+        eab_kid = self.eab_kid_get(csr, revocation=revocation)
+        if (
+            profiles_dic
+            and eab_kid
+            and eab_kid in profiles_dic
+            and "cahandler_name" in profiles_dic[eab_kid]
+        ):
+            name = profiles_dic[eab_kid]["cahandler_name"]
+        self.logger.debug("EABhandler.cahandler_name_get() ended with: %s", name)
+        return name
+
     def keyfile_content_load(self, key_file_content) -> dict:
         """load profiles from key_file"""
         self.logger.debug("EABhandler.keyfile_content_load()")

--- a/test/test_acme_ca_handler.py
+++ b/test/test_acme_ca_handler.py
@@ -59,7 +59,7 @@ class TestACMEHandler(unittest.TestCase):
         """exit"""
         self.assertFalse(self.cahandler.__exit__())
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_018__config_load(self, mock_load_cfg):
         """test _config_load default configparser object"""
         parser = configparser.ConfigParser()
@@ -81,7 +81,7 @@ class TestACMEHandler(unittest.TestCase):
         )
         self.assertFalse(self.cahandler.acme_keypath)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_019__config_load(self, mock_load_cfg):
         """test _config_load empty cahandler section"""
         parser = configparser.ConfigParser()
@@ -109,7 +109,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_020__config_load(self, mock_load_cfg):
         """test _config_load unknown values"""
         parser = configparser.ConfigParser()
@@ -137,7 +137,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_021__config_load(self, mock_load_cfg):
         """test _config_load key_file value"""
         parser = configparser.ConfigParser()
@@ -161,7 +161,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_022__config_load(self, mock_load_cfg):
         """test _config_load key_file value"""
         parser = configparser.ConfigParser()
@@ -188,7 +188,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual("acme_keypath", self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_023__config_load(self, mock_load_cfg):
         """test _config_load url value"""
         parser = configparser.ConfigParser()
@@ -212,7 +212,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_024__config_load(self, mock_load_cfg):
         """test _config_load account values"""
         parser = configparser.ConfigParser()
@@ -240,7 +240,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_025__config_load(self, mock_load_cfg):
         """test _config_load key_size"""
         parser = configparser.ConfigParser()
@@ -268,7 +268,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_026__config_load(self, mock_load_cfg):
         """test _config_load email"""
         parser = configparser.ConfigParser()
@@ -296,7 +296,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_027__config_load(self, mock_load_cfg):
         """test _config_load email"""
         parser = configparser.ConfigParser()
@@ -324,7 +324,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_028__config_load(self, mock_load_cfg):
         """test _config_load email"""
         parser = configparser.ConfigParser()
@@ -352,7 +352,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_029__config_load(self, mock_load_cfg):
         """test _config_load allowlist"""
         parser = configparser.ConfigParser()
@@ -380,7 +380,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_030__config_load(self, mock_load_cfg):
         """test _config_load allowlist - failed json parse"""
         parser = configparser.ConfigParser()
@@ -408,7 +408,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_031__config_load(self, mock_load_cfg):
         """test _config_load allowlist - failed json parse"""
         parser = configparser.ConfigParser()
@@ -436,7 +436,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertFalse(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_032__config_load(self, mock_load_cfg):
         """test _config_load allowlist - failed json parse"""
         parser = configparser.ConfigParser()
@@ -465,7 +465,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_033__config_load(self, mock_load_cfg):
         """test _config_load allowlist - failed json parse"""
         parser = configparser.ConfigParser()
@@ -498,7 +498,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_034__config_load(self, mock_load_cfg):
         """test _config_load allowlist - failed json parse"""
         parser = configparser.ConfigParser()
@@ -528,7 +528,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertFalse(self.cahandler.acme_keypath)
         self.assertTrue(self.cahandler.ssl_verify)
 
-    @patch("examples.ca_handler.acme_ca_handler.load_config")
+    @patch("examples.ca_handler.acme_ca_handler.load_config_section")
     def test_035__config_load(self, mock_load_cfg):
         """test _config_load allowlist - failed json parse"""
         parser = configparser.ConfigParser()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -2710,7 +2710,7 @@ klGUNHG98CtsmlhrivhSTJWqSIOfyKGF
         with self.assertLogs("test_a2c", level="INFO") as lcm:
             self.assertEqual("foo", self.ca_handler_load(self.logger, config_dic))
         self.assertIn(
-            "CRITICAL:test_a2c:Loading CAhandler configured in cfg failed with err: exc_mock_util",
+            "CRITICAL:test_a2c:Loading CAhandler from foo failed with err: exc_mock_util",
             lcm.output,
         )
 

--- a/test/test_openssl_ca_handler.py
+++ b/test/test_openssl_ca_handler.py
@@ -784,7 +784,7 @@ class TestACMEHandler(unittest.TestCase):
             self.cahandler._certificate_store(cert)
         self.assertIn("DEBUG:test_a2c:Convert serial to hex: 42: 2A", lcm.output)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_075__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -793,7 +793,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertFalse(self.cahandler.save_cert_as_hex)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_076__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -803,7 +803,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertTrue(self.cahandler.save_cert_as_hex)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_077__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -814,7 +814,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual("blocked_domainlist", self.cahandler.blocked_domainlist)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_078__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -830,7 +830,7 @@ class TestACMEHandler(unittest.TestCase):
         )
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_079__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -846,7 +846,7 @@ class TestACMEHandler(unittest.TestCase):
         )
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_080__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -856,7 +856,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual("allowed_domainlist", self.cahandler.allowed_domainlist)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_081__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -866,7 +866,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(["*.bar.local"], self.cahandler.allowed_domainlist)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_082__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -881,7 +881,7 @@ class TestACMEHandler(unittest.TestCase):
         )
         self.assertEqual(["block.all"], self.cahandler.allowed_domainlist)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_083__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -891,7 +891,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(["*.bar.local"], self.cahandler.blocked_domainlist)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_084__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -906,7 +906,7 @@ class TestACMEHandler(unittest.TestCase):
         )
         self.assertEqual(["block.all"], self.cahandler.allowed_domainlist)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_085__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -916,7 +916,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(["*.bar.local"], self.cahandler.allowed_domainlist)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_086__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -931,7 +931,7 @@ class TestACMEHandler(unittest.TestCase):
         )
         self.assertEqual(["block.all"], self.cahandler.allowed_domainlist)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_087__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -941,7 +941,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(["*.bar.local"], self.cahandler.blocked_domainlist)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_088__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -957,7 +957,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(["block.all"], self.cahandler.allowed_domainlist)
 
     @patch("json.loads")
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_089__config_load(self, mock_load_cfg, mock_jl):
         """config load"""
         parser = configparser.ConfigParser()
@@ -967,7 +967,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual("openssl_conf", self.cahandler.openssl_conf)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_090__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -976,7 +976,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual("issuing_ca_key", self.cahandler.issuer_dict["issuing_ca_key"])
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_091__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -987,7 +987,7 @@ class TestACMEHandler(unittest.TestCase):
             "issuing_ca_cert", self.cahandler.issuer_dict["issuing_ca_cert"]
         )
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_092__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -998,7 +998,7 @@ class TestACMEHandler(unittest.TestCase):
             b"issuing_ca_key_passphrase", self.cahandler.issuer_dict["passphrase"]
         )
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_093__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -1007,7 +1007,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual(10, self.cahandler.cert_validity_days)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_094__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -1016,7 +1016,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual("cert_save_path", self.cahandler.cert_save_path)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_095__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -1025,7 +1025,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual(["root_ca"], self.cahandler.ca_cert_chain_list)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_096__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -1034,7 +1034,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertEqual(["root_ca", "sub_ca"], self.cahandler.ca_cert_chain_list)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_097__config_load(self, mock_load_cfg):
         """config load"""
         parser = configparser.ConfigParser()
@@ -1044,7 +1044,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual("issuing_ca_crl", self.cahandler.issuer_dict["issuing_ca_crl"])
 
     @patch.dict("os.environ", {"foo": "foo_var"})
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_098_config_load(self, mock_load_cfg):
         """test _config_load - load template with passphrase variable"""
         parser = configparser.ConfigParser()
@@ -1054,7 +1054,7 @@ class TestACMEHandler(unittest.TestCase):
         self.assertEqual(b"foo_var", self.cahandler.issuer_dict["passphrase"])
 
     @patch.dict("os.environ", {"foo": "foo_var"})
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_099_config_load(self, mock_load_cfg):
         """test _config_load - load template passpharese variable configured but does not exist"""
         parser = configparser.ConfigParser()
@@ -1068,7 +1068,7 @@ class TestACMEHandler(unittest.TestCase):
         )
 
     @patch.dict("os.environ", {"foo": "foo_var"})
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_100_config_load(self, mock_load_cfg):
         """test _config_load - load template with passphrase variable  - overwritten bei cfg file"""
         parser = configparser.ConfigParser()
@@ -1085,7 +1085,7 @@ class TestACMEHandler(unittest.TestCase):
             lcm.output,
         )
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_101__config_load(self, mock_load_cfg):
         """config load no cn_enforce"""
         parser = configparser.ConfigParser()
@@ -1094,7 +1094,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertFalse(self.cahandler.cn_enforce)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_102__config_load(self, mock_load_cfg):
         """config load cn_enforce True"""
         parser = configparser.ConfigParser()
@@ -1103,7 +1103,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertTrue(self.cahandler.cn_enforce)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_103__config_load(self, mock_load_cfg):
         """config load cn_enforce True"""
         parser = configparser.ConfigParser()
@@ -1112,7 +1112,7 @@ class TestACMEHandler(unittest.TestCase):
         self.cahandler._config_load()
         self.assertFalse(self.cahandler.cn_enforce)
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_104__config_load(self, mock_load_cfg):
         """config load cn_enforce True"""
         parser = configparser.ConfigParser()
@@ -1126,7 +1126,7 @@ class TestACMEHandler(unittest.TestCase):
             lcm.output,
         )
 
-    @patch("examples.ca_handler.openssl_ca_handler.load_config")
+    @patch("examples.ca_handler.openssl_ca_handler.load_config_section")
     def test_105__config_load(self, mock_load_cfg):
         """config load cn_enforce True"""
         parser = configparser.ConfigParser()

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -431,7 +431,7 @@ class TestACMEHandler(unittest.TestCase):
         with self.assertLogs("test_a2c", level="INFO") as lcm:
             self.trigger._config_load()
         self.assertIn(
-            "CRITICAL:test_a2c:Loading CAhandler configured in cfg failed with err: 'NoneType' object has no attribute 'loader'",
+            "CRITICAL:test_a2c:Loading CAhandler from foo failed with err: 'NoneType' object has no attribute 'loader'",
             lcm.output,
         )
 


### PR DESCRIPTION
Not sure, whether you're interested in this (if so: It will probably need some more work - currently it's more a PoC for my own setup):
With this PR, one can configure multiple handlers for different domains. E.g. I have a domain which can be forwarded to letsencrypt (converting all challenges to dns challenges), and others which cannot and are signed by a local CA via openssl.

N.B: This is fully AI-generated currently. So do not bother to read every line before I did. I'm mainly interested in whether this would be something, that you would be willing to merge in general or not.