### PR TITLE
[min-devel] bump to  v0.44

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,22 @@ This is a high-level summary of the most important changes. For a full list of
 changes, see the [git commit log](https://github.com/grindsa/acme2certifier/commits)
 and pick the appropriate release branch.
 
+## Changes in 0.44
+
+**Features and Improvements**:
+
+- Option `ca_error_details_forward` allowing to pass error messages from CA to acme-client
+- Align account deactivation responses with the relevant RFC requirements
+- Harmonize the formatting of JSON responses across project
+
+**Bug Fixes**:
+
+- [#345 Add missing functions for nonce cleanup to django handler](https://github.com/grindsa/acme2certifier/issues/345)
+- Align the dry‑run messages between the Certificate and Order classes
+- Raise an exception when a database error occurs during Authorization creation
+- Skip prevalidation when identifier value is missing in \_apply_prevalidation_whitelist()
+- Cover JSON parsing errors in compare_jwk()
+
 ## Changes in 0.43.2
 
 **Bug Fixes**:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,9 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.42.x  | :white_check_mark: |
-| 0.41.x  | :white_check_mark: |
-| \< 0.41 | :x:  |
+| 0.44.x  | :white_check_mark: |
+| 0.43.x  | :white_check_mark: |
+| \< 0.43 | :x:  |
 
 ## Reporting a Vulnerability
 

--- a/acme_srv/authorization.py
+++ b/acme_srv/authorization.py
@@ -814,14 +814,12 @@ class Authorization(object):
             id_type,
             id_value,
         )
+        if not id_value:
+            return
         if (
-            id_value
-            and (
-                (id_type == "dns" and self.config.email_identifier_rewrite)
-                or id_type == "email"
-            )
-            and "@" in id_value
-        ):
+            (id_type == "dns" and self.config.email_identifier_rewrite)
+            or id_type == "email"
+        ) and "@" in id_value:
             self._handle_email_prevalidation(
                 authz_name, auth_details, id_value, authz_info
             )

--- a/acme_srv/challenge_validators/email_reply_validator.py
+++ b/acme_srv/challenge_validators/email_reply_validator.py
@@ -4,8 +4,7 @@ Email Reply Challenge Validator.
 Implements validation logic for email-reply-00 challenges.
 """
 
-from typing import Tuple
-import re
+from typing import Optional, Tuple
 from .base import ChallengeValidator, ChallengeContext, ValidationResult
 from acme_srv.helper import b64_url_encode, convert_byte_to_string, sha256_hash
 
@@ -113,19 +112,19 @@ class EmailReplyChallengeValidator(ChallengeValidator):
             )
             return None
 
-    def _extract_email_keyauth(self, email_body: str) -> str:
-        """Extract keyauthorization from email body - placeholder for actual implementation."""
+    def _extract_email_keyauth(self, email_body: Optional[str]) -> Optional[str]:
+        """Extract keyauthorization from email body between PEM-style delimiters."""
         self.logger.debug("EmailReplyChallengeValidator._extract_email_keyauth()")
+        begin = "-----BEGIN ACME RESPONSE-----"
+        end = "-----END ACME RESPONSE-----"
         email_keyauthorization = None
         if email_body:
-            # extract keyauthorization from email body
-            match = re.search(
-                r"-+BEGIN ACME RESPONSE-+\s*([\w=+/ -]+)\s*-+END ACME RESPONSE-+",
-                email_body,
-                re.DOTALL,
-            )
-            if match:
-                email_keyauthorization = match.group(1).strip()
+            start = email_body.find(begin)
+            if start >= 0:
+                start += len(begin)
+                stop = email_body.find(end, start)
+                if stop >= 0:
+                    email_keyauthorization = email_body[start:stop].strip() or None
 
         self.logger.debug(
             "Challenge._emailchallenge_keyauth_extract() ended with: %s",

--- a/acme_srv/helpers/validation.py
+++ b/acme_srv/helpers/validation.py
@@ -47,7 +47,10 @@ def validate_email(logger: logging.Logger, contact_list: List[str]) -> bool:
     """validate contact against RFC608"""
     logger.debug("Helper.validate_email()")
     result = True
-    pattern = r"^[A-Za-z0-9\.\+_-]+@[A-Za-z]+[A-Za-z0-9\._-]+[A-Za-z0-9]+\.[a-zA-Z\.]+[a-zA-Z]+$"
+    pattern = (
+        r"^[A-Za-z0-9.+_-]+@[A-Za-z][A-Za-z0-9._-]+[A-Za-z0-9]"
+        r"\.[A-Za-z]+(?:\.[A-Za-z]+)*$"
+    )
     # check if we got a list or single address
     if isinstance(contact_list, list):
         for contact in contact_list:

--- a/acme_srv/version.py
+++ b/acme_srv/version.py
@@ -4,5 +4,5 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = "0.43.2"
+__version__ = "0.44"
 __dbversion__ = "0.41"

--- a/docs/external_database_support.md
+++ b/docs/external_database_support.md
@@ -6,9 +6,11 @@
 
 Acme2certifier supports external databases by using the [Django Python framework](https://www.djangoproject.com/). The default SQLite backend is not designed to handle concurrent write access, which can easily occur in an environment with a high transaction frequency.
 
-All [databases supported by Django](https://docs.djangoproject.com/en/5.0/ref/databases/) should work in theory; MariaDB and PostgreSQL will be tested during [release regression](https://github.com/grindsa/acme2certifier/blob/master/.github/workflows/django_tests..yml).
+All [databases supported by Django](https://docs.djangoproject.com/en/5.0/ref/databases/) should work in principle; MariaDB and PostgreSQL will be tested during [release regression](https://github.com/grindsa/acme2certifier/blob/master/.github/workflows/django_tests.yml).
 
-This guide is written for **Ubuntu 24.04**; however, adapting it to other Linux distributions should not be difficult.
+The following documentation explains how to configure Django-based database access depending on your installation method.
+
+This guide focuses on Docker and **Ubuntu 24.04**-based deb deployments; however, adapting it to other Linux distributions should not be difficult.
 
 ## Preparation
 
@@ -19,10 +21,10 @@ The steps below assume that MariaDB is already installed and running on your sys
 - Open the MySQL command-line client:
 
 ```bash
-sudo mysql -u  root
+sudo mysql -u root
 ```
 
-- create the acme2certifier database and database user
+- Create the acme2certifier database and database user:
 
 ```SQL
 CREATE DATABASE acme2certifier CHARACTER SET UTF8;
@@ -36,7 +38,7 @@ FLUSH PRIVILEGES;
 apt-get install python3-django python3-mysqldb python3-pymysql
 ```
 
-### When using PostgreSQL
+### When Using PostgreSQL
 
 It is assumed that PostgreSQL is already installed and running.
 
@@ -60,21 +62,21 @@ GRANT USAGE ON schema public TO acme2certifier;
 GRANT postgres TO acme2certifier;
 ```
 
-- Install missing python modules
+- Install missing Python modules:
 
 ```bash
 sudo apt-get install python3-django python3-psycopg2
 ```
 
-### When using SQL Server
+### When Using SQL Server
 
-_SQL Server support has not been tested in the [release regression](https://github.com/grindsa/acme2certifier/actions/workflows/django_tests..yml) to the same extent as the other two databases._
+_SQL Server support has not been tested in the [release regression](https://github.com/grindsa/acme2certifier/actions/workflows/django_tests.yml) to the same extent as the other two databases._
 
 Note that this part of the guide is written for **Red Hat Enterprise Linux 9**.
 
 It is assumed that SQL Server is already installed and running.
 
-Open SQL Server Management Studio.
+- Open SQL Server Management Studio.
 
 - Create the acme2certifier database and database user:
 
@@ -84,9 +86,9 @@ CREATE LOGIN acme2certifier WITH PASSWORD = 'a2c+passwd';
 CREATE USER acme2certifier FOR LOGIN acme2certifier;
 ```
 
-- From Object Explorer, open acme2certifier, Security, Logins, acme2certifier Properties. Then, from User Mapping, map the user to the database and give necessary roles. From Server Roles, give public and sysadmin roles. In essence, grant all access to the database for the acme2certifier user.
+- From Object Explorer, open acme2certifier → Security → Logins → acme2certifier Properties. Under User Mapping, map the user to the database and grant the required roles. Under Server Roles, grant `public` and `sysadmin` as needed so the acme2certifier user has full access to the database.
 
-- Install missing python modules
+- Install missing Python modules:
 
 ```bash
 pip install mssql-django pyodbc
@@ -97,6 +99,8 @@ sudo dnf install unixODBC
 
 ## Install and Configure acme2certifier
 
+### Debian-based deployment
+
 - Download the [latest deb package](https://github.com/grindsa/acme2certifier/releases)
 - Install the package locally
 
@@ -104,7 +108,7 @@ sudo dnf install unixODBC
 sudo apt-get install -y ./acme2certifier_<version>-1_all.deb
 ```
 
-- Copy and activate Apache2 configuration file
+- Copy and activate the Apache2 configuration file:
 
 ```bash
 sudo cp /var/www/acme2certifier/examples/apache2/apache_django.conf /etc/apache2/sites-available/acme2certifier.conf
@@ -146,15 +150,27 @@ python3 -c "import secrets; print(secrets.token_urlsafe(50))"
 ```
 
 - Modify `/var/www/acme2certifier/acme2certifier/settings.py` and:
-  - Insert the secret-key created in the previous step
-  - Update the 'ALLOWED_HOSTS'- section with both ip-address and fqdn of the node
-  - Configure a connection to mariadb as shown below
+  - Insert the secret key created in the previous step
+  - Update the `ALLOWED_HOSTS` section with both the IP address and FQDN of the node
+  - Configure a connection to MariaDB as shown below
 
 ```python
 SECRET_KEY = "+%*lei)yj9b841=2d5(u)a&7*uwi@l99$(*&ong@g*p1%q)g$e"
 ALLOWED_HOSTS = ["192.168.14.132", "ub2204-c1.bar.local"]
 (...)
 ```
+
+### Docker Deployments (apache2-django / nginx-django)
+
+**No manual file copying is required.**
+
+The official Docker images already contain:
+
+- the Django project under `/var/www/acme2certifier/acme2certifier/`
+- a ready-made Django settings file (`/var/www/acme2certifier/acme2certifier/settings.py`) to be updated
+- the Django database handler at `/var/www/acme2certifier/acme_srv/db_handler.py`
+
+Mount a volume or directory from the Docker host into `/var/www/acme2certifier/volume`. When this volume is present, acme2certifier automatically writes `settings.py`, `acme_srv.cfg`, and all Django migration sets into it and maps them back to the appropriate internal locations during container startup.
 
 ### Connecting to MariaDB
 
@@ -177,7 +193,7 @@ DATABASES = {
 }
 ```
 
-### Connecting to PostGres
+### Connecting to PostgreSQL
 
 - Modify `/var/www/acme2certifier/acme2certifier/settings.py` and configure your database connection as below:
 
@@ -214,9 +230,9 @@ DATABASES = {
 
 - You may also need to disable some SELinux settings for Apache, depending on your server configuration.
 
-## Finalize acme2cerifier configuration
+## Finalize acme2certifier configuration
 
-- Create a Django migration set, apply the migrations, and load fixtures: Modify the [configuration file](acme_srv.md) `/var/www/acme2certifier/volume/acme_srv.cfg`according to your needs. If your CA handler needs runtime information (configuration files, keys, certificate bundles, etc.) to be shared between the nodes, ensure they are loaded from `/var/www/acme2certifier/volume`. Below is an example for the `[CAhandler]` section of the openssl-handler I use during my tests:
+- Modify the [configuration file](acme_srv.md) `/var/www/acme2certifier/volume/acme_srv.cfg` according to your needs. If your CA handler needs runtime information (configuration files, keys, certificate bundles, etc.) to be shared between (cluster) nodes, ensure they are loaded from `/var/www/acme2certifier/volume`. Below is an example `[CAhandler]` section for the OpenSSL handler:
 
 ```cfg
 [CAhandler]
@@ -248,13 +264,15 @@ sudo python3 manage.py loaddata acme_srv/fixture/status.yaml
 sudo python3 /var/www/acme2certifier/tools/django_update.py
 ```
 
-- Restart the apache2 service
+- Restart the Apache2 service:
 
 ```bash
 sudo systemctl restart apache2.service
 ```
 
-- Test the server by accessing the directory resource
+## Test enrollment
+
+- Test the server by accessing the directory resource:
 
 ```bash
 curl http://ub2204-c1.bar.local/directory
@@ -264,9 +282,7 @@ curl http://ub2204-c1.bar.local/directory
 {"newAccount": "http://ub2204-c1.bar.local/acme_srv/newaccount", "fa8b347d3849421ebc4b234205418805": "https://community.letsencrypt.org/t/adding-random-entries-to-the-directory/33417", "keyChange": "http://ub2204-c1.bar.local/acme_srv/key-change", "newNonce": "http://ub2204-c1.bar.local/acme_srv/newnonce", "meta": {"home": "https://github.com/grindsa/acme2certifier", "author": "grindsa <grindelsack@gmail.com>"}, "newOrder": "http://ub2204-c1.bar.local/acme_srv/neworders", "revokeCert": "http://ub2204-c1.bar.local/acme_srv/revokecert"}
 ```
 
-## Test enrollment
-
-- Try to enroll certificates by using your favorite ACME client. I am using [lego](https://github.com/go-acme/lego).
+- Try to enroll certificates by using your favorite ACME client. This example uses [lego](https://github.com/go-acme/lego).
 
 ```bash
  docker run -i -p 80:80 -v $PWD/lego:/.lego/ --rm --name lego --network acme goacme/lego run --tls-skip-verify -s https://ub2204-c1.bar.local -a --email "lego@example.com" -d lego01.bar.local --http

--- a/test/test_authorization.py
+++ b/test/test_authorization.py
@@ -1991,24 +1991,21 @@ class TestAuthorization(unittest.TestCase):
         domain_utils.is_domain_whitelisted = orig_is_domain_whitelisted
 
     def test_087b_apply_prevalidation_whitelist_missing_id_value(self):
-        """Test _apply_prevalidation_whitelist skips email branch when id_value is None."""
+        """Test _apply_prevalidation_whitelist skips all branches when id_value is None."""
         self.authorization.config.email_identifier_rewrite = True
         self.authorization.config.prevalidated_emaillist = ["user@example.com"]
+        self.authorization.config.prevalidated_domainlist = ["*"]
+        self.authorization.config.prevalidated_iplist = ["0.0.0.0/0"]
         self.authorization.repository = Mock()
 
-        authz_info = {"status": "pending"}
-        self.authorization._apply_prevalidation_whitelist(
-            "authz1", {}, "email", None, authz_info
-        )
-
-        self.assertEqual(authz_info["status"], "pending")
-        self.authorization.repository.mark_authorization_as_valid.assert_not_called()
-
-        self.authorization._apply_prevalidation_whitelist(
-            "authz2", {}, "dns", None, {"status": "pending"}
-        )
-
-        self.authorization.repository.mark_authorization_as_valid.assert_not_called()
+        for id_type in ("email", "dns", "ip"):
+            authz_info = {"status": "pending"}
+            self.authorization._apply_prevalidation_whitelist(
+                f"authz_{id_type}", {"order__name": "order_1"}, id_type, None, authz_info
+            )
+            self.assertEqual(authz_info["status"], "pending")
+            self.authorization.repository.mark_authorization_as_valid.assert_not_called()
+            self.authorization.repository.mark_order_as_ready.assert_not_called()
 
     def test_088_handle_domain_prevalidation_wildcard_identifier_matches_policy(self):
         """Wildcard identifiers normalized to base domain should still match wildcard whitelist entries."""

--- a/test/test_challenge_validators.py
+++ b/test/test_challenge_validators.py
@@ -1686,7 +1686,7 @@ class TestEmailReplyChallengeValidator(unittest.TestCase):
         self.assertEqual(result, "test_keyauth_value")
 
     def test_012_extract_email_keyauth_multiline_response(self):
-        """Test _extract_email_keyauth with multiline response - current limitation"""
+        """Test _extract_email_keyauth with multiline response"""
         email_body = """
         Some email content
         -----BEGIN ACME RESPONSE-----
@@ -1698,9 +1698,7 @@ class TestEmailReplyChallengeValidator(unittest.TestCase):
 
         result = self.validator._extract_email_keyauth(email_body)
 
-        # Current implementation limitation: regex pattern [\w=+/ -]+ doesn't match newlines
-        # so multiline ACME responses return None instead of the expected content
-        self.assertIsNone(result)
+        self.assertEqual(result, "test_keyauth_value\n        with multiple lines")
 
     def test_013_extract_email_keyauth_no_match(self):
         """Test _extract_email_keyauth with no match"""
@@ -1720,6 +1718,25 @@ class TestEmailReplyChallengeValidator(unittest.TestCase):
         """Test _extract_email_keyauth with None body"""
         result = self.validator._extract_email_keyauth(None)
 
+        self.assertIsNone(result)
+
+    def test_016_extract_email_keyauth_base64url(self):
+        """Test _extract_email_keyauth with base64url characters (.-_)"""
+        email_body = """
+-----BEGIN ACME RESPONSE-----
+abc-DEF_123.xyz==
+-----END ACME RESPONSE-----
+"""
+        result = self.validator._extract_email_keyauth(email_body)
+        self.assertEqual(result, "abc-DEF_123.xyz==")
+
+    def test_017_extract_email_keyauth_empty_block(self):
+        """Test _extract_email_keyauth with empty ACME response block"""
+        email_body = """
+-----BEGIN ACME RESPONSE-----
+-----END ACME RESPONSE-----
+"""
+        result = self.validator._extract_email_keyauth(email_body)
         self.assertIsNone(result)
 
 

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -1551,6 +1551,14 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         """validate email containing last letter of domain cannot -"""
         self.assertFalse(self.validate_email(self.logger, "foo@example-.com"))
 
+    def test_136b_helper_validate_email_double_dot(self):
+        """validate email rejecting consecutive dots in domain"""
+        self.assertFalse(self.validate_email(self.logger, "foo@example..com"))
+
+    def test_136c_helper_validate_email_multi_tld(self):
+        """validate email with multi-label TLD"""
+        self.assertTrue(self.validate_email(self.logger, "foo@example.co.uk"))
+
     def test_137_helper_cert_dates_get(self):
         """get issuing and expiration date from rsa certificate"""
         cert = "MIIElTCCAn2gAwIBAgIRAKD_ulfqPUn-ggOUHOxjp40wDQYJKoZIhvcNAQELBQAwSDELMAkGA1UEBhMCREUxDzANBgNVBAgMBkJlcmxpbjEXMBUGA1UECgwOQWNtZTJDZXJ0aWZpZXIxDzANBgNVBAMMBnN1Yi1jYTAeFw0yMDA1MjcxMjMwMjNaFw0yMDA2MjYxMjMwMjNaMBkxFzAVBgNVBAMMDmZvbzEuYmFyLmxvY2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwbx-z-9wsEewBf1hnk3yAy5TFg-lWVdwk2QRdAMDTExVP823QF_K-t6cxJV_-QuWVbHN-lx6nQCXIqCZSN97hN0YTkrw8jnA4FpZzyvYI9rKEO3p4sxqndbu4X-gtyMBbXOLhjTlN2f7Z081XWIgkikvuZU2XzMZ-BbRFDfsPdDRwbwvgJU6NxpdIKm2DmYIP1MFo-tLu0toAc0nm9v8Otme28_kpJxmW3iOMkqN9BE-qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw_a9O1NPrjKFQmPaCk8k9ICvPoLHXtLabekCmvdxyRlDwD_Xoaygpd9-UHCREhcOu_wIDAQABo4GoMIGlMAsGA1UdDwQEAwIF4DAZBgNVHREEEjAQgg5mb28xLmJhci5sb2NhbDAdBgNVHQ4EFgQUqy5KOBlkyX29l4EHTCSzhZuDg-EwDgYDVR0PAQH_BAQDAgWgMB8GA1UdIwQYMBaAFBs0P896R0FUZHfnxMJL52ftKQOkMAwGA1UdEwEB_wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMBMA0GCSqGSIb3DQEBCwUAA4ICAQB7pQpILzxqcU2RKlr17rcne6NSJTUJnNXALeUFy5PrnjjJY1_B1cKaWluk3p7AMFvUjBpcucGCfEDudW290AQxYjrvl8_ePkzRzEkAo76L7ZqED5upYBZVn_3lA5Alr8L67UC0bDMhKTsy8WJzhWHQlMb37_YFUvtNPoI_MI09Q842VXeNQz5UDZmW9qhyeDIkf6fwOAO66VnGTLuUm2LGQZ-St2GauxR0ZUcRtMJoc-c7WOdHs8DlUCoFtglrzVH98501Sx749CG4nkJr4QNDpkw2hAhlo4Cxzp6PlljPNSgM9MsqqVdrgqDteDM_n-yrVFGezCik4QexDkWARPutRLQtpbhudExVnoFM68ihZ0y3oeDjgUBLybBQpcBAsBqiJ66Q8HTZRSqO9zlKW5Vm1KwAVDh_qgELxvqd0wIVkyxBKPta2l1fvb5YBiVqo4JyNcCTnoBS1emO4vk8XjroKijwLnU0cEXwHrY4JF1uU_kOtoZMGPul5EuBMcODLs7JJ3_IqJd8quI7Vf5zSsaB6nSzQ8XmiQiVogKflBeLl7AWmYCiL-FLP_q4dSJmvdr6fPMNy4-cfDO4Awc8RNfv-VjF5Mq57X1IXJrWKkat4lCEoPMq5WRJV8uVm6XNdwvUJxgCYR9mfol7T6imODDd7BNV4dKYvyteoS0auC0iww"

--- a/test/test_wsgi_acme2certifier.py
+++ b/test/test_wsgi_acme2certifier.py
@@ -211,7 +211,7 @@ class TestACMEHandler(unittest.TestCase):
         environ = {"foo": "bar", "wsgi.input": StringIO("""foo""")}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.authz(environ, Mock()),
         )
@@ -466,7 +466,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_new.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.newaccount(environ, Mock()),
         )
@@ -484,7 +484,7 @@ class TestACMEHandler(unittest.TestCase):
         environ = {"REMOTE_ADDR": "REMOTE_ADDR", "PATH_INFO": "PATH_INFO"}
         mock_get.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
-            [b'{"code": 200, "data": "data"}'], self.directory(environ, Mock())
+            [b'{\n  "code": 200,\n  "data": "data"\n}'], self.directory(environ, Mock())
         )
         self.assertFalse(mock_body.called)
         self.assertTrue(mock_get.called)
@@ -500,7 +500,7 @@ class TestACMEHandler(unittest.TestCase):
         environ = {"REMOTE_ADDR": "REMOTE_ADDR", "PATH_INFO": "PATH_INFO"}
         mock_get.return_value = {"code": 500, "error": "error"}
         self.assertEqual(
-            [b'{"status": 403, "message": "Forbidden", "detail": "error"}'],
+            [b'{\n  "status": 403,\n  "message": "Forbidden",\n  "detail": "error"\n}'],
             self.directory(environ, Mock()),
         )
         self.assertFalse(mock_body.called)
@@ -524,7 +524,7 @@ class TestACMEHandler(unittest.TestCase):
         # mock_post.return_value = {'code': 200, 'data': 'data'}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.cert(environ, Mock()),
         )
@@ -592,7 +592,7 @@ class TestACMEHandler(unittest.TestCase):
         # mock_post.return_value = {'code': 200, 'data': 'data'}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.chall(environ, Mock()),
         )
@@ -678,7 +678,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_post.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.neworders(environ, Mock()),
         )
@@ -727,7 +727,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_gen.return_value = "foo"
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected HEAD or GET."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected HEAD or GET."\n}'
             ],
             self.newnonce(environ, Mock()),
         )
@@ -767,7 +767,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_post.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.order(environ, Mock()),
         )
@@ -829,7 +829,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_post.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.revokecert(environ, Mock()),
         )
@@ -891,7 +891,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_post.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.trigger(environ, Mock()),
         )
@@ -908,7 +908,7 @@ class TestACMEHandler(unittest.TestCase):
             "PATH_INFO": "PATH_INFO",
         }
         self.assertEqual(
-            [b'{"status": 404, "message": "Not Found", "detail": "Not Found"}'],
+            [b'{\n  "status": 404,\n  "message": "Not Found",\n  "detail": "Not Found"\n}'],
             self.not_found(environ, Mock()),
         )
 
@@ -1022,7 +1022,7 @@ class TestACMEHandler(unittest.TestCase):
         mock_post.return_value = {"code": 200, "data": "data"}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.housekeeping(environ, Mock()),
         )
@@ -1065,7 +1065,7 @@ class TestACMEHandler(unittest.TestCase):
         # mock_post.return_value = {'code': 200, 'data': 'data'}
         self.assertEqual(
             [
-                b'{"status": 405, "message": "Method Not Allowed", "detail": "Wrong request type. Expected POST."}'
+                b'{\n  "status": 405,\n  "message": "Method Not Allowed",\n  "detail": "Wrong request type. Expected POST."\n}'
             ],
             self.renewalinfo(environ, Mock()),
         )


### PR DESCRIPTION
This release does only include one new feature and a few minor improvements:

- Option `ca_error_details_forward` allowing to pass error messages from CA to acme-client
- Align account deactivation responses with the relevant RFC requirements
- Harmonize the formatting of JSON responses across project

Main aim is to bundle some improvements collected from users before going for the project-restructuring which is rather a big-bang.

