### PR TITLE
[min-devel] new rpm design

### DIFF
--- a/.github/actions/rpm_build_upload/action.yml
+++ b/.github/actions/rpm_build_upload/action.yml
@@ -13,9 +13,19 @@ runs:
     id: rpm_build
     uses: ./.github/actions/rpm_build
 
-  - name: "Rename rpm package"
+  - name: "Rename main RPM package"
     run: |
-      sudo mv ${{ steps.rpm_build.outputs.rpm_dir_path }}/noarch/acme2certifier-*.noarch.rpm ${{ steps.rpm_build.outputs.rpm_dir_path }}/noarch/acme2certifier-${{ github.run_id }}.noarch.rpm
+      set -euo pipefail
+      NOARCH="${{ steps.rpm_build.outputs.rpm_dir_path }}/noarch"
+      # Rename payload RPM only; keep flavor subpackages (acme2certifier-python*).
+      main="$(ls -1 "${NOARCH}"/acme2certifier-[0-9]*.noarch.rpm 2>/dev/null | head -n 1)"
+      if [[ -z "${main}" ]]; then
+        echo "ERROR: main acme2certifier-*.noarch.rpm not found in ${NOARCH}" >&2
+        ls -la "${NOARCH}" >&2 || true
+        exit 1
+      fi
+      sudo mv "${main}" "${NOARCH}/acme2certifier-${{ github.run_id }}.noarch.rpm"
+      ls -la "${NOARCH}"
     shell: bash
 
   - name: "Upload RPM package"

--- a/.github/actions/rpm_prep/action.yml
+++ b/.github/actions/rpm_prep/action.yml
@@ -10,6 +10,12 @@ inputs:
   RH_VERSION:
     description: "RHEL version"
     required: true
+  PYTHON_STACK:
+    description: >-
+      SBOM leaf under rpm-repo/RPMs/rhelN/: python39 (EL8 default),
+      python36 (EL8 legacy), python3 (EL9 default). Empty = auto from RH_VERSION.
+    required: false
+    default: ""
   DJANGO_DB:
     description: "Django database"
   RPM_BUILD:
@@ -88,12 +94,58 @@ runs:
 
     - name: "Retrieve rpm from SBOM repo"
       run: |
-        git clone https://$GH_USER:$GH_SBOM_REPO_TOKEN@github.com/$GH_USER/sbom /tmp/sbom
-        cp /tmp/sbom/rpm-repo/RPMs/rhel$RH_VERSION/*.rpm  data
+        set -euo pipefail
+        # Map OS + flavor → SBOM leaf (see grindsa/sbom rpm-repo/README.md)
+        STACK="${PYTHON_STACK:-}"
+        if [[ -z "${STACK}" ]]; then
+          case "${RH_VERSION}" in
+            8) STACK=python39 ;;
+            9) STACK=python3 ;;
+            *)
+              echo "ERROR: unsupported RH_VERSION=${RH_VERSION} (expected 8 or 9)" >&2
+              exit 1
+              ;;
+          esac
+        fi
+        case "${STACK}" in
+          python36|python39|python3) ;;
+          *)
+            echo "ERROR: PYTHON_STACK must be python36|python39|python3 (got: ${STACK})" >&2
+            exit 1
+            ;;
+        esac
+        LEAF="rpm-repo/RPMs/rhel${RH_VERSION}/${STACK}"
+        echo "SBOM leaf: ${LEAF}"
+
+        rm -rf /tmp/sbom
+        # Partial clone + sparse checkout: only the needed RPM leaf (not whole repo / SRPMs)
+        git clone --filter=blob:none --sparse --depth 1 \
+          "https://${GH_USER}:${GH_SBOM_REPO_TOKEN}@github.com/${GH_USER}/sbom" /tmp/sbom
+        git -C /tmp/sbom sparse-checkout set "${LEAF}"
+
+        SRC="/tmp/sbom/${LEAF}"
+        if [[ ! -d "${SRC}" ]]; then
+          echo "ERROR: missing SBOM path ${SRC}" >&2
+          ls -la /tmp/sbom/rpm-repo/RPMs/rhel${RH_VERSION}/ 2>/dev/null || true
+          exit 1
+        fi
+
+        # Stage only noarch + runner arch (skip foreign-arch RPMs in the leaf)
+        ARCH="$(uname -m)"
+        shopt -s nullglob
+        copied=0
+        for r in "${SRC}"/*.noarch.rpm "${SRC}"/*."${ARCH}".rpm; do
+          [[ -f "${r}" ]] || continue
+          sudo cp -v "${r}" data/
+          copied=$((copied + 1))
+        done
+        echo "Staged ${copied} companion RPM(s) for arch=${ARCH} from ${LEAF}"
+        ls -la data/*.rpm 2>/dev/null | head -50 || true
       env:
         GH_USER: ${{ inputs.GH_USER }}
         GH_SBOM_REPO_TOKEN: ${{ inputs.GH_SBOM_REPO_TOKEN }}
         RH_VERSION: ${{ inputs.RH_VERSION }}
+        PYTHON_STACK: ${{ inputs.PYTHON_STACK }}
       shell: bash
 
     - name: "Pull AlmaLinux image"

--- a/.github/actions/rpm_prep/action.yml
+++ b/.github/actions/rpm_prep/action.yml
@@ -58,7 +58,9 @@ runs:
         sudo cp .github/acme2certifier_key.pem data/nginx/acme2certifier_key.pem
         if [ -f ${{ steps.rpm_build.outputs.rpm_dir_path }}noarch/acme2certifier-${{ env.TAG_NAME }}-1.0.noarch.rpm ]; then
           echo "RPM exists"
-          sudo cp ${{ steps.rpm_build.outputs.rpm_dir_path }}noarch/acme2certifier-${{ env.TAG_NAME }}-1.0.noarch.rpm data
+          # Main payload + python flavor subpackages
+          sudo cp ${{ steps.rpm_build.outputs.rpm_dir_path }}noarch/acme2certifier-*.noarch.rpm data/
+          ls -la data/acme2certifier-*.rpm
         else
           echo "RPM does not exist"
         fi

--- a/.github/actions/rpm_prep/action.yml
+++ b/.github/actions/rpm_prep/action.yml
@@ -14,6 +14,7 @@ inputs:
     description: >-
       SBOM leaf under rpm-repo/RPMs/rhelN/: python39 (EL8 default),
       python36 (EL8 legacy), python3 (EL9 default). Empty = auto from RH_VERSION.
+      Space-separated list allowed (e.g. "python36 python39" for EL8 upgrades).
     required: false
     default: ""
   DJANGO_DB:
@@ -96,51 +97,58 @@ runs:
       run: |
         set -euo pipefail
         # Map OS + flavor → SBOM leaf (see grindsa/sbom rpm-repo/README.md)
-        STACK="${PYTHON_STACK:-}"
-        if [[ -z "${STACK}" ]]; then
+        STACKS="${PYTHON_STACK:-}"
+        if [[ -z "${STACKS}" ]]; then
           case "${RH_VERSION}" in
-            8) STACK=python39 ;;
-            9) STACK=python3 ;;
+            8) STACKS=python39 ;;
+            9) STACKS=python3 ;;
             *)
               echo "ERROR: unsupported RH_VERSION=${RH_VERSION} (expected 8 or 9)" >&2
               exit 1
               ;;
           esac
         fi
-        case "${STACK}" in
-          python36|python39|python3) ;;
-          *)
-            echo "ERROR: PYTHON_STACK must be python36|python39|python3 (got: ${STACK})" >&2
-            exit 1
-            ;;
-        esac
-        LEAF="rpm-repo/RPMs/rhel${RH_VERSION}/${STACK}"
-        echo "SBOM leaf: ${LEAF}"
 
         rm -rf /tmp/sbom
-        # Partial clone + sparse checkout: only the needed RPM leaf (not whole repo / SRPMs)
+        # Partial clone + sparse checkout: only the needed RPM leaf/leaves
         git clone --filter=blob:none --sparse --depth 1 \
           "https://${GH_USER}:${GH_SBOM_REPO_TOKEN}@github.com/${GH_USER}/sbom" /tmp/sbom
-        git -C /tmp/sbom sparse-checkout set "${LEAF}"
 
-        SRC="/tmp/sbom/${LEAF}"
-        if [[ ! -d "${SRC}" ]]; then
-          echo "ERROR: missing SBOM path ${SRC}" >&2
-          ls -la /tmp/sbom/rpm-repo/RPMs/rhel${RH_VERSION}/ 2>/dev/null || true
-          exit 1
-        fi
-
-        # Stage only noarch + runner arch (skip foreign-arch RPMs in the leaf)
         ARCH="$(uname -m)"
         shopt -s nullglob
         copied=0
-        for r in "${SRC}"/*.noarch.rpm "${SRC}"/*."${ARCH}".rpm; do
-          [[ -f "${r}" ]] || continue
-          sudo cp -v "${r}" data/
-          copied=$((copied + 1))
+        leaves=()
+        for STACK in ${STACKS}; do
+          case "${STACK}" in
+            python36|python39|python3) ;;
+            *)
+              echo "ERROR: PYTHON_STACK entries must be python36|python39|python3 (got: ${STACK})" >&2
+              exit 1
+              ;;
+          esac
+          LEAF="rpm-repo/RPMs/rhel${RH_VERSION}/${STACK}"
+          leaves+=("${LEAF}")
         done
-        echo "Staged ${copied} companion RPM(s) for arch=${ARCH} from ${LEAF}"
-        ls -la data/*.rpm 2>/dev/null | head -50 || true
+        git -C /tmp/sbom sparse-checkout set "${leaves[@]}"
+
+        for STACK in ${STACKS}; do
+          LEAF="rpm-repo/RPMs/rhel${RH_VERSION}/${STACK}"
+          SRC="/tmp/sbom/${LEAF}"
+          if [[ ! -d "${SRC}" ]]; then
+            echo "ERROR: missing SBOM path ${SRC}" >&2
+            ls -la /tmp/sbom/rpm-repo/RPMs/rhel${RH_VERSION}/ 2>/dev/null || true
+            exit 1
+          fi
+          echo "SBOM leaf: ${LEAF}"
+          # Stage only noarch + runner arch (skip foreign-arch RPMs in the leaf)
+          for r in "${SRC}"/*.noarch.rpm "${SRC}"/*."${ARCH}".rpm; do
+            [[ -f "${r}" ]] || continue
+            sudo cp -v "${r}" data/
+            copied=$((copied + 1))
+          done
+        done
+        echo "Staged ${copied} companion RPM(s) for arch=${ARCH} from: ${STACKS}"
+        ls -la data/*.rpm 2>/dev/null | head -80 || true
       env:
         GH_USER: ${{ inputs.GH_USER }}
         GH_SBOM_REPO_TOKEN: ${{ inputs.GH_SBOM_REPO_TOKEN }}

--- a/.github/workflows/deployment-rpm.yml
+++ b/.github/workflows/deployment-rpm.yml
@@ -56,7 +56,7 @@ jobs:
   test-rpm-flavor:
     needs: guard
     runs-on: ubuntu-latest
-    if: github.repository == 'grindsa/acme2certifier1'
+    if: github.repository == 'grindsa/acme2certifier'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deployment-rpm.yml
+++ b/.github/workflows/deployment-rpm.yml
@@ -1,0 +1,200 @@
+name: Deployment Tests - RPM
+# Validates the dual-EL RPM concept:
+#   - EL8 default: acme2certifier-python39 + sbom rhel8/python39
+#   - EL8 legacy:  acme2certifier-python3  + sbom rhel8/python36
+#   - EL9 default: acme2certifier-python3  + sbom rhel9/python3
+#
+# Producer run must upload the noarch/ artifact (main + flavor subpackages)
+# as acme2certifier-<run_id>.noarch.rpm (see rpm_build_upload).
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to run the workflow on'
+        required: true
+        default: 'main'
+      run_id:
+        description: 'Run ID of the producing workflow'
+        required: true
+        default: '0'
+      sha:
+        description: 'SHA of the commit to run the workflow on'
+        required: true
+        default: ''
+      called_by_workflow:
+        description: 'Name of the producing workflow'
+        required: true
+        default: 'manual-trigger'
+      full_ref:
+        description: 'Full git ref of the commit to run the workflow on'
+        required: false
+        default: ''
+
+jobs:
+
+  # ---------------------------------------------------------
+  # Quick guard to validate incoming payload
+  # ---------------------------------------------------------
+  guard:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.sha != '' && inputs.run_id != '' && inputs.branch != '' && github.repository == 'grindsa/acme2certifier' }}
+    steps:
+      - run: |
+          echo "Triggered by SHA:    $SHA"
+          echo "From branch:         $BRANCH"
+          echo "Producer run_id:     $RUN_ID"
+          echo "Producer workflow:   $CALLED_BY"
+        env:
+          SHA: ${{ inputs.sha }}
+          BRANCH: ${{ inputs.branch }}
+          RUN_ID: ${{ inputs.run_id }}
+          CALLED_BY: ${{ inputs.called_by_workflow }}
+
+  # ---------------------------------------------------------
+  # RPM flavor matrix (prebuilt artifacts + SBOM companions)
+  # ---------------------------------------------------------
+  test-rpm-flavor:
+    needs: guard
+    runs-on: ubuntu-latest
+    if: github.repository == 'grindsa/acme2certifier1'
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: ['wsgi', 'django']
+        target:
+          - rhversion: '8'
+            python_stack: python39
+            python_cli: '3.9'
+            flavor_pkg: acme2certifier-python39
+            expect_interpreter: /usr/bin/python3.9
+          - rhversion: '8'
+            python_stack: python36
+            python_cli: '3.6'
+            flavor_pkg: acme2certifier-python3
+            expect_interpreter: /usr/bin/python3
+          - rhversion: '9'
+            python_stack: python3
+            python_cli: '3'
+            flavor_pkg: acme2certifier-python3
+            expect_interpreter: /usr/bin/python3
+
+    steps:
+
+      - name: "checkout GIT"
+        uses: actions/checkout@v6
+
+      - name: "Parse JSON secret"
+        uses: ./.github/actions/parse-json-secret
+        with:
+          json_secret: ${{ secrets.GH_CFG }}
+
+      - name: "Prepare Alma environment (SBOM companions)"
+        uses: ./.github/actions/rpm_prep
+        with:
+          GH_USER: ${{ env.GH_USER }}
+          GH_SBOM_REPO_TOKEN: ${{ env.GH_SBOM_REPO_TOKEN }}
+          RH_VERSION: ${{ matrix.target.rhversion }}
+          PYTHON_STACK: ${{ matrix.target.python_stack }}
+          RPM_BUILD: false
+
+      - name: "Download RPM artifact (main + flavor subpackages)"
+        uses: ./.github/actions/download_artifact
+        with:
+          RUN_ID: ${{ inputs.run_id }}
+          ARTIFACT_NAME: acme2certifier-${{ inputs.run_id }}.noarch.rpm
+          DESTINATION_PATH: data/
+          TOKEN: ${{ secrets.GH_WF_TOKEN }}
+          REPO: ${{ github.repository }}
+
+      - name: "Assert flavor RPM present beside main payload"
+        run: |
+          set -euo pipefail
+          echo "Staged RPMs:"
+          ls -la data/*.rpm
+          test -f "data/acme2certifier-${RUN_ID}.noarch.rpm"
+          shopt -s nullglob
+          flavors=(data/${FLAVOR_PKG}-*.noarch.rpm)
+          if ((${#flavors[@]} == 0)); then
+            echo "ERROR: missing flavor RPM ${FLAVOR_PKG}-*.noarch.rpm in artifact" >&2
+            exit 1
+          fi
+          echo "Found flavor: ${flavors[0]}"
+        env:
+          RUN_ID: ${{ inputs.run_id }}
+          FLAVOR_PKG: ${{ matrix.target.flavor_pkg }}
+
+      - name: "Prepare acme_srv.cfg with openssl_ca_handler"
+        uses: ./.github/actions/setup_openssl_cahandler
+
+      - name: "Execute install script (flavor via --python)"
+        run: |
+          set -euo pipefail
+          docker exec acme-srv bash /tmp/acme2certifier/a2c-rpm.sh install \
+            -m "${MODE}" \
+            --python "${PYTHON_CLI}"
+        env:
+          MODE: ${{ matrix.mode }}
+          PYTHON_CLI: ${{ matrix.target.python_cli }}
+
+      - name: "Assert active python.conf matches flavor"
+        run: |
+          set -euo pipefail
+          docker exec -e EXPECT="${EXPECT}" -e FLAVOR_PKG="${FLAVOR_PKG}" acme-srv bash -lc '
+            set -euo pipefail
+            conf=/etc/acme2certifier/python.conf
+            test -f "$conf"
+            echo "--- $conf ---"
+            cat "$conf"
+            actual=$(awk -F= "/^[[:space:]]*python_interpreter[[:space:]]*=/ {
+              gsub(/[[:space:]]/, \"\", \$2); print \$2; exit
+            }" "$conf")
+            echo "interpreter=${actual} expected=${EXPECT}"
+            test "${actual}" = "${EXPECT}"
+            rpm -q acme2certifier
+            rpm -q "${FLAVOR_PKG}"
+          '
+        env:
+          EXPECT: ${{ matrix.target.expect_interpreter }}
+          FLAVOR_PKG: ${{ matrix.target.flavor_pkg }}
+
+      - name: "Flush logs before enrollment"
+        uses: ./.github/actions/logs_flush
+        with:
+          DEPLOYMENT_TYPE: rpm
+
+      - name: "Wait for ACME directory"
+        uses: ./.github/actions/wait_for_directory
+
+      - name: "Test enrollment / renewal / revocation"
+        uses: ./.github/actions/acme_clients
+
+      - name: "Assert enrollment activity in logs"
+        uses: ./.github/actions/logs_assert
+        with:
+          DEPLOYMENT_TYPE: rpm
+          PATTERN: "Certificate"
+          IGNORE_CASE: "true"
+
+      - name: "[ * ] Collecting test logs"
+        if: ${{ failure() }}
+        uses: ./.github/actions/collect_failure_logs
+        with:
+          DEPLOYMENT_TYPE: rpm
+
+      - name: "Sanitize failure artifacts"
+        if: ${{ failure() }}
+        uses: ./.github/actions/sanitize_artifact_payload
+        with:
+          ARTIFACT_DIR: ${{ github.workspace }}/artifact
+
+      - name: "[ * ] Uploading artifacts"
+        uses: actions/upload-artifact@v7
+        if: ${{ failure() }}
+        with:
+          name: test-rpm-rh${{ matrix.target.rhversion }}-${{ matrix.target.python_stack }}-${{ matrix.mode }}.tar.gz
+          path: ${{ github.workspace }}/artifact/upload/
+          retention-days: 1
+
+      - name: "Secure cleanup"
+        if: ${{ always() }}
+        uses: ./.github/actions/secure_cleanup

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,47 @@ This is a high-level summary of the most important changes. For a full list of
 changes, see the [git commit log](https://github.com/grindsa/acme2certifier/commits)
 and pick the appropriate release branch.
 
+## Changes in 0.45
+
+**New Features**:
+
+- [Package-first layout](docs/upgrading.md) (`acme2certifier.*`) with pip, DEB, RPM, and Docker installs; Django app and project shipped in the package
+- [Custom CA/EAB/Hooks loading](docs/ca_handler.md#custom-handlers-path-or-package) via `*_module` (dotted import or filesystem path); deprecated `*_file` keys still supported until 0.48
+- [DB handler selection](docs/acme_srv.md) via `[DBhandler] handler` or `ACME_SRV_DB_HANDLER` environment variable
+- [`a2c-wsgi2django`](docs/migrate_wsgi_to_django.md) CLI to migrate ACME runtime data from WSGI SQLite to Django ORM via a portable JSON dump (`export`, `import`, `check`, `wipe`)
+- Digicert CA handler options `request_retries` and `request_retry_backoff` for HTTP transport retries
+
+**RPM packaging (quick reference)** — install: [install_rpm.md](docs/install_rpm.md); upgrade: [upgrading.md](docs/upgrading.md#rpm-pre-045--045)
+
+One **noarch** payload + one **Python flavor** metapackage (mutually exclusive). Default app Python is **3.9** on EL8 and EL9.
+
+| Package | Role |
+| --- | --- |
+| `acme2certifier` | Application under `/opt/acme2certifier` (no `python*-*` Requires) |
+| `acme2certifier-python39` | **EL8 default** — parallel Python 3.9 (`python39-*`, `uwsgi-plugin-python39`) |
+| `acme2certifier-python3` | **EL9 default** (system 3.9) / **EL8 legacy** (system 3.6) |
+
+Companions (cryptography, jwcrypto, …) come from AppStream/EPEL or [grindsa/sbom](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs) matching the flavor prefix.
+
+**Bug Fixes and Improvements**:
+
+- Route CA handler HTTP calls through the shared `request_operation` helper (including retry support)
+- Improve ASA CA handler parsing of error responses from the CA
+- Improve OpenSSL CA handler handling of absolute certificate/key paths
+- Security defaults hardening:
+  - `/trigger` endpoint is disabled by default and requires both `[Trigger] enabled=True` and CA handler opt-in (`supports_trigger=True`)
+  - Legacy unauthenticated GET on challenge/authorization resources is disabled by default (`legacy_acme_get=False`)
+  - URL generation supports canonical host override via `[DEFAULT] server_name`; startup warnings are emitted when falling back to request headers and when `server_name` is not part of `Directory.caaidentities`
+  - HTTP-01 can reject non-global/private targets via `http01_block_private_ips` (opt-in)
+  - `nonce_check_disable` and `signature_check_disable` are ignored unless `ACME2CERTIFIER_I_KNOW_THE_RISK=1` is set
+  - Django packaged settings refuse to start with the insecure default `SECRET_KEY`; warn when `ALLOWED_HOSTS` contains `*`
+  - Certificate resource names use 15-character identifiers (full `Certificate.name` column width)
+- Resolve relative `acme_srv.db` paths against the deploy base directory and clarify default DB location
+- Stop shipping `acme_srv.cfg` inside DEB/RPM packages; preserve handler configuration across install/restart
+- Adapt Docker entrypoints and install scripts to the package layout
+- Log which config file and DB/CA handler are active at startup
+- Operator [logging](docs/logging.md): optional syslog (`syslog_address`) and `log_file` destinations, ACME problem WARNING/ERROR lines with `account=`, HTTP edge dump redaction (nonce/tokens/cert PEM; `log_cert_content` restores legacy cert logging)
+
 ## Changes in 0.44
 
 **Features and Improvements**:

--- a/docs/install_rpm.md
+++ b/docs/install_rpm.md
@@ -97,13 +97,18 @@ sudo yum -y localinstall \
   /tmp/acme2certifier/acme2certifier-python3-<version>-1.0.noarch.rpm
 ```
 
-Nginx and uWSGI are **Recommends**, not hard Requires. For the nginx path:
+Nginx and uWSGI are **Recommends**, not hard Requires. Matching Python plugin comes from the flavor:
 
 ```bash
-sudo yum -y install nginx uwsgi-plugin-python3 python3-uwsgidecorators
+# EL9 / EL8 legacy (system Python) — stock EPEL plugin
+sudo yum -y install nginx uwsgi uwsgi-plugin-python3 python3-uwsgidecorators
+
+# EL8 default (python39) — project-provided plugin + AppStream python39
+sudo yum -y install nginx uwsgi
+sudo yum -y localinstall /tmp/acme2certifier/uwsgi-plugin-python39-*.rpm
 ```
 
-> **Note:** `uwsgi-plugin-python3` matches **system** Python. That fits `acme2certifier-python3`. The EL8 `python39` default needs a matching process manager (or stay on legacy `python3` until one is available). See [rpm-el-packaging.md](architecture/rpm-el-packaging.md) §7.3.
+Set `plugins = python3` or `plugins = python39` in `/opt/acme2certifier/acme2certifier.ini` to match the flavor (flavor `%post` and `a2c-rpm.sh` do this). See [rpm-el-packaging.md](architecture/rpm-el-packaging.md) §7.3.
 
 ### Red Hat 8.x: Upgrade Required Packages (legacy python3 / 3.6)
 

--- a/docs/install_rpm.md
+++ b/docs/install_rpm.md
@@ -110,28 +110,42 @@ sudo yum -y localinstall /tmp/acme2certifier/uwsgi-plugin-python39-*.rpm
 
 Set `plugins = python3` or `plugins = python39` in `/opt/acme2certifier/acme2certifier.ini` to match the flavor (flavor `%post` and `a2c-rpm.sh` do this). See [rpm-el-packaging.md](architecture/rpm-el-packaging.md) §7.3.
 
+### Project RPM repository (SBOM)
+
+Companion / backport RPMs live under [grindsa/sbom `rpm-repo/RPMs`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs), split by **EL major** and **Python stack**:
+
+| OS | a2c flavor | Directory |
+| --- | --- | --- |
+| EL8 | `acme2certifier-python39` (default) | [`RPMs/rhel8/python39/`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel8/python39) |
+| EL8 | `acme2certifier-python3` (legacy 3.6) | [`RPMs/rhel8/python36/`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel8/python36) |
+| EL9 | `acme2certifier-python3` (default) | [`RPMs/rhel9/python3/`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel9/python3) |
+
+Install matching `noarch` / host-arch RPMs only (do not mix `python3-*` and `python39-*` leaves).
+
 ### Red Hat 8.x: Upgrade Required Packages (legacy python3 / 3.6)
 
-If using **`acme2certifier-python3` on EL8**, upgrade:
+If using **`acme2certifier-python3` on EL8**, upgrade (from [`rhel8/python36`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel8/python36)):
 
 - [python3-cryptography](https://cryptography.io/en/latest/) to version 36.0.1 or higher.
 - [python3-dns](https://www.dnspython.org/) to version 2.1 or higher.
 - [python3-jwcrypto](https://jwcrypto.readthedocs.io/en/latest/) to version 0.8 or higher.
 
-Backports of these packages from RHEL 9 can be found in the [A2C RPM repository](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8):
+Examples:
 
-- [python3-cryptography-36.0.1-4.el8.x86_64.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-cryptography-36.0.1-4.el8.x86_64.rpm)
-- [python3-dns-2.1.0-6.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-dns-2.1.0-6.el8.noarch.rpm)
-- [python3-jwcrypto-0.8-4.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-jwcrypto-0.8-4.el8.noarch.rpm)
+- [python3-cryptography-36.0.1-4.el8.x86_64.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-cryptography-36.0.1-4.el8.x86_64.rpm)
+- [python3-dns-2.2.1-2.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-dns-2.2.1-2.el8.noarch.rpm)
+- [python3-jwcrypto-1.5.1-1.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-jwcrypto-1.5.1-1.el8.noarch.rpm)
 
 ### Additional Modules for Specific CA Handlers
 
-Depending on your CA handler, you may need these additional modules (prefix must match the flavor: `python3-*` or `python39-*`):
+Depending on your CA handler, you may need these additional modules (prefix must match the flavor: `python3-*` or `python39-*`). Examples for **EL8 legacy** (`python36/`):
 
-- [python3-impacket-0.11.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm) for [MS WCCE handler](https://github.com/grindsa/acme2certifier/blob/master/docs/mswcce.md).
-- [python3-ntlm-auth-1.5.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-ntlm-auth-1.5.0-2.el8.noarch.rpm) for [MS WSE handler](https://github.com/grindsa/acme2certifier/blob/master/docs/mscertsrv.md).
-- [python3-requests_ntlm-1.1.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-requests_ntlm-1.1.0-14.el8.noarch.rpm) for [MS WSE handler](https://github.com/grindsa/acme2certifier/blob/master/docs/mscertsrv.md).
-- [python3-requests-pkcs12-1.16](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-requests-pkcs12-1.16-1.el8.noarch.rpm) for [EST](https://github.com/grindsa/acme2certifier/blob/master/docs/est.md) or [EJBCA](https://github.com/grindsa/acme2certifier/blob/master/docs/ejbca.md) handler.
+- [python3-impacket-0.11.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm) for [MS WCCE handler](mswcce.md).
+- [python3-ntlm-auth-1.5.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-ntlm-auth-1.5.0-2.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
+- [python3-requests_ntlm-1.1.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-requests_ntlm-1.1.0-14.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
+- [python3-requests-pkcs12-1.16](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-requests-pkcs12-1.16-1.el8.noarch.rpm) for [EST](est.md) or [EJBCA](ejbca.md) handler.
+
+For **EL8 default** (`python39/`), use the matching `python39-*` NVRs from that leaf (e.g. `python39-impacket`, `python39-django`).
 
 ## 4. Copy the Nginx Configuration File
 

--- a/docs/install_rpm.md
+++ b/docs/install_rpm.md
@@ -130,22 +130,28 @@ If using **`acme2certifier-python3` on EL8**, upgrade (from [`rhel8/python36`](h
 - [python3-dns](https://www.dnspython.org/) to version 2.1 or higher.
 - [python3-jwcrypto](https://jwcrypto.readthedocs.io/en/latest/) to version 0.8 or higher.
 
-Examples:
+Examples (grindsa rebuilds):
 
-- [python3-cryptography-36.0.1-4.el8.x86_64.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-cryptography-36.0.1-4.el8.x86_64.rpm)
-- [python3-dns-2.2.1-2.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-dns-2.2.1-2.el8.noarch.rpm)
-- [python3-jwcrypto-1.5.1-1.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-jwcrypto-1.5.1-1.el8.noarch.rpm)
+- [python3-cryptography-36.0.1-4grindsa.el8.x86_64.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-cryptography-36.0.1-4grindsa.el8.x86_64.rpm)
+- [python3-dns-2.2.1-2grindsa.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-dns-2.2.1-2grindsa.el8.noarch.rpm)
+- [python3-jwcrypto-1.5.1-1grindsa.el8.noarch.rpm](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-jwcrypto-1.5.1-1grindsa.el8.noarch.rpm)
 
 ### Additional Modules for Specific CA Handlers
 
 Depending on your CA handler, you may need these additional modules (prefix must match the flavor: `python3-*` or `python39-*`). Examples for **EL8 legacy** (`python36/`):
 
-- [python3-impacket-0.11.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm) for [MS WCCE handler](mswcce.md).
-- [python3-ntlm-auth-1.5.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-ntlm-auth-1.5.0-2.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
-- [python3-requests_ntlm-1.1.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-requests_ntlm-1.1.0-14.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
-- [python3-requests-pkcs12-1.16](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-requests-pkcs12-1.16-1.el8.noarch.rpm) for [EST](est.md) or [EJBCA](ejbca.md) handler.
+- [python3-impacket-0.11.0-2grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm) for [MS WCCE handler](mswcce.md).
+- [python3-ntlm-auth-1.5.0-2grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-ntlm-auth-1.5.0-2grindsa.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
+- [python3-requests_ntlm-1.1.0-14grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-requests_ntlm-1.1.0-14grindsa.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
+- [python3-requests-pkcs12-1.16-1grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-requests-pkcs12-1.16-1grindsa.el8.noarch.rpm) for [EST](est.md) or [EJBCA](ejbca.md) handler.
 
-For **EL8 default** (`python39/`), use the matching `python39-*` NVRs from that leaf (e.g. `python39-impacket`, `python39-django`).
+For **EL8 default** (`python39/`), matching grindsa NVRs:
+
+- [python39-impacket-0.11.0-2grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python39/python39-impacket-0.11.0-2grindsa.el8.noarch.rpm) for [MS WCCE handler](mswcce.md).
+- [python39-ntlm-auth-1.5.0-1grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python39/python39-ntlm-auth-1.5.0-1grindsa.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
+- [python39-requests_ntlm-1.1.0-1grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python39/python39-requests_ntlm-1.1.0-1grindsa.el8.noarch.rpm) for [MS WSE handler](mscertsrv.md).
+- [python39-requests-pkcs12-1.7-1grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python39/python39-requests-pkcs12-1.7-1grindsa.el8.noarch.rpm) for [EST](est.md) or [EJBCA](ejbca.md) handler.
+- [python39-requests-gssapi-1.4.0-1grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python39/python39-requests-gssapi-1.4.0-1grindsa.el8.noarch.rpm) / [python39-gssapi-1.6.9-1grindsa](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python39/python39-gssapi-1.6.9-1grindsa.el8.x86_64.rpm) for Kerberos / GSSAPI handlers.
 
 ## 4. Copy the Nginx Configuration File
 

--- a/docs/install_rpm.md
+++ b/docs/install_rpm.md
@@ -228,3 +228,7 @@ Expected output:
 ## 11. Enroll a Certificate
 
 Use your preferred ACME client to enroll a certificate. If an issue occurs, enable debugging in `/opt/acme2certifier/acme_srv.cfg` and check `/var/log/messages` for errors.
+
+## Upgrading from pre-0.45
+
+Step-by-step RPM upgrade (EL8 python39 swap, SBOM companions, cfg `*_module`, SQLite path): [Upgrading — RPM: pre-0.45 → 0.45+](upgrading.md#rpm-pre-045--045).

--- a/docs/install_rpm.md
+++ b/docs/install_rpm.md
@@ -4,19 +4,28 @@
 
 # RPM Installation on AlmaLinux / Red Hat EL / Rocky / CentOS Stream
 
-One **noarch** RPM installs on **EL8 (Python 3.6)** and **EL9 (Python 3.9)**. The package tree lives under `/opt/acme2certifier` (not system `site-packages`), with `PYTHONPATH=/opt/acme2certifier`.
+One **noarch** payload RPM (`acme2certifier`) installs on **EL8 and EL9** under `/opt/acme2certifier` (`PYTHONPATH=/opt/acme2certifier`). Python modules come from a **flavor metapackage**:
+
+| Flavor | Role |
+| --- | --- |
+| `acme2certifier-python39` | **EL8 default** — parallel Python 3.9 |
+| `acme2certifier-python3` | **EL9 default** (system 3.9) / **EL8 legacy** (system 3.6) |
+
+Default **app** Python is **3.9** on both majors.
 
 > **PyPI / pip installs** (e.g. [`a2c-rel-nginx.sh`](../examples/install_scripts/a2c-rel-nginx.sh)) require Python ≥ 3.7 and are **EL9-only**. Use this RPM path for EL8.
 
 ## Automated install script
 
-[`examples/install_scripts/a2c-rpm.sh`](../examples/install_scripts/a2c-rpm.sh) installs a local `.rpm`, configures Nginx + uWSGI, and sets `--mode`:
+[`examples/install_scripts/a2c-rpm.sh`](../examples/install_scripts/a2c-rpm.sh) installs the main `.rpm` **plus** the matching flavor from the same directory, configures Nginx + uWSGI, and sets `--mode` (either wsgi or django):
 
 ```bash
 chmod a+rx examples/install_scripts/a2c-rpm.sh
 ./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-0.45.dev1-1.0.noarch.rpm
 ./examples/install_scripts/a2c-rpm.sh -r ../acme2certifier-*.rpm -m django
 ./examples/install_scripts/a2c-rpm.sh -m wsgi --no-ssl
+# EL8 legacy system Python 3.6
+./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-*.rpm --python 3.6
 # Sync volume/cfg and restart nginx + acme2certifier (no reinstall)
 ./examples/install_scripts/a2c-rpm.sh restart --volume-dir /path/to/volume
 # Copy volume/acme_ca only (no restart)
@@ -25,8 +34,9 @@ chmod a+rx examples/install_scripts/a2c-rpm.sh
 
 | Option | Meaning |
 | --- | --- |
-| `-r, --rpm PATH` | path to `acme2certifier-*.rpm` (or auto-find in `.` / `..` / data-dir) |
+| `-r, --rpm PATH` | path to **main** `acme2certifier-<ver>*.rpm` (flavors auto-found beside it) |
 | `-m, --mode wsgi\|django` | DB handler + matching uWSGI module (default: `wsgi`) |
+| `--python VER` | flavor: `3.9` / `python39` (EL8 default), `3.6` / `python3` (EL9 default / EL8 legacy) |
 | `--restart` / `restart` | sync volume/cfg and restart services (no reinstall) |
 | `--update` / `update` | sync `volume/acme_ca` only (no restart) |
 | `--volume-dir DIR` | sync source (default: `/tmp/acme2certifier/volume` when present) |
@@ -43,11 +53,15 @@ Works with `dnf` or `yum` on EL8 and EL9. The remainder of this guide is the man
 | `/opt/acme2certifier/acme2certifier_wsgi.py` | WSGI entry |
 | `/opt/acme2certifier/acme2certifier.ini` | uWSGI (includes `python-path`) |
 | `/opt/acme2certifier/share/{nginx,apache2,skeletons}/` | Example web configs |
-| `/usr/bin/a2c-*` | CLI wrappers (`PYTHONPATH` set) |
+| `/etc/acme2certifier/python.conf` | Active flavor interpreter (`python_interpreter=`) |
+| `/usr/bin/a2c-*` | CLI wrappers (`PYTHONPATH` + interpreter from `python.conf`) |
 
-## 1. Download the Latest RPM Package
+## 1. Download the Latest RPM Packages
 
-Download the latest [RPM package](https://github.com/grindsa/acme2certifier/releases).
+Download the latest [RPM packages](https://github.com/grindsa/acme2certifier/releases):
+
+- `acme2certifier-<version>-1.0.noarch.rpm` (payload)
+- `acme2certifier-python3-<version>-1.0.noarch.rpm` and/or `acme2certifier-python39-<version>-1.0.noarch.rpm`
 
 ## 2. Install "Extra Packages for Enterprise Linux (EPEL)"
 
@@ -56,10 +70,31 @@ sudo yum install -y epel-release
 sudo yum update -y
 ```
 
-## 3. Install the RPM Package
+## 3. Install the RPM Packages
+
+**EL9 (default — system Python 3.9):**
 
 ```bash
-sudo yum -y localinstall /tmp/acme2certifier/acme2certifier-<version>-1.0.noarch.rpm
+sudo yum -y localinstall \
+  /tmp/acme2certifier/acme2certifier-<version>-1.0.noarch.rpm \
+  /tmp/acme2certifier/acme2certifier-python3-<version>-1.0.noarch.rpm
+```
+
+**EL8 (default — parallel Python 3.9):**
+
+```bash
+sudo yum -y install python39   # AppStream / module as required by your OS
+sudo yum -y localinstall \
+  /tmp/acme2certifier/acme2certifier-<version>-1.0.noarch.rpm \
+  /tmp/acme2certifier/acme2certifier-python39-<version>-1.0.noarch.rpm
+```
+
+**EL8 legacy (system Python 3.6):**
+
+```bash
+sudo yum -y localinstall \
+  /tmp/acme2certifier/acme2certifier-<version>-1.0.noarch.rpm \
+  /tmp/acme2certifier/acme2certifier-python3-<version>-1.0.noarch.rpm
 ```
 
 Nginx and uWSGI are **Recommends**, not hard Requires. For the nginx path:
@@ -68,9 +103,11 @@ Nginx and uWSGI are **Recommends**, not hard Requires. For the nginx path:
 sudo yum -y install nginx uwsgi-plugin-python3 python3-uwsgidecorators
 ```
 
-### Red Hat 8.x: Upgrade Required Packages
+> **Note:** `uwsgi-plugin-python3` matches **system** Python. That fits `acme2certifier-python3`. The EL8 `python39` default needs a matching process manager (or stay on legacy `python3` until one is available). See [rpm-el-packaging.md](architecture/rpm-el-packaging.md) §7.3.
 
-If installing on Red Hat 8.x, upgrade the following packages:
+### Red Hat 8.x: Upgrade Required Packages (legacy python3 / 3.6)
+
+If using **`acme2certifier-python3` on EL8**, upgrade:
 
 - [python3-cryptography](https://cryptography.io/en/latest/) to version 36.0.1 or higher.
 - [python3-dns](https://www.dnspython.org/) to version 2.1 or higher.
@@ -84,7 +121,7 @@ Backports of these packages from RHEL 9 can be found in the [A2C RPM repository]
 
 ### Additional Modules for Specific CA Handlers
 
-Depending on your CA handler, you may need these additional modules:
+Depending on your CA handler, you may need these additional modules (prefix must match the flavor: `python3-*` or `python39-*`):
 
 - [python3-impacket-0.11.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm) for [MS WCCE handler](https://github.com/grindsa/acme2certifier/blob/master/docs/mswcce.md).
 - [python3-ntlm-auth-1.5.0](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-ntlm-auth-1.5.0-2.el8.noarch.rpm) for [MS WSE handler](https://github.com/grindsa/acme2certifier/blob/master/docs/mscertsrv.md).
@@ -133,10 +170,11 @@ sudo systemctl start nginx.service
 
 ## 10. Verify the Server
 
-Smoke-check the import path:
+Smoke-check the import path (use the flavor interpreter from `/etc/acme2certifier/python.conf` when set):
 
 ```bash
 PYTHONPATH=/opt/acme2certifier python3 -c "import acme2certifier.acme_srv; print('ok')"
+# or: a2c-cli --help
 ```
 
 Test the directory resource:

--- a/docs/mswcce.md
+++ b/docs/mswcce.md
@@ -17,7 +17,7 @@ Be aware of the following limitations when using this handler:
 
 1. Active Directory Certificate Services (AD-CS) must be enabled and properly configured.
 1. The CA handler uses RPC/DCOM to communicate with the CA server, so the CA server must be accessible via **TCP port 445**.
-1. *(Optional)*: If installing from RPM or DEB and planning to use Kerberos authentication, ensure you have an updated [Impacket module (version 0.11 or higher)](https://github.com/fortra/impacket), as older versions have issues handling UTF-8 encoded passwords. You can find updated packages in the [A2C GitHub repository](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs).
+1. *(Optional)*: If installing from RPM or DEB and planning to use Kerberos authentication, ensure you have an updated [Impacket module (version 0.11 or higher)](https://github.com/fortra/impacket), as older versions have issues handling UTF-8 encoded passwords. You can find updated packages in the [A2C SBOM RPM repository](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs) (`rhel8/python36`, `rhel8/python39`, or `rhel9/python3`).
 1. You need a set of credentials with sufficient permissions to access the service and enrollment templates.
 
 ## Local Installation
@@ -28,7 +28,7 @@ Be aware of the following limitations when using this handler:
 
 Some malware scanners, such as Microsoft Defender, classify Impacket as a hacking tool (see [Fortra Impacket Issue #1762](https://github.com/fortra/impacket/issues/1762) or [Fortra Impacket Issue #1271](https://github.com/fortra/impacket/issues/1271#issuecomment-1058729047)). These alerts are triggered mainly by example scripts included in the package, not the library itself.
 
-To avoid issues with your security team, consider installing a stripped-down version of Impacket without flagged scripts. Pre-packaged versions are available for [RHEL 8](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm) and [RHEL 9](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel9/python3-impacket-0.11.0-2grindsa.el9.noarch.rpm) in the [SBOM repository](https://github.com/grindsa/sbom/tree/main/rpm-repo).
+To avoid issues with your security team, consider installing a stripped-down version of Impacket without flagged scripts. Pre-packaged versions are available for [RHEL 8 (python36)](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel8/python36/python3-impacket-0.11.0-2grindsa.el8.noarch.rpm), [RHEL 8 (python39)](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel8/python39), and [RHEL 9](https://github.com/grindsa/sbom/raw/main/rpm-repo/RPMs/rhel9/python3/python3-impacket-0.11.0-2grindsa.el9.noarch.rpm) in the [SBOM repository](https://github.com/grindsa/sbom/tree/main/rpm-repo).
 
 If installing from pip or source, follow these steps:
 

--- a/docs/tnauthlist.md
+++ b/docs/tnauthlist.md
@@ -12,7 +12,7 @@ The current implementation follows these specifications:
 
 - [RFC 9447 - Automated Certificate Management Environment (ACME) Challenges Using an Authority Token](https://www.rfc-editor.org/rfc/rfc9447)
 - [RFC 9448 - TNAuthList Profile of Automated Certificate Management Environment (ACME) Authority Token](https://www.rfc-editor.org/rfc/rfc9448.html)
-- [ATIS-1000080](https://access.atis.org/higherlogic/ws/public/download/69428)
+- [ATIS-1000080](https://atis.org/resources/signature-based-handling-of-asserted-information-using-tokens-shaken-governance-model-and-certificate-management-atis-1000080-v002/)
 
 ## Enabling TNAuthList Support
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -245,47 +245,136 @@ sudo -E a2c-manage loaddata status
 
 ---
 
-## RPM (WSGI)
+## RPM: pre-0.45 → 0.45+
 
-Paths: `/opt/acme2certifier`, config `/opt/acme2certifier/acme_srv.cfg` (`%config(noreplace)`).
+Paths: `/opt/acme2certifier`, config `/opt/acme2certifier/acme_srv.cfg` (`%config(noreplace)`). Greenfield install: [install_rpm.md](install_rpm.md).
 
-1. Backup cfg, DB, custom handlers.
-2. Install:
+Pre-0.45 RPMs were a **single** package that pulled system `python3-*` (EL8 = Python **3.6**). From 0.45 the layout is **payload + flavor**:
 
-```bash
-sudo yum -y localinstall ./acme2certifier-<version>-1.0.noarch.rpm
-# or: sudo ./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-*.rpm --mode wsgi
-```
+| Piece | Role |
+| --- | --- |
+| `acme2certifier-<ver>-1.0.noarch.rpm` | application under `/opt/acme2certifier` |
+| `acme2certifier-python39-<ver>-1.0.noarch.rpm` | **EL8 default** (Python 3.9) |
+| `acme2certifier-python3-<ver>-1.0.noarch.rpm` | **EL9 default** / EL8 optional legacy 3.6 |
+| SBOM companions | matching `python39-*` or `python3-*` from [grindsa/sbom](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs) |
+| `uwsgi-plugin-python39` | EL8 default uWSGI plugin (project RPM) |
 
-   ```bash
-   sudo yum -y localinstall ./acme2certifier-<version>-1.0.noarch.rpm \
-     ./acme2certifier-python3-<version>-1.0.noarch.rpm
-   # EL8 default 3.9: use acme2certifier-python39-*.rpm instead of python3
-   # or: sudo ./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-*.rpm --mode wsgi
-   ```
+Apply [Config](#config-all-install-types) (`*_module`, imports) together with the package swap below. Django settings/`INSTALLED_APPS`: see [Django settings](#django-settings-django-installs-only) above.
 
-```bash
-sudo cp /opt/acme2certifier/share/nginx/nginx_acme_srv.conf /etc/nginx/conf.d/
-sudo systemctl restart nginx acme2certifier
-```
-
-5. Verify: `curl -sS http://127.0.0.1/directory`
-
-## RPM (Django)
-
-1. Backup as above (DB includes `django_migrations` history; migration files ship in the RPM).
-2. Install with Django mode:
+### 1. Backup
 
 ```bash
-sudo ./examples/install_scripts/a2c-rpm.sh \
-  --rpm ./acme2certifier-<version>-1.0.noarch.rpm \
-  --mode django
+sudo systemctl stop acme2certifier nginx || true
+sudo cp -a /opt/acme2certifier/acme_srv.cfg /root/acme_srv.cfg.pre045.bak
+# SQLite (legacy path was often acme_srv/acme_srv.db)
+sudo cp -a /opt/acme2certifier/acme_srv.db /root/acme_srv.db.pre045.bak 2>/dev/null || true
+sudo cp -a /opt/acme2certifier/acme_srv/acme_srv.db /root/acme_srv.db.pre045.bak 2>/dev/null || true
+sudo cp -a /opt/acme2certifier/volume /root/acme2certifier-volume.pre045.bak 2>/dev/null || true
 ```
 
-3. Ensure uWSGI uses `module = acme2certifier.django_project.wsgi:application`.
-4. Update settings if you ship a custom `settings.py` (see Django section).
-5. Set `[DBhandler] handler: django` and `*_module` in `/opt/acme2certifier/acme_srv.cfg`.
-6. Migrate:
+### 2. Migrate `acme_srv.cfg`
+
+Edit `/opt/acme2certifier/acme_srv.cfg` (or the volume copy you symlink to it) per [Config](#config-all-install-types). Example:
+
+```ini
+[CAhandler]
+handler_module: acme2certifier.cahandlers.<your_handler>
+# remove: handler_file: ...
+
+[EABhandler]
+eab_handler_module: acme2certifier.eabhandlers.<your_handler>
+# remove: eab_handler_file: ...
+
+[Hooks]
+hooks_module: acme2certifier.hookhandlers.<your_hooks>
+# remove: hooks_file: ...
+
+[DBhandler]
+handler: wsgi   # or django
+```
+
+Custom handlers: set `handler_module:` to a **filesystem path** and fix imports to `acme2certifier.acme_srv…`. See [module mapping](#module-mapping).
+
+### 3. EL8: clear conflicting `python3-*` helpers, then install `python39-*`
+
+System / SBOM `python3-*` and grindsa `python39-*` both ship unversioned tools under `/usr/bin` (e.g. `django-admin`, `jws`). Install **one stack at a time**.
+
+```bash
+sudo systemctl stop acme2certifier nginx || true
+
+# Remove packages that own colliding /usr/bin paths before python39 companions
+# (--nodeps keeps the acme2certifier RPM until the flavor install below).
+for bin in /usr/bin/django-admin /usr/bin/jws; do
+  [[ -e "$bin" ]] || continue
+  pkg="$(rpm -qf --qf '%{NAME}' "$bin" 2>/dev/null || true)"
+  [[ -n "$pkg" ]] || continue
+  echo "Removing $pkg (owns $bin)"
+  sudo rpm -e --nodeps "$pkg" || true
+done
+
+sudo yum -y install python39
+sudo yum -y localinstall /path/to/sbom/rhel8/python39/*.noarch.rpm \
+  /path/to/sbom/rhel8/python39/*.$(uname -m).rpm
+```
+
+Companion leaf: [`RPMs/rhel8/python39/`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel8/python39).
+
+**EL9:** skip the python39 swap; keep system `python3` and use [`RPMs/rhel9/python3/`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel9/python3) only for grindsa backports you need.
+
+### 4. Install 0.45+ payload + flavor
+
+Download from [Releases](https://github.com/grindsa/acme2certifier/releases) into one directory (main + flavor + `uwsgi-plugin-python39` on EL8).
+
+**Preferred (EL8 → Python 3.9):**
+
+```bash
+chmod a+rx ./a2c-rpm.sh
+sudo ./a2c-rpm.sh --rpm ./acme2certifier-<version>-1.0.noarch.rpm \
+  --python 3.9 \
+  -m wsgi    # or: -m django
+```
+
+**Manual EL8:**
+
+```bash
+sudo yum -y localinstall \
+  ./acme2certifier-<version>-1.0.noarch.rpm \
+  ./acme2certifier-python39-<version>-1.0.noarch.rpm \
+  ./uwsgi-plugin-python39-*.rpm
+grep -E '^plugins' /opt/acme2certifier/acme2certifier.ini
+# expect: plugins = python39
+```
+
+**EL9:**
+
+```bash
+sudo ./a2c-rpm.sh --rpm ./acme2certifier-<version>-1.0.noarch.rpm --python 3 -m wsgi
+# or localinstall main + acme2certifier-python3-*.rpm + EPEL uwsgi-plugin-python3
+```
+
+`%config(noreplace)` keeps your edited `acme_srv.cfg` when present.
+
+### 5. WSGI SQLite path
+
+≤0.44 often stored SQLite at `/opt/acme2certifier/acme_srv/acme_srv.db`. 0.45+ defaults to `/opt/acme2certifier/acme_srv.db`. If you still have the old file only:
+
+```bash
+if [[ -f /opt/acme2certifier/acme_srv/acme_srv.db && ! -f /opt/acme2certifier/acme_srv.db ]]; then
+  sudo mv /opt/acme2certifier/acme_srv/acme_srv.db /opt/acme2certifier/acme_srv.db
+  sudo ln -sfn /opt/acme2certifier/acme_srv.db /opt/acme2certifier/acme_srv/acme_srv.db
+fi
+sudo chown nginx:nginx /opt/acme2certifier/acme_srv.db
+# ensure acme_srv.cfg [DBhandler] dbfile: points at the live path
+```
+
+### 6. Django mode extras
+
+If upgrading a Django deployment:
+
+1. Point settings at `acme2certifier.django_app` / `acme2certifier.django_project` (see [Django settings](#django-settings-django-installs-only)).
+2. Ensure uWSGI uses `module = acme2certifier.django_project.wsgi:application`.
+3. Set `[DBhandler] handler: django`.
+4. Migrate:
 
 ```bash
 export ACME_SRV_CONFIGFILE=/opt/acme2certifier/acme_srv.cfg
@@ -294,9 +383,21 @@ sudo -E a2c-manage migrate
 sudo -E a2c-manage loaddata status
 ```
 
-7. `sudo systemctl restart nginx acme2certifier`; verify `/directory`.
+### 7. Restart and verify
 
----
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart acme2certifier nginx
+curl -sS http://127.0.0.1/directory
+cat /etc/acme2certifier/python.conf   # EL8 default: python_interpreter=/usr/bin/python3.9
+PYTHONPATH=/opt/acme2certifier /usr/bin/python3.9 -c "import acme2certifier.acme_srv; print('ok')"
+```
+
+### 8. Staying on EL8 Python 3.6 (not recommended)
+
+Only if you cannot enable parallel 3.9: install `acme2certifier-python3` (legacy flavor) and companions from [`rhel8/python36/`](https://github.com/grindsa/sbom/tree/main/rpm-repo/RPMs/rhel8/python36), with `uwsgi-plugin-python3` and `plugins = python3`. You still must migrate cfg to `*_module` and package imports as in this document.
+
+______________________________________________________________________
 
 ## pip / venv (WSGI or Django)
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -257,8 +257,12 @@ sudo yum -y localinstall ./acme2certifier-<version>-1.0.noarch.rpm
 # or: sudo ./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-*.rpm --mode wsgi
 ```
 
-3. Edit `/opt/acme2certifier/acme_srv.cfg` → `*_module`; `[DBhandler] handler: wsgi`.
-4. Refresh nginx/uWSGI from share if needed:
+   ```bash
+   sudo yum -y localinstall ./acme2certifier-<version>-1.0.noarch.rpm \
+     ./acme2certifier-python3-<version>-1.0.noarch.rpm
+   # EL8 default 3.9: use acme2certifier-python39-*.rpm instead of python3
+   # or: sudo ./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-*.rpm --mode wsgi
+   ```
 
 ```bash
 sudo cp /opt/acme2certifier/share/nginx/nginx_acme_srv.conf /etc/nginx/conf.d/

--- a/examples/install_scripts/a2c-rpm.sh
+++ b/examples/install_scripts/a2c-rpm.sh
@@ -37,6 +37,7 @@
 # Notes:
 #   - Works on AlmaLinux / RHEL / Rocky / CentOS Stream 8 and 9 (dnf or yum).
 #   - Default app Python is 3.9 (EL8: acme2certifier-python39, EL9: acme2certifier-python3).
+#   - EL8 python39 uses uwsgi-plugin-python39 (project RPM beside the main RPM, or repos).
 #   - If EL8 python39 flavor localinstall fails (missing modules), falls back to
 #     acme2certifier-python3 (3.6) unless --python was set explicitly.
 #   - Installs EPEL + nginx + uWSGI stack (soft Recommends of the RPM).
@@ -146,6 +147,65 @@ find_flavor_rpm() {
     fi
   fi
   return 1
+}
+
+# Locate uwsgi-plugin-python39 (or similar) next to the main RPM / data-dir.
+find_named_rpm() {
+  local pkg_name="$1"
+  local main_rpm="${2:-}"
+  local matches=()
+  local dir=""
+  if [[ -n "${main_rpm}" ]]; then
+    dir="$(dirname "${main_rpm}")"
+    # shellcheck disable=SC2086
+    mapfile -t matches < <(ls -1t "${dir}/${pkg_name}"-*.rpm 2>/dev/null || true)
+    if [[ ${#matches[@]} -gt 0 && -f "${matches[0]}" ]]; then
+      printf '%s\n' "${matches[0]}"
+      return 0
+    fi
+  fi
+  if [[ -n "${DATA_DIR}" ]]; then
+    # shellcheck disable=SC2086
+    mapfile -t matches < <(ls -1t "${DATA_DIR}/${pkg_name}"-*.rpm 2>/dev/null || true)
+    if [[ ${#matches[@]} -gt 0 && -f "${matches[0]}" ]]; then
+      printf '%s\n' "${matches[0]}"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Install the uWSGI Python plugin matching the selected flavor.
+# python39 → uwsgi-plugin-python39 (project/local RPM preferred); else system python3 plugin.
+install_uwsgi_python_plugin() {
+  local flavor="$1"
+  local main_rpm="${2:-}"
+  local plugin_pkg plugin_file
+  if [[ "${flavor}" == "acme2certifier-python39" ]]; then
+    plugin_pkg="uwsgi-plugin-python39"
+    if plugin_file="$(find_named_rpm "${plugin_pkg}" "${main_rpm}")"; then
+      echo "==> Installing ${plugin_pkg} from ${plugin_file}"
+      ${SUDO} ${PKG} localinstall -y "${plugin_file}"
+      return 0
+    fi
+    echo "==> Installing ${plugin_pkg} from repos"
+    if ! ${SUDO} ${PKG} install -y "${plugin_pkg}"; then
+      echo "ERROR: ${plugin_pkg} not found locally or in repos." >&2
+      echo "       Place ${plugin_pkg}-*.rpm next to the main RPM (project SBOM/build)." >&2
+      return 1
+    fi
+    return 0
+  fi
+  plugin_pkg="uwsgi-plugin-python3"
+  echo "==> Installing ${plugin_pkg} (+ python3-uwsgidecorators)"
+  ${SUDO} ${PKG} install -y "${plugin_pkg}" python3-uwsgidecorators
+}
+
+uwsgi_plugins_value() {
+  case "$1" in
+    acme2certifier-python39) echo "python39" ;;
+    *) echo "python3" ;;
+  esac
 }
 
 resolve_flavor_name() {
@@ -510,13 +570,12 @@ ${SUDO} ${PKG} install -y curl --allowerasing 2>/dev/null || ${SUDO} ${PKG} inst
 ${SUDO} ${PKG} install -y \
   nginx \
   uwsgi \
-  uwsgi-plugin-python3 \
-  python3-uwsgidecorators \
   openssl \
   policycoreutils-python-utils \
   checkpolicy \
   tar \
   procps-ng
+# Matching Python plugin is installed after flavor resolve (incl. fallback).
 
 if [[ "${MODE}" == "django" ]]; then
   echo "==> Installing Django-related system packages"
@@ -560,6 +619,8 @@ if ! ${SUDO} ${PKG} localinstall -y "${RPM_FILE}" "${FLAVOR_FILE}"; then
     exit 1
   fi
 fi
+
+install_uwsgi_python_plugin "${FLAVOR_PKG}" "${RPM_FILE}" || exit 1
 
 PY_BIN="$(selected_python_bin)"
 echo "==> Verifying package import (PYTHONPATH=${APP_ROOT}, python=${PY_BIN})"
@@ -658,7 +719,12 @@ else
     -e 's/module = acme2certifier\.django_project\.wsgi.*/module = acme2certifier_wsgi:application/' \
     "${UWSGI_INI}" || true
 fi
-grep -q '^plugins' "${UWSGI_INI}" || echo 'plugins = python3' | ${SUDO} tee -a "${UWSGI_INI}" >/dev/null
+UWSGI_PLUGIN="$(uwsgi_plugins_value "${FLAVOR_PKG}")"
+if grep -q '^plugins' "${UWSGI_INI}"; then
+  ${SUDO} sed -i "s|^plugins[[:space:]]*=.*|plugins = ${UWSGI_PLUGIN}|" "${UWSGI_INI}"
+else
+  echo "plugins = ${UWSGI_PLUGIN}" | ${SUDO} tee -a "${UWSGI_INI}" >/dev/null
+fi
 if grep -q '^python-path' "${UWSGI_INI}"; then
   ${SUDO} sed -i "s|^python-path = .*|python-path = ${APP_ROOT}|" "${UWSGI_INI}"
 else

--- a/examples/install_scripts/a2c-rpm.sh
+++ b/examples/install_scripts/a2c-rpm.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Install acme2certifier from a local .rpm (Nginx + uWSGI) on EL8 / EL9.
 #
-# Install root: /opt/acme2certifier (RPM layout; PYTHONPATH-based, Python 3.6+).
+# Install root: /opt/acme2certifier (RPM layout; PYTHONPATH-based).
+# Python modules come from a flavor metapackage (see docs/architecture/rpm-el-packaging.md).
 # For PyPI/venv on EL9 only, use a2c-rel-nginx.sh instead.
 #
 # Usage:
@@ -9,9 +10,13 @@
 #   ./examples/install_scripts/a2c-rpm.sh install|restart|update [options]
 #
 # Options:
-#   -r, --rpm PATH              path to acme2certifier-*.noarch.rpm (required unless
-#                               a matching .rpm is found in . / .. / data-dir)
+#   -r, --rpm PATH              path to main acme2certifier-*.noarch.rpm (required unless
+#                               a matching .rpm is found in . / .. / data-dir). Flavor
+#                               RPMs are taken from the same directory.
 #   -m, --mode wsgi|django      application mode (default: wsgi)
+#       --python VER|NAME       flavor: 3.9|39|python39 (EL8 default),
+#                               3|python3 (EL9 default / EL8 legacy 3.6),
+#                               3.6 (alias for python3 on EL8)
 #       --restart               sync volume/cfg and restart nginx + acme2certifier
 #       --update                sync volume/acme_ca only (no restart)
 #       --volume-dir DIR        sync DIR into APP_ROOT/volume (default: use
@@ -25,15 +30,17 @@
 #   ./examples/install_scripts/a2c-rpm.sh --rpm ./acme2certifier-0.45.dev1-1.0.noarch.rpm
 #   ./examples/install_scripts/a2c-rpm.sh -r ../acme2certifier-*.rpm -m django
 #   ./examples/install_scripts/a2c-rpm.sh install -m wsgi --no-ssl
+#   ./examples/install_scripts/a2c-rpm.sh install --python 3.6   # EL8 legacy
 #   ./examples/install_scripts/a2c-rpm.sh restart
-#   ./examples/install_scripts/a2c-rpm.sh restart -m django
 #   ./examples/install_scripts/a2c-rpm.sh --update --volume-dir /tmp/acme2certifier/volume
 #
 # Notes:
 #   - Works on AlmaLinux / RHEL / Rocky / CentOS Stream 8 and 9 (dnf or yum).
+#   - Default app Python is 3.9 (EL8: acme2certifier-python39, EL9: acme2certifier-python3).
+#   - If EL8 python39 flavor localinstall fails (missing modules), falls back to
+#     acme2certifier-python3 (3.6) unless --python was set explicitly.
 #   - Installs EPEL + nginx + uWSGI stack (soft Recommends of the RPM).
-#   - EL8 may need newer cryptography/dns/jwcrypto from the A2C RPM repo; see
-#     docs/install_rpm.md. CI installs those via .github/actions/rpm_prep.
+#   - EL8 legacy 3.6 may need cryptography/dns/jwcrypto backports; see docs/install_rpm.md.
 #   - MSSQL (msodbcsql18 / mssql-django) is also installed by rpm_prep when
 #     DJANGO_DB=mssql — not by this script.
 #   - CI-only host tweaks (syslog-ng/krb5, nginx.conf trim) stay in rpm_prep, not here.
@@ -48,35 +55,52 @@ RPM_GLOBS=()
 ENABLE_SSL=1
 VOLUME_DIR=""
 DATA_DIR=""
+PYTHON_OPT=""
+FLAVOR_PKG=""
 APP_ROOT="/opt/acme2certifier"
 CFG="${APP_ROOT}/acme_srv.cfg"
 SHARE="${APP_ROOT}/share"
 UWSGI_INI="${APP_ROOT}/acme2certifier.ini"
+PYTHON_CONF="/etc/acme2certifier/python.conf"
 NGINX_USER="nginx"
 
 usage() {
-  sed -n '2,36p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,42p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# Prefer the main payload RPM; skip flavor packages (acme2certifier-python*).
+pick_main_rpm() {
+  local f
+  for f in "$@"; do
+    [[ -f "${f}" ]] || continue
+    case "$(basename "${f}")" in
+      acme2certifier-python*) continue ;;
+      acme2certifier-*.rpm|acme2certifier-*.RPM) printf '%s\n' "${f}"; return 0 ;;
+    esac
+  done
+  return 1
 }
 
 find_rpm() {
   local candidate
   local candidates=()
+  local matches=()
 
   if [[ ${#RPM_GLOBS[@]} -gt 1 ]]; then
-    ls -1t "${RPM_GLOBS[@]}" 2>/dev/null | head -n 1
-    return 0
+    # shellcheck disable=SC2086
+    mapfile -t matches < <(ls -1t "${RPM_GLOBS[@]}" 2>/dev/null || true)
+    pick_main_rpm "${matches[@]}" && return 0
   fi
   if [[ ${#RPM_GLOBS[@]} -eq 1 ]]; then
     candidate="${RPM_GLOBS[0]}"
     # shellcheck disable=SC2086
     if compgen -G "${candidate}" >/dev/null 2>&1; then
       # shellcheck disable=SC2086
-      ls -1t ${candidate} 2>/dev/null | head -n 1
-      return 0
+      mapfile -t matches < <(ls -1t ${candidate} 2>/dev/null || true)
+      pick_main_rpm "${matches[@]}" && return 0
     fi
     if [[ -f "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return 0
+      pick_main_rpm "${candidate}" && return 0
     fi
   elif [[ -n "${RPM_PATH}" ]]; then
     candidates+=("${RPM_PATH}")
@@ -91,15 +115,81 @@ find_rpm() {
     # shellcheck disable=SC2086
     if compgen -G "${candidate}" >/dev/null 2>&1; then
       # shellcheck disable=SC2086
-      ls -1t ${candidate} 2>/dev/null | head -n 1
-      return 0
+      mapfile -t matches < <(ls -1t ${candidate} 2>/dev/null || true)
+      pick_main_rpm "${matches[@]}" && return 0
     fi
     if [[ -f "${candidate}" ]]; then
-      printf '%s\n' "${candidate}"
-      return 0
+      pick_main_rpm "${candidate}" && return 0
     fi
   done
   return 1
+}
+
+find_flavor_rpm() {
+  local flavor_name="$1"
+  local main_rpm="$2"
+  local dir
+  dir="$(dirname "${main_rpm}")"
+  local matches=()
+  # shellcheck disable=SC2086
+  mapfile -t matches < <(ls -1t "${dir}/${flavor_name}"-*.rpm "${dir}/${flavor_name}"-*.noarch.rpm 2>/dev/null || true)
+  if [[ ${#matches[@]} -gt 0 && -f "${matches[0]}" ]]; then
+    printf '%s\n' "${matches[0]}"
+    return 0
+  fi
+  if [[ -n "${DATA_DIR}" ]]; then
+    # shellcheck disable=SC2086
+    mapfile -t matches < <(ls -1t "${DATA_DIR}/${flavor_name}"-*.rpm 2>/dev/null || true)
+    if [[ ${#matches[@]} -gt 0 && -f "${matches[0]}" ]]; then
+      printf '%s\n' "${matches[0]}"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+resolve_flavor_name() {
+  local el="$1"
+  local opt="${2:-}"
+  local normalized
+  normalized="$(echo "${opt}" | tr '[:upper:]' '[:lower:]')"
+  case "${normalized}" in
+    "" )
+      if [[ "${el}" == "8" ]]; then
+        echo "acme2certifier-python39"
+      else
+        echo "acme2certifier-python3"
+      fi
+      ;;
+    3.9|39|python39|acme2certifier-python39)
+      echo "acme2certifier-python39"
+      ;;
+    3.6|3|python3|acme2certifier-python3)
+      echo "acme2certifier-python3"
+      ;;
+    3.11|311|python3.11|acme2certifier-python3.11)
+      echo "acme2certifier-python3.11"
+      ;;
+    *)
+      echo "ERROR: unsupported --python value: ${opt}" >&2
+      echo "       use 3.9|39|python39, 3.6|3|python3, or 3.11" >&2
+      return 1
+      ;;
+  esac
+}
+
+selected_python_bin() {
+  if [[ -r "${PYTHON_CONF}" ]]; then
+    local py
+    py="$(awk -F= '/^[[:space:]]*python_interpreter[[:space:]]*=/ {
+      gsub(/[[:space:]]/, "", $2); print $2; exit
+    }' "${PYTHON_CONF}" 2>/dev/null || true)"
+    if [[ -n "${py}" && -x "${py}" ]]; then
+      printf '%s\n' "${py}"
+      return 0
+    fi
+  fi
+  printf '%s\n' "/usr/bin/python3"
 }
 
 el_major() {
@@ -322,6 +412,14 @@ while [[ $# -gt 0 ]]; do
       MODE_EXPLICIT=1
       shift 2
       ;;
+    --python)
+      PYTHON_OPT="${2:-}"
+      if [[ -z "${PYTHON_OPT}" ]]; then
+        echo "ERROR: --python requires a value (e.g. 3.9, 3.6, python3)" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
     --volume-dir)
       VOLUME_DIR="${2:-}"
       shift 2
@@ -382,12 +480,29 @@ fi
 EL_MAJOR="$(el_major)"
 echo "==> Detected package manager: ${PKG} (EL major: ${EL_MAJOR})"
 
+FLAVOR_PKG="$(resolve_flavor_name "${EL_MAJOR}" "${PYTHON_OPT}")" || exit 1
+echo "==> Python flavor (requested): ${FLAVOR_PKG}"
+
 RPM_FILE="$(find_rpm)" || {
-  echo "ERROR: no .rpm found. Pass --rpm /path/to/acme2certifier-*.noarch.rpm" >&2
+  echo "ERROR: no main .rpm found. Pass --rpm /path/to/acme2certifier-<ver>-*.noarch.rpm" >&2
   exit 1
 }
 RPM_FILE="$(readlink -f "${RPM_FILE}")"
 echo "==> Using package: ${RPM_FILE}"
+
+resolve_flavor_file() {
+  local flavor="$1"
+  local f
+  f="$(find_flavor_rpm "${flavor}" "${RPM_FILE}")" || return 1
+  readlink -f "${f}"
+}
+
+FLAVOR_FILE="$(resolve_flavor_file "${FLAVOR_PKG}")" || {
+  echo "ERROR: flavor RPM ${FLAVOR_PKG}-*.rpm not found next to ${RPM_FILE}" >&2
+  echo "       Build/copy subpackages from the same rpmbuild (python3 / python39)." >&2
+  exit 1
+}
+echo "==> Using flavor: ${FLAVOR_FILE}"
 
 echo "==> Installing EPEL + Nginx/uWSGI stack"
 ${SUDO} ${PKG} install -y epel-release
@@ -406,34 +521,57 @@ ${SUDO} ${PKG} install -y \
 if [[ "${MODE}" == "django" ]]; then
   echo "==> Installing Django-related system packages"
   DJANGO_RPM=""
-  for cand in python3-django4.2 python3-django; do
+  DJANGO_CANDS=(python3-django4.2 python3-django)
+  if [[ "${FLAVOR_PKG}" == "acme2certifier-python39" ]]; then
+    DJANGO_CANDS=(python39-django python3-django4.2 python3-django)
+  fi
+  for cand in "${DJANGO_CANDS[@]}"; do
     if ${SUDO} ${PKG} install -y "${cand}" 2>/dev/null; then
       DJANGO_RPM="${cand}"
       break
     fi
   done
   if [[ -z "${DJANGO_RPM}" ]]; then
-    echo "ERROR: could not install Django (tried python3-django4.2, python3-django)." >&2
+    echo "ERROR: could not install Django (tried: ${DJANGO_CANDS[*]})." >&2
     echo "       Enable EPEL / CRB and retry, or install Django manually." >&2
     exit 1
   fi
   echo "==> Installed Django package: ${DJANGO_RPM}"
-  for cand in python3-pyyaml python3-mysqlclient python3-PyMySQL python3-psycopg2 python3-sqlparse; do
+  for cand in python3-pyyaml python3-mysqlclient python3-PyMySQL python3-psycopg2 python3-sqlparse \
+              python39-pyyaml python39-mysqlclient python39-PyMySQL python39-psycopg2; do
     ${SUDO} ${PKG} install -y "${cand}" 2>/dev/null || true
   done
-  if ! ${SUDO} python3 -c "import django; print('django', django.get_version())"; then
-    echo "ERROR: Django RPM installed but 'import django' failed" >&2
+fi
+
+echo "==> Installing ${RPM_FILE} + ${FLAVOR_FILE}"
+if ! ${SUDO} ${PKG} localinstall -y "${RPM_FILE}" "${FLAVOR_FILE}"; then
+  if [[ "${EL_MAJOR}" == "8" \
+     && "${FLAVOR_PKG}" == "acme2certifier-python39" \
+     && -z "${PYTHON_OPT}" ]]; then
+    echo "==> WARN: python39 flavor install failed; falling back to acme2certifier-python3 (EL8 legacy 3.6)"
+    FLAVOR_PKG="acme2certifier-python3"
+    FLAVOR_FILE="$(resolve_flavor_file "${FLAVOR_PKG}")" || {
+      echo "ERROR: fallback flavor RPM ${FLAVOR_PKG}-*.rpm not found" >&2
+      exit 1
+    }
+    echo "==> Using flavor: ${FLAVOR_FILE}"
+    ${SUDO} ${PKG} localinstall -y "${RPM_FILE}" "${FLAVOR_FILE}"
+  else
     exit 1
   fi
 fi
 
-echo "==> Installing ${RPM_FILE}"
-${SUDO} ${PKG} localinstall -y "${RPM_FILE}"
-
-echo "==> Verifying package import (PYTHONPATH=${APP_ROOT})"
-${SUDO} env PYTHONPATH="${APP_ROOT}" python3 -c \
+PY_BIN="$(selected_python_bin)"
+echo "==> Verifying package import (PYTHONPATH=${APP_ROOT}, python=${PY_BIN})"
+${SUDO} env PYTHONPATH="${APP_ROOT}" "${PY_BIN}" -c \
   "import acme2certifier.acme_srv; from acme2certifier.acme_srv.version import __version__; print('acme2certifier', __version__)"
 command -v a2c-cli >/dev/null
+if [[ "${MODE}" == "${MODE_DJANGO}" ]]; then
+  if ! ${SUDO} "${PY_BIN}" -c "import django; print('${MODE_DJANGO}', django.get_version())"; then
+    echo "ERROR: Django installed but 'import django' failed with ${PY_BIN}" >&2
+    exit 1
+  fi
+fi
 
 ${SUDO} mkdir -p "${APP_ROOT}/volume" /run/uwsgi
 
@@ -590,15 +728,16 @@ ${SUDO} systemctl restart acme2certifier
 ${SUDO} systemctl restart nginx
 
 echo
-echo "Done. mode=${MODE} el=${EL_MAJOR}"
+echo "Done. mode=${MODE} el=${EL_MAJOR} flavor=${FLAVOR_PKG} python=${PY_BIN}"
 echo "  App root: ${APP_ROOT}"
 echo "  Config:   ${CFG}"
+echo "  Python:   ${PYTHON_CONF}"
 echo "  Test:     curl -sS http://127.0.0.1/directory | head"
 echo "  Next:     edit ${CFG} (CA handler), see docs/acme_srv.md"
 echo "  Logs:     journalctl -u acme2certifier -n 50 --no-pager"
-echo "            tail -n 50 /var/log/nginx/error.log"
-if [[ "${EL_MAJOR}" == "8" ]]; then
+echo "            tail -n 50 /var/log/nginx/error.log" >&2
+if [[ "${EL_MAJOR}" == "8" && "${FLAVOR_PKG}" == "acme2certifier-python3" ]]; then
   echo
-  echo "  Note (EL8): if imports fail on cryptography/jwcrypto/dns, install"
+  echo "  Note (EL8 legacy 3.6): if imports fail on cryptography/jwcrypto/dns, install"
   echo "  backports from https://github.com/grindsa/sbom (docs/install_rpm.md)."
 fi

--- a/examples/install_scripts/fetch-sbom-rpms.sh
+++ b/examples/install_scripts/fetch-sbom-rpms.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Fetch companion RPMs from grindsa/sbom (same logic as rpm_prep
+# "Retrieve rpm from SBOM repo").
+#
+# Usage:
+#   ./examples/install_scripts/fetch-sbom-rpms.sh -v 8
+#   ./examples/install_scripts/fetch-sbom-rpms.sh -v 8 -s python36 -d /tmp/acme2certifier
+#   ./examples/install_scripts/fetch-sbom-rpms.sh -v 9 --local-sbom ~/Development/sbom
+#
+# Env (optional, mirrors CI):
+#   RH_VERSION, PYTHON_STACK, GH_USER, GH_SBOM_REPO_TOKEN, DEST_DIR
+set -euo pipefail
+
+RH_VERSION="${RH_VERSION:-}"
+PYTHON_STACK="${PYTHON_STACK:-}"
+GH_USER="${GH_USER:-grindsa}"
+GH_SBOM_REPO_TOKEN="${GH_SBOM_REPO_TOKEN:-}"
+DEST_DIR="${DEST_DIR:-data}"
+LOCAL_SBOM=""
+CLONE_DIR="${CLONE_DIR:-/tmp/sbom}"
+KEEP_CLONE=0
+
+usage() {
+  cat <<'EOF'
+Usage: fetch-sbom-rpms.sh -v 8|9 [options]
+
+Options:
+  -v, --rh-version N     EL major (8 or 9) [required unless RH_VERSION set]
+  -s, --stack NAME       python39 (EL8 default) | python36 | python3 (EL9 default)
+  -d, --dest DIR         destination directory (default: data)
+  -u, --gh-user USER     GitHub user/org owning sbom (default: grindsa)
+  -t, --token TOKEN      GitHub token (or GH_SBOM_REPO_TOKEN); omit for public HTTPS
+      --local-sbom DIR   use existing sbom checkout instead of cloning
+      --clone-dir DIR    clone target (default: /tmp/sbom)
+      --keep-clone       do not rm -rf clone dir before clone
+  -h, --help             show this help
+
+Copies only *.noarch.rpm and *.<uname -m>.rpm from:
+  rpm-repo/RPMs/rhel<N>/<stack>/
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -v|--rh-version) RH_VERSION="$2"; shift 2 ;;
+    -s|--stack) PYTHON_STACK="$2"; shift 2 ;;
+    -d|--dest) DEST_DIR="$2"; shift 2 ;;
+    -u|--gh-user) GH_USER="$2"; shift 2 ;;
+    -t|--token) GH_SBOM_REPO_TOKEN="$2"; shift 2 ;;
+    --local-sbom) LOCAL_SBOM="$2"; shift 2 ;;
+    --clone-dir) CLONE_DIR="$2"; shift 2 ;;
+    --keep-clone) KEEP_CLONE=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${RH_VERSION}" ]]; then
+  echo "ERROR: -v/--rh-version (or RH_VERSION) required" >&2
+  usage >&2
+  exit 1
+fi
+
+STACK="${PYTHON_STACK:-}"
+if [[ -z "${STACK}" ]]; then
+  case "${RH_VERSION}" in
+    8) STACK=python39 ;;
+    9) STACK=python3 ;;
+    *)
+      echo "ERROR: unsupported RH_VERSION=${RH_VERSION} (expected 8 or 9)" >&2
+      exit 1
+      ;;
+  esac
+fi
+case "${STACK}" in
+  python36|python39|python3) ;;
+  *)
+    echo "ERROR: PYTHON_STACK must be python36|python39|python3 (got: ${STACK})" >&2
+    exit 1
+    ;;
+esac
+
+LEAF="rpm-repo/RPMs/rhel${RH_VERSION}/${STACK}"
+echo "SBOM leaf: ${LEAF}"
+
+if [[ -n "${LOCAL_SBOM}" ]]; then
+  SBOM_ROOT="${LOCAL_SBOM}"
+  if [[ ! -d "${SBOM_ROOT}" ]]; then
+    echo "ERROR: --local-sbom not a directory: ${SBOM_ROOT}" >&2
+    exit 1
+  fi
+else
+  if [[ "${KEEP_CLONE}" -eq 0 ]]; then
+    rm -rf "${CLONE_DIR}"
+  fi
+  if [[ -n "${GH_SBOM_REPO_TOKEN}" ]]; then
+    REMOTE="https://${GH_USER}:${GH_SBOM_REPO_TOKEN}@github.com/${GH_USER}/sbom"
+  else
+    REMOTE="https://github.com/${GH_USER}/sbom.git"
+  fi
+  # Partial clone + sparse checkout: only the needed RPM leaf (not whole repo / SRPMs)
+  git clone --filter=blob:none --sparse --depth 1 "${REMOTE}" "${CLONE_DIR}"
+  git -C "${CLONE_DIR}" sparse-checkout set "${LEAF}"
+  SBOM_ROOT="${CLONE_DIR}"
+fi
+
+SRC="${SBOM_ROOT}/${LEAF}"
+if [[ ! -d "${SRC}" ]]; then
+  echo "ERROR: missing SBOM path ${SRC}" >&2
+  ls -la "${SBOM_ROOT}/rpm-repo/RPMs/rhel${RH_VERSION}/" 2>/dev/null || true
+  exit 1
+fi
+
+mkdir -p "${DEST_DIR}"
+ARCH="$(uname -m)"
+shopt -s nullglob
+copied=0
+for r in "${SRC}"/*.noarch.rpm "${SRC}"/*."${ARCH}".rpm; do
+  [[ -f "${r}" ]] || continue
+  cp -v "${r}" "${DEST_DIR}/"
+  copied=$((copied + 1))
+done
+echo "Staged ${copied} companion RPM(s) for arch=${ARCH} from ${LEAF} → ${DEST_DIR}/"
+ls -la "${DEST_DIR}"/*.rpm 2>/dev/null | head -50 || true

--- a/examples/install_scripts/rpm/acme2certifier.spec
+++ b/examples/install_scripts/rpm/acme2certifier.spec
@@ -28,9 +28,9 @@ Requires:       tar
 Requires(post): policycoreutils
 Requires:       policycoreutils-python-utils
 
-# Web stack is operator-chosen (nginx+uWSGI or httpd+mod_wsgi)
+# Web stack is operator-chosen (nginx+uWSGI or httpd+mod_wsgi).
+# Matching uWSGI Python plugin is Recommended on each flavor.
 Recommends:      nginx
-Recommends:      uwsgi-plugin-python3
 Recommends:      krb5-workstation
 Recommends:      krb5-libs
 
@@ -69,6 +69,7 @@ Requires:       python3-xmltodict
 Requires:       python3-pyasn1
 Requires:       python3-pyasn1-modules
 Requires:       python3-pyyaml
+Recommends:      uwsgi-plugin-python3
 Recommends:      python3-uwsgidecorators
 Recommends:      python3-dataclasses
 Conflicts:      acme2certifier-python39
@@ -80,7 +81,8 @@ Python flavor for acme2certifier using system python3-* modules.
   - EL9: default (system Python 3.9)
   - EL8: legacy/fallback (system Python 3.6)
 
-Writes %{python_confdir}/python.conf and conflicts with other flavors.
+Writes %{python_confdir}/python.conf, sets uWSGI plugins = python3,
+and conflicts with other flavors.
 
 %package -n acme2certifier-python39
 Summary:        acme2certifier runtime for Python 3.9 (python39-*)
@@ -102,14 +104,17 @@ Requires:       python39-xmltodict
 Requires:       python39-pyasn1
 Requires:       python39-pyasn1-modules
 Requires:       python39-pyyaml
+Recommends:      uwsgi-plugin-python39
 Conflicts:      acme2certifier-python3
 Conflicts:      acme2certifier-python3.11
 
 %description -n acme2certifier-python39
 Python flavor for acme2certifier using python39-* modules (EL8 default app runtime).
 
-Writes %{python_confdir}/python.conf and conflicts with other flavors.
-Missing modules may come from AppStream/EPEL or project-provided RPMs.
+Writes %{python_confdir}/python.conf, sets uWSGI plugins = python39,
+and conflicts with other flavors.
+Missing modules / uwsgi-plugin-python39 may come from AppStream/EPEL
+or project-provided RPMs.
 
 %prep
 %autosetup -p1 -n %{name}-%{?ghsha}%{?!ghsha:%{version}} -N
@@ -308,6 +313,14 @@ DST="${CONFDIR}/python.conf"
 if [ "$1" -eq 1 ] || [ ! -e "${DST}" ]; then
     cp -a "${SRC}" "${DST}"
 fi
+INI=%{app_root}/acme2certifier.ini
+if [ -f "${INI}" ]; then
+    if grep -q '^plugins' "${INI}"; then
+        sed -i 's/^plugins[[:space:]]*=.*/plugins = python3/' "${INI}"
+    else
+        echo 'plugins = python3' >> "${INI}"
+    fi
+fi
 
 %post -n acme2certifier-python39
 CONFDIR=%{python_confdir}
@@ -315,6 +328,14 @@ SRC="${CONFDIR}/python.conf.python39"
 DST="${CONFDIR}/python.conf"
 if [ "$1" -eq 1 ] || [ ! -e "${DST}" ]; then
     cp -a "${SRC}" "${DST}"
+fi
+INI=%{app_root}/acme2certifier.ini
+if [ -f "${INI}" ]; then
+    if grep -q '^plugins' "${INI}"; then
+        sed -i 's/^plugins[[:space:]]*=.*/plugins = python39/' "${INI}"
+    else
+        echo 'plugins = python39' >> "${INI}"
+    fi
 fi
 
 %postun python3

--- a/examples/install_scripts/rpm/acme2certifier.spec
+++ b/examples/install_scripts/rpm/acme2certifier.spec
@@ -1,5 +1,8 @@
-# Dual-EL noarch package: install under /opt (not %{python3_sitelib})
-# so one RPM works on EL8 (Python 3.6) and EL9 (Python 3.9).
+# Dual-EL noarch packaging (see docs/architecture/rpm-el-packaging.md):
+#   acme2certifier           — /opt payload (no python*-* module Requires)
+#   acme2certifier-python3   — system python3-* (EL9 default 3.9 / EL8 legacy 3.6)
+#   acme2certifier-python39  — parallel Python 3.9 (EL8 default)
+#
 # Disable automatic requires/provides processing
 AutoReqProv: no
 
@@ -7,6 +10,7 @@ AutoReqProv: no
 %global         __python        %{__python3}
 %global         dest_dir        /opt
 %global         app_root        %{dest_dir}/%{projname}
+%global         python_confdir  %{_sysconfdir}/%{projname}
 %{!?_unitdir: %global _unitdir /usr/lib/systemd/system}
 
 Summary:        library implementing ACME server functionality
@@ -19,9 +23,36 @@ Release:        1.0
 License:        GPL3; @grindsa@github
 URL:            https://github.com/grindsa/acme2certifier
 
-# Core runtime (EPEL often required on EL8)
-Requires:       python3
+# OS / packaging helpers only — Python modules live on flavor subpackages
 Requires:       tar
+Requires(post): policycoreutils
+Requires:       policycoreutils-python-utils
+
+# Web stack is operator-chosen (nginx+uWSGI or httpd+mod_wsgi)
+Recommends:      nginx
+Recommends:      uwsgi-plugin-python3
+Recommends:      krb5-workstation
+Recommends:      krb5-libs
+
+BuildArch:		noarch
+
+Source0:        %{name}-%{version}.tar.gz
+
+%description
+acme2certifier is an ACME protocol proxy for CA servers that do not speak ACME natively.
+
+This RPM installs the application under %{app_root} (PYTHONPATH=%{app_root}).
+Install a Python flavor metapackage for module dependencies:
+
+  - acme2certifier-python39  — EL8 default (parallel Python 3.9)
+  - acme2certifier-python3   — EL9 default (system 3.9) / EL8 legacy (system 3.6)
+
+See docs/architecture/rpm-el-packaging.md and docs/install_rpm.md.
+
+%package python3
+Summary:        acme2certifier runtime for system Python 3 (python3-*)
+Requires:       %{name} = %{version}-%{release}
+Requires:       python3
 Requires:       python3-dateutil
 Requires:       python3-pytz
 Requires:       python3-setuptools
@@ -38,37 +69,47 @@ Requires:       python3-xmltodict
 Requires:       python3-pyasn1
 Requires:       python3-pyasn1-modules
 Requires:       python3-pyyaml
-Requires(post): policycoreutils
-Requires:       policycoreutils-python-utils
-
-# Web stack is operator-chosen (nginx+uWSGI or httpd+mod_wsgi)
-Recommends:      nginx
-Recommends:      uwsgi-plugin-python3
 Recommends:      python3-uwsgidecorators
 Recommends:      python3-dataclasses
-Recommends:      krb5-workstation
-Recommends:      krb5-libs
+Conflicts:      acme2certifier-python39
+Conflicts:      acme2certifier-python3.11
 
-BuildArch:		noarch
+%description python3
+Python flavor for acme2certifier using system python3-* modules.
 
-Source0:        %{name}-%{version}.tar.gz
+  - EL9: default (system Python 3.9)
+  - EL8: legacy/fallback (system Python 3.6)
 
-%description
-acme2certifier is an ACME protocol proxy for CA servers that do not speak ACME natively.
+Writes %{python_confdir}/python.conf and conflicts with other flavors.
 
-This RPM installs:
-  - the acme2certifier Python package under %{app_root}/acme2certifier
-    (PYTHONPATH=%{app_root}; works on EL8 Python 3.6 and EL9 Python 3.9)
-  - deploy files under %{app_root} (WSGI entry, share/, examples/, systemd unit)
-  - console wrappers in %{_bindir} (a2c-*)
+%package -n acme2certifier-python39
+Summary:        acme2certifier runtime for Python 3.9 (python39-*)
+Requires:       %{name} = %{version}-%{release}
+Requires:       python39
+Requires:       python39-dateutil
+Requires:       python39-pytz
+Requires:       python39-setuptools
+Requires:       python39-jwcrypto
+Requires:       python39-cryptography
+Requires:       python39-pyOpenSSL
+Requires:       python39-dns
+Requires:       python39-requests
+Requires:       python39-requests-pkcs12
+Requires:       python39-pysocks
+Requires:       python39-josepy
+Requires:       python39-acme
+Requires:       python39-xmltodict
+Requires:       python39-pyasn1
+Requires:       python39-pyasn1-modules
+Requires:       python39-pyyaml
+Conflicts:      acme2certifier-python3
+Conflicts:      acme2certifier-python3.11
 
-Web servers are not hard dependencies. For nginx+uWSGI:
-  - cp %{app_root}/share/nginx/nginx_acme_srv[_ssl].conf /etc/nginx/conf.d/
-  - systemctl enable --now acme2certifier nginx
+%description -n acme2certifier-python39
+Python flavor for acme2certifier using python39-* modules (EL8 default app runtime).
 
-Apache example vhosts are under %{app_root}/share/apache2/.
-
-See https://github.com/grindsa/acme2certifier and docs/install_rpm.md.
+Writes %{python_confdir}/python.conf and conflicts with other flavors.
+Missing modules may come from AppStream/EPEL or project-provided RPMs.
 
 %prep
 %autosetup -p1 -n %{name}-%{?ghsha}%{?!ghsha:%{version}} -N
@@ -83,7 +124,8 @@ APP=%{buildroot}%{app_root}
     "$APP/examples" \
     %{buildroot}%{_unitdir} \
     %{buildroot}%{_bindir} \
-    %{buildroot}%{_docdir}/%{projname}
+    %{buildroot}%{_docdir}/%{projname} \
+    %{buildroot}%{python_confdir}
 
 # Importable package (parent of this dir is PYTHONPATH)
 %{__cp} -a acme2certifier "$APP/"
@@ -137,7 +179,22 @@ UNIT
 
 %{__chmod} -R go-w "$APP"
 
-# Console wrappers (set PYTHONPATH; do not rely on versioned sitelib)
+# Flavor python.conf files (only one flavor installed at a time)
+cat > %{buildroot}%{python_confdir}/python.conf.python3 <<'EOF'
+# Managed by acme2certifier-python3 (%config(noreplace)).
+# Absolute path preferred.
+python_interpreter=/usr/bin/python3
+python_min=3.6
+EOF
+
+cat > %{buildroot}%{python_confdir}/python.conf.python39 <<'EOF'
+# Managed by acme2certifier-python39 (%config(noreplace)).
+# Absolute path preferred.
+python_interpreter=/usr/bin/python3.9
+python_min=3.9
+EOF
+
+# Console wrappers: honor /etc/acme2certifier/python.conf when present
 install_wrapper() {
     name="$1"
     module="$2"
@@ -145,7 +202,17 @@ install_wrapper() {
 #!/bin/bash
 export PYTHONPATH="/opt/acme2certifier\${PYTHONPATH:+:\${PYTHONPATH}}"
 export ACME_SRV_CONFIGFILE="\${ACME_SRV_CONFIGFILE:-/opt/acme2certifier/acme_srv.cfg}"
-exec /usr/bin/python3 -m ${module} "\$@"
+PY=/usr/bin/python3
+PYCONF=/etc/acme2certifier/python.conf
+if [[ -r "\${PYCONF}" ]]; then
+  _py="\$(awk -F= '/^[[:space:]]*python_interpreter[[:space:]]*=/ {
+    gsub(/[[:space:]]/, "", \$2); print \$2; exit
+  }' "\${PYCONF}" 2>/dev/null || true)"
+  if [[ -n "\${_py}" && -x "\${_py}" ]]; then
+    PY="\${_py}"
+  fi
+fi
+exec "\${PY}" -m ${module} "\$@"
 EOF
     %{__chmod} 0755 "%{buildroot}%{_bindir}/${name}"
 }
@@ -189,6 +256,16 @@ install_wrapper a2c-mswcce-connection-test acme2certifier.tools.a2c_mswcce_conne
 %attr(0755,root,root) %{_bindir}/a2c-invalidator
 %attr(0755,root,root) %{_bindir}/a2c-report-generator
 %attr(0755,root,root) %{_bindir}/a2c-mswcce-connection-test
+%attr(0755,root,root) %{_bindir}/a2c-wsgi2django
+%dir %{python_confdir}
+
+%files python3
+%dir %{python_confdir}
+%attr(0644,root,root) %{python_confdir}/python.conf.python3
+
+%files -n acme2certifier-python39
+%dir %{python_confdir}
+%attr(0644,root,root) %{python_confdir}/python.conf.python39
 
 %changelog
 
@@ -221,4 +298,32 @@ fi
 
 if id nginx >/dev/null 2>&1; then
     chown -R nginx:nginx /opt/acme2certifier 2>/dev/null || true
+fi
+
+%post python3
+CONFDIR=%{python_confdir}
+SRC="${CONFDIR}/python.conf.python3"
+DST="${CONFDIR}/python.conf"
+# $1==1 install (incl. flavor swap); $1>=2 upgrade — keep admin edits
+if [ "$1" -eq 1 ] || [ ! -e "${DST}" ]; then
+    cp -a "${SRC}" "${DST}"
+fi
+
+%post -n acme2certifier-python39
+CONFDIR=%{python_confdir}
+SRC="${CONFDIR}/python.conf.python39"
+DST="${CONFDIR}/python.conf"
+if [ "$1" -eq 1 ] || [ ! -e "${DST}" ]; then
+    cp -a "${SRC}" "${DST}"
+fi
+
+%postun python3
+# Conflicts ensure exclusivity; remove active conf when this flavor is erased.
+if [ "$1" -eq 0 ]; then
+    rm -f %{python_confdir}/python.conf
+fi
+
+%postun -n acme2certifier-python39
+if [ "$1" -eq 0 ]; then
+    rm -f %{python_confdir}/python.conf
 fi


### PR DESCRIPTION
Split the EL RPM into a noarch payload plus mutually exclusive Python flavor metapackages, so EL8 can run the app on parallel Python 3.9 instead of system 3.6. 

Default app Python is 3.9 on both EL8 and EL9.