### PR TITLE
[min-devel] control profiles_check_disable via eab-profiling feature

### DIFF
--- a/.github/actions/wf_specific/eab_profiling/fixtures/xca.json
+++ b/.github/actions/wf_specific/eab_profiling/fixtures/xca.json
@@ -37,6 +37,9 @@
         "www.example.local",
         "www.example.org"
       ]
+    },
+    "order": {
+      "profiles_check_disable": "True"
     }
   },
   "keyid_03": {
@@ -45,6 +48,36 @@
       "prevalidated_domainlist": [
         "www.example.local"
       ]
+    }
+  },
+  "keyid_04": {
+    "hmac": "YW5kX2hlcmVfaXNfYW5vdGhlcl92ZXJ5X2xvbmdfbWFja19obWFjX2tleV90b19jaGVja19pZl9jaGFuZ2VzX2FmZmVjdF9pbW1lZGF0ZWx5",
+    "cahandler": {
+      "allowed_domainlist": [
+        "www.example.local",
+        "www.example.org",
+        "*.acme"
+      ]
+    },
+    "order": {
+      "profiles_check_disable": "True"
+    }
+  },
+  "keyid_05": {
+    "hmac": "a2V5aWRfMDVfaG1hY19rZXlfd2hpY2hfaXNfbG9uZ2VyX3RoYW5fMjU2X2JpdHNfZm9yX3Byb2ZpbGVfY2hlY2tfZGlzYWJsZV9jaXh4",
+    "cahandler": {
+      "template_name": [
+        "template",
+        "acme"
+      ],
+      "allowed_domainlist": [
+        "www.example.local",
+        "www.example.org",
+        "*.acme"
+      ]
+    },
+    "order": {
+      "profiles_check_disable": "True"
     }
   }
 }

--- a/.github/actions/wf_specific/xca_ca_handler/enroll_eab_acmeprofile/action.yml
+++ b/.github/actions/wf_specific/xca_ca_handler/enroll_eab_acmeprofile/action.yml
@@ -49,6 +49,54 @@ runs:
       sudo openssl x509 -in lego/certificates/lego.acme.crt -text -ext extendedKeyUsage | grep "TLS Web Server Authentication, TLS Web Client Authentication"
     shell: bash
 
+  - name: "EAB - 02c - Enroll lego with unknown profile when profiles_check_disable is set"
+    run: |
+      sudo rm -rf lego/*
+      docker run -i -v $PWD/lego:/.lego/ --rm --name lego --network acme goacme/lego run --tls-skip-verify -s https://acme-srv -a --email "lego@example.com" --eab --eab.kid keyid_04 --eab.hmac YW5kX2hlcmVfaXNfYW5vdGhlcl92ZXJ5X2xvbmdfbWFja19obWFjX2tleV90b19jaGVja19pZl9jaGFuZ2VzX2FmZmVjdF9pbW1lZGF0ZWx5 -d lego.acme --http --profile unknown
+      sudo openssl verify -CAfile cert-2.pem -untrusted cert-1.pem  lego/certificates/lego.acme.crt
+      sudo openssl x509 -in lego/certificates/lego.acme.crt -text -ext keyUsage | grep "Digital Signature, Non Repudiation, Key Encipherment, Key Agreement"
+      sudo openssl x509 -in lego/certificates/lego.acme.crt -text -ext extendedKeyUsage | grep "TLS Web Server Authentication, TLS Web Client Authentication"
+    shell: bash
+
+  - name: "EAB - 02d - Enroll lego with unknown profile on keyid_00 after disable kid (isolation)"
+    id: legofail01b
+    continue-on-error: true
+    run: |
+      sudo rm -rf lego/*
+      docker run -i -v $PWD/lego:/.lego/ --rm --name lego --network acme goacme/lego run --tls-skip-verify -s https://acme-srv -a --email "lego@example.com" --eab --eab.kid keyid_00 --eab.hmac V2VfbmVlZF9hbm90aGVyX3ZlcnkfX2xvbmdfaG1hY190b19jaGVja19lYWJfZm9yX2tleWlkXzAwX2FzX2xlZ29fZW5mb3JjZXNfYW5faG1hY19sb25nZXJfdGhhbl8yNTZfYml0cw -d lego.acme --http --profile unknown
+    shell: bash
+
+  - name: "EAB - 02d - check result"
+    if: steps.legofail01b.outcome != 'failure'
+    run: |
+      echo "legofail outcome is ${{steps.legofail01b.outcome }}"
+      exit 1
+    shell: bash
+
+  - name: "EAB - 02e - Enroll lego with unknown profile when disable and template_name list (to fail)"
+    id: legofail04
+    continue-on-error: true
+    run: |
+      sudo rm -rf lego/*
+      docker run -i -v $PWD/lego:/.lego/ --rm --name lego --network acme goacme/lego run --tls-skip-verify -s https://acme-srv -a --email "lego@example.com" --eab --eab.kid keyid_05 --eab.hmac a2V5aWRfMDVfaG1hY19rZXlfd2hpY2hfaXNfbG9uZ2VyX3RoYW5fMjU2X2JpdHNfZm9yX3Byb2ZpbGVfY2hlY2tfZGlzYWJsZV9jaXh4 -d lego.acme --http --profile unknown
+    shell: bash
+
+  - name: "EAB - 02e - check result"
+    if: steps.legofail04.outcome != 'failure'
+    run: |
+      echo "legofail outcome is ${{steps.legofail04.outcome }}"
+      exit 1
+    shell: bash
+
+  - name: "EAB - 02f - Enroll lego with allowed profile when disable and template_name list"
+    run: |
+      sudo rm -rf lego/*
+      docker run -i -v $PWD/lego:/.lego/ --rm --name lego --network acme goacme/lego run --tls-skip-verify -s https://acme-srv -a --email "lego@example.com" --eab --eab.kid keyid_05 --eab.hmac a2V5aWRfMDVfaG1hY19rZXlfd2hpY2hfaXNfbG9uZ2VyX3RoYW5fMjU2X2JpdHNfZm9yX3Byb2ZpbGVfY2hlY2tfZGlzYWJsZV9jaXh4 -d lego.acme --http --profile acme
+      sudo openssl verify -CAfile cert-2.pem -untrusted cert-1.pem  lego/certificates/lego.acme.crt
+      sudo openssl x509 -in lego/certificates/lego.acme.crt -text -ext keyUsage | grep "Digital Signature, Non Repudiation, Key Encipherment, Key Agreement"
+      sudo openssl x509 -in lego/certificates/lego.acme.crt -text -ext extendedKeyUsage | grep "TLS Web Server Authentication, TLS Web Client Authentication"
+    shell: bash
+
   - name: "EAB - 03 - Enroll lego with a template_name/ca_name taken from kid.json"
     run: |
       sudo rm -rf lego/*

--- a/acme2certifier/acme_srv/order.py
+++ b/acme2certifier/acme_srv/order.py
@@ -399,8 +399,20 @@ class Order(object):
                     default=bool(self.config.ca_error_details_forward),
                 )
 
+                # load amd apply profiles from eab profile if specified
                 eab_profile_dic = self._load_eab_profile_mapping(profile_dic, eab_kid)
                 self._apply_eab_profile_mapping(account_name, eab_profile_dic)
+
+                # load profiles_check_disable from eab profile if specified
+                self.config.profiles_check_disable = eab_profile_as_bool(
+                    self._load_eab_profile_param(
+                        profile_dic,
+                        eab_kid,
+                        "profiles_check_disable",
+                        self.config.profiles_check_disable,
+                    ),
+                    default=bool(self.config.profiles_check_disable),
+                )
 
         except Exception as err:
             self.logger.error(

--- a/docs/eab_profiling.md
+++ b/docs/eab_profiling.md
@@ -60,6 +60,9 @@ Below is an example configuration to be used for [Insta Certifier](certifier.md)
   },
   "keyid_02": {
     "hmac": "hmac-key",
+    "order": {
+      "profiles_check_disable": "True"
+    },
     "challenge": {
       "challenge_validation_disable": "True",
       "foward_address_check": "True",
@@ -76,8 +79,8 @@ Below is an example configuration to be used for [Insta Certifier](certifier.md)
 
 - ACME accounts created with keyid "keyid_00" will always use profile-id "profile_1" and specific api-user credentials for enrollment from certificate authority "non_default_ca". Further, the SANs/Common Names to be used in enrollment requests are restricted to the domains "example.com", "example.org" and "example.fi".
 - ACME accounts created with keyid "keyid_01" and can specify 3 different profile_ids by using the [header_info feature](header_info.md). Enrollment requests having other profile_ids will be rejected. In case no profile_id get specified the first profile_id in the list ("profile_1") will be used. SAN/CNs to be used are restricted to "example.fi" and ".local" All other enrollment parameters will be taken from acme_srv.cfg. Furthermore the challenge validation got disabled for this user which means that acme2certifier will accept any CN/SAN matching the pattern "*.example.fi" or "*.acme".
-- ACME accounts created with keyid "keyid_02" do not have any special enrollment configuration as all parameters will be taken from the \[CAhandler\] section in ´acme_srv.cfg´. Furthermore, challenge validation got disabled and both forward and reverse address checking gets activated.
-- ACME accounts created with keyid "keyid_03" can use the [pre-validation domainlist](identifier_prevalidation.md) feature to enroll certificates for "www.example.fi" and "\*.acme" without challenge-validation
+- ACME accounts created with keyid "keyid_02" do not have any special enrollment configuration as all parameters will be taken from the \[CAhandler\] section in ´acme_srv.cfg´. Furthermore, challenge validation got disabled, ACME profile-name validation is skipped (`order.profiles_check_disable`), and both forward and reverse address checking gets activated.
+- ACME accounts created with keyid "keyid_03" can use the [pre-validation domainlist](identifier_prevalidation.md) feature to enroll certificates for `www.example.fi` and `*.acme` without challenge-validation
 
 Starting from v0.36 acme2certifier does support profile configuration in yaml format. Below a configuration example providing the same level of functionality as the above JSON configuration
 
@@ -110,8 +113,10 @@ keyid_01:
 
 keyid_02:
   hmac: "hmac-key"
+  order:
+    profiles_check_disable: True
   challenge:
-    challenge_validation_disable": True
+    challenge_validation_disable: True
     forward_address_check: True
     reverse_address_check: True
 

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -3298,6 +3298,79 @@ class TestOrderClass(unittest.TestCase):
                     self.assertEqual(result.get("code"), 403)
                     mock_warning.assert_not_called()
 
+    def _setup_eab_kid_profile(self, kid: str, profile_entry: dict) -> None:
+        self.order.config.eab_profiling = True
+        self.order.repository.account_lookup.return_value = {"eab_kid": kid}
+        mock_eab_handler = MagicMock()
+        mock_eab_handler.__enter__.return_value.key_file_load.return_value = {
+            kid: profile_entry
+        }
+        self.order.config.eab_handler = MagicMock(return_value=mock_eab_handler)
+
+    def test_204_apply_eab_profile_mapping_enables_profile_check(self):
+        self.order.config.profiles_check_disable = True
+        self.order._apply_eab_profile_mapping("acct1", {"web": True})
+        self.assertFalse(self.order.config.profiles_check_disable)
+
+    def test_205_apply_eab_profile_profiles_check_disable_true_string(self):
+        self.order.config.profiles_check_disable = False
+        self._setup_eab_kid_profile(
+            "kid_disable",
+            {"order": {"profiles_check_disable": "True"}},
+        )
+        self.order._apply_eab_profile("acct")
+        self.assertTrue(self.order.config.profiles_check_disable)
+        self.assertIsInstance(self.order.config.profiles_check_disable, bool)
+
+    def test_206_apply_eab_profile_profiles_check_disable_false_against_global_true(
+        self,
+    ):
+        self.order.config.profiles_check_disable = True
+        self._setup_eab_kid_profile(
+            "kid_enable",
+            {"order": {"profiles_check_disable": "False"}},
+        )
+        self.order._apply_eab_profile("acct")
+        self.assertFalse(self.order.config.profiles_check_disable)
+        self.assertIsInstance(self.order.config.profiles_check_disable, bool)
+
+    def test_207_apply_eab_profile_profiles_check_disable_missing_keeps_global(self):
+        self.order.config.profiles_check_disable = False
+        self._setup_eab_kid_profile("kid_missing", {"order": {}})
+        self.order._apply_eab_profile("acct")
+        self.assertFalse(self.order.config.profiles_check_disable)
+
+    def test_208_apply_eab_profile_mapping_then_profiles_check_disable_true(self):
+        self.order.config.profiles_check_disable = False
+        self.order.config.profile_mapping_field = "template_name"
+        self._setup_eab_kid_profile(
+            "kid_both",
+            {
+                "order": {
+                    "template_name": ["web", "code"],
+                    "profiles_check_disable": "True",
+                }
+            },
+        )
+        self.order._apply_eab_profile("acct")
+        self.assertEqual(self.order.config.profiles, {"web": True, "code": True})
+        self.assertTrue(self.order.config.profiles_check_disable)
+
+    def test_209_apply_eab_profile_profiles_check_disable_ignored_when_profiling_off(
+        self,
+    ):
+        self.order.config.eab_profiling = False
+        self.order.config.profiles_check_disable = False
+        self.order.repository.account_lookup.return_value = {"eab_kid": "kid_disable"}
+        mock_eab_handler = MagicMock()
+        mock_eab_handler.__enter__.return_value.key_file_load.return_value = {
+            "kid_disable": {"order": {"profiles_check_disable": "True"}}
+        }
+        self.order.config.eab_handler = MagicMock(return_value=mock_eab_handler)
+        self.order._apply_eab_profile("acct")
+        self.assertFalse(self.order.config.profiles_check_disable)
+        mock_eab_handler.__enter__.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Allow per-EAB-kid override of ACME profile-name validation via order.profiles_check_disable in the kid profile (JSON/YAML).

[Order] profiles_check_disable already exists globally. EAB profile mapping (template_name / equivalent) currently turns that check back on for that account. 

This change loads profiles_check_disable from the kid after mapping, so a kid can skip unknown-profile rejection without changing the global default. Other kids stay isolated.