### PR TITLE
adding yaml support for a2c config file

### DIFF
--- a/.github/acme_srv.openssl.yml
+++ b/.github/acme_srv.openssl.yml
@@ -1,0 +1,34 @@
+DEFAULT:
+  debug: true
+
+Nonce:
+  # disable nonce/signature checks. THIS IS A SEVERE SECURITY ISSUE!
+  # Ignored unless ACME2CERTIFIER_I_KNOW_THE_RISK=1 is set (checks stay enabled).
+  # Please use only for testing/debugging purposes.
+  nonce_check_disable: false
+  # signature_check_disable: false
+
+Certificate:
+  revocation_reason_check_disable: false
+
+Challenge:
+  # when true disable challenge validation. Challenge will be set to 'valid' without further checking
+  # THIS IS A SEVERE SECURTIY ISSUE! Please do only for testing/debugging purposes
+  challenge_validation_disable: false
+
+Order:
+  tnauthlist_support: false
+  retry_after_timeout: 15
+
+CAhandler:
+  # CA specific options
+  # Paths below are relative to ACME2CERTIFIER_BASE_DIR (required under Apache/mod_wsgi).
+  handler_module: acme2certifier.cahandlers.openssl_ca_handler
+  ca_cert_chain_list:
+    - volume/acme_ca/root-ca-cert.pem
+  issuing_ca_key: volume/acme_ca/sub-ca-key.pem
+  issuing_ca_key_passphrase: Test1234
+  issuing_ca_cert: volume/acme_ca/sub-ca-cert.pem
+  issuing_ca_crl: volume/acme_ca/sub-ca-crl.pem
+  cert_validity_days: 30
+  cert_save_path: volume/acme_ca/certs

--- a/.github/actions/acme_clients/action.yml
+++ b/.github/actions/acme_clients/action.yml
@@ -55,9 +55,9 @@ runs:
 
     - name: "Create directories"
       run: |
+        sudo rm -rf acme-sh certbot lego
         mkdir -p acme-sh/
         sudo mkdir -p certbot/
-        sudo rm -rf lego
         sudo mkdir -p lego/ca
         sudo cp .github/acme2certifier_cabundle.pem certbot/
         sudo cp .github/acme2certifier_cabundle.pem lego/

--- a/.github/actions/wf_specific/openssl_ca_handler/stage_yaml_cfg/action.yml
+++ b/.github/actions/wf_specific/openssl_ca_handler/stage_yaml_cfg/action.yml
@@ -1,0 +1,45 @@
+name: "stage_yaml_cfg"
+description: "Stage acme_srv.yml into a volume dir and point acme_srv.cfg at it"
+inputs:
+  VOLUME_DIR:
+    description: "Target volume directory (acme_srv.yml / acme_srv.cfg are written here)"
+    required: false
+    default: "data/volume"
+  CFG_SOURCE:
+    description: "Source YAML config"
+    required: false
+    default: ".github/acme_srv.openssl.yml"
+  PATH_REWRITE_FROM:
+    description: "Optional substring to rewrite in the staged YAML"
+    required: false
+    default: ""
+  PATH_REWRITE_TO:
+    description: "Replacement for PATH_REWRITE_FROM"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Stage acme_srv.yml"
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo mkdir -p "${VOLUME_DIR}"
+        sudo cp "${CFG_SOURCE}" "${VOLUME_DIR}/acme_srv.yml"
+        sudo chmod 777 "${VOLUME_DIR}/acme_srv.yml"
+        if [[ -n "${PATH_REWRITE_FROM}" ]]; then
+          sudo sed -i "s|${PATH_REWRITE_FROM}|${PATH_REWRITE_TO}|g" \
+            "${VOLUME_DIR}/acme_srv.yml"
+        fi
+        sudo rm -f "${VOLUME_DIR}/acme_srv.cfg"
+        sudo ln -sfn acme_srv.yml "${VOLUME_DIR}/acme_srv.cfg"
+        echo "--- ${VOLUME_DIR}/acme_srv.cfg -> acme_srv.yml ---"
+        ls -l "${VOLUME_DIR}/acme_srv.cfg" "${VOLUME_DIR}/acme_srv.yml"
+        echo "--- ${VOLUME_DIR}/acme_srv.yml ---"
+        cat "${VOLUME_DIR}/acme_srv.yml"
+      env:
+        VOLUME_DIR: ${{ inputs.VOLUME_DIR }}
+        CFG_SOURCE: ${{ inputs.CFG_SOURCE }}
+        PATH_REWRITE_FROM: ${{ inputs.PATH_REWRITE_FROM }}
+        PATH_REWRITE_TO: ${{ inputs.PATH_REWRITE_TO }}

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ acme_srv/certifier_ca_handler.py
 acme_srv/acme_srv.cfg
 # Local checkout config at repo root (preferred over acme_srv/acme_srv.cfg)
 /acme_srv.cfg
+/acme_srv.yaml
+/acme_srv.yml
 acme_srv/wsgi_handler.py
 acme_srv/django_handler.py
 acme_srv/a2c_response.py
@@ -176,6 +178,7 @@ acme_srv/acme_srv.db.old.*
 *.key
 *.db-wal
 *.db-shm
+*.old
 settings.json
 coverage.lcov
 .github/acme2certifier.pem

--- a/acme2certifier/acme_srv/helpers/config.py
+++ b/acme2certifier/acme_srv/helpers/config.py
@@ -7,6 +7,9 @@ import logging
 import os
 import warnings
 from typing import Any, Dict, List, Optional, Set, Tuple
+
+import yaml
+
 from .plugin_loader import eab_handler_load
 from .global_variables import CONFIGURATION_ERROR_DETAIL, PARSING_ERR_MSG
 
@@ -14,20 +17,47 @@ from .global_variables import CONFIGURATION_ERROR_DETAIL, PARSING_ERR_MSG
 _ACME_SRV_CFG_PATH_WARNED: Set[str] = set()
 # Emit successful load INFO at most once per absolute path per process.
 _ACME_SRV_CFG_LOADED: Set[str] = set()
-# Last successful load (path, source); used after logger_setup.
-_LAST_LOADED_CFG: Optional[Tuple[str, str]] = None
+# Last successful load (path, source, format); used after logger_setup.
+_LAST_LOADED_CFG: Optional[Tuple[str, str, str]] = None
 ACME_SRV_CFG_FILENAME = "acme_srv.cfg"
+ACME_SRV_YAML_FILENAMES = ("acme_srv.yaml", "acme_srv.yml")
+_YAML_CONFIG_EXTENSIONS = {".yaml", ".yml"}
 
 
-def _log_cfg_loaded_once(logger: logging.Logger, cfg_path: str, source: str) -> None:
+class _UniqueKeyLoader(yaml.SafeLoader):
+    """SafeLoader that rejects duplicate mapping keys."""
+
+    def construct_mapping(
+        self, node: yaml.nodes.MappingNode, deep: bool = False
+    ) -> Dict[Any, Any]:
+        if not isinstance(node, yaml.nodes.MappingNode):
+            return super().construct_mapping(node, deep=deep)
+        self.flatten_mapping(node)
+        mapping: Dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in mapping:
+                raise yaml.constructor.ConstructorError(
+                    "while constructing a mapping",
+                    node.start_mark,
+                    f"found duplicate key {key!r}",
+                    key_node.start_mark,
+                )
+            mapping[key] = self.construct_object(value_node, deep=deep)
+        return mapping
+
+
+def _log_cfg_loaded_once(
+    logger: logging.Logger, cfg_path: str, source: str, cfg_format: str
+) -> None:
     """Log successful acme_srv.cfg load once per absolute path (then DEBUG)."""
     abs_path = os.path.abspath(cfg_path)
-    message = "Loaded acme_srv.cfg %s (%s)"
+    message = "Loaded acme_srv.cfg %s (%s, %s)"
     if abs_path not in _ACME_SRV_CFG_LOADED:
         _ACME_SRV_CFG_LOADED.add(abs_path)
-        logger.info(message, abs_path, source)
+        logger.info(message, abs_path, source, cfg_format)
     else:
-        logger.debug(message, abs_path, source)
+        logger.debug(message, abs_path, source, cfg_format)
 
 
 def log_loaded_acme_srv_cfg(logger: logging.Logger) -> None:
@@ -37,8 +67,8 @@ def log_loaded_acme_srv_cfg(logger: logging.Logger) -> None:
     configured; this flushes the pending path/source to the app logger.
     """
     if _LAST_LOADED_CFG:
-        path, source = _LAST_LOADED_CFG
-        _log_cfg_loaded_once(logger, path, source)
+        path, source, cfg_format = _LAST_LOADED_CFG
+        _log_cfg_loaded_once(logger, path, source, cfg_format)
 
 
 def config_check(logger: logging.Logger, config_dic: Dict):
@@ -412,18 +442,36 @@ def resolve_config_path(path: Optional[str]) -> Optional[str]:
     return os.path.normpath(os.path.join(base_dir, path))
 
 
+def _acme_srv_config_paths(directory: str) -> Tuple[str, ...]:
+    """Return cfg, then yaml, then yml paths for one directory."""
+    names = (ACME_SRV_CFG_FILENAME,) + ACME_SRV_YAML_FILENAMES
+    return tuple(os.path.join(directory, name) for name in names)
+
+
+def _first_existing_acme_srv_config(directory: str) -> Optional[str]:
+    """First existing acme_srv config in a directory (``.cfg`` wins)."""
+    for path in _acme_srv_config_paths(directory):
+        if os.path.isfile(path):
+            return path
+    return None
+
+
 def _default_acme_srv_cfg_file(
     logger: Optional[logging.Logger] = None,
 ) -> str:
     """Resolve default acme_srv.cfg after the package move.
 
-    Candidates (first existing file wins):
-    1. Preferred OS deploy roots: ``/var/www/acme2certifier/acme_srv.cfg``
-       (DEB) or ``/opt/acme2certifier/acme_srv.cfg`` (RPM)
-    2. Checkout / install root: ``<repo>/acme_srv.cfg``
-    3. Nested deploy paths under ``.../acme_srv/acme_srv.cfg`` (warn)
-    4. Next to the package module: ``.../acme_srv/acme_srv.cfg``
-    5. Legacy repo layout: ``<repo>/acme_srv/acme_srv.cfg`` (warn)
+    Candidates (first existing file wins). At each location ``acme_srv.cfg``
+    is tried before ``acme_srv.yaml`` then ``acme_srv.yml``:
+
+    1. Preferred OS deploy roots: ``/var/www/acme2certifier/`` (DEB) or
+       ``/opt/acme2certifier/`` (RPM)
+    2. Checkout / install root: ``<repo>/``
+    3. Nested deploy paths under ``.../acme_srv/`` (warn)
+    4. Next to the package module: ``.../acme_srv/``
+    5. Legacy repo layout: ``<repo>/acme_srv/`` (warn)
+
+    If nothing exists, fall back to ``/var/www/acme2certifier/acme_srv.cfg``.
     """
     log = logger or logging.getLogger(__name__)
     log.debug("Helper._default_acme_srv_cfg_file() start")
@@ -431,71 +479,230 @@ def _default_acme_srv_cfg_file(
     helpers_dir = os.path.dirname(os.path.abspath(__file__))
     pkg_dir = os.path.dirname(helpers_dir)  # .../acme_srv (new or install tree)
     install_or_repo_root = os.path.dirname(os.path.dirname(pkg_dir))
-    repo_cfg = os.path.join(install_or_repo_root, ACME_SRV_CFG_FILENAME)
+    fallback_cfg = os.path.join("/var/www/acme2certifier", ACME_SRV_CFG_FILENAME)
 
-    preferred_deploy_cfgs = (
-        "/var/www/acme2certifier/acme_srv.cfg",
-        "/opt/acme2certifier/acme_srv.cfg",
-        repo_cfg,
+    preferred_dirs = (
+        "/var/www/acme2certifier",
+        "/opt/acme2certifier",
+        install_or_repo_root,
     )
-    nested_deploy_cfgs = (
-        (
-            "/var/www/acme2certifier/acme_srv/acme_srv.cfg",
-            "/var/www/acme2certifier/acme_srv.cfg",
-        ),
-        (
-            "/opt/acme2certifier/acme_srv/acme_srv.cfg",
-            "/opt/acme2certifier/acme_srv.cfg",
-        ),
+    nested_dirs = (
+        ("/var/www/acme2certifier/acme_srv", "/var/www/acme2certifier"),
+        ("/opt/acme2certifier/acme_srv", "/opt/acme2certifier"),
     )
-    packaged_cfg = os.path.join(pkg_dir, ACME_SRV_CFG_FILENAME)
-    legacy_cfg = os.path.join(install_or_repo_root, "acme_srv", ACME_SRV_CFG_FILENAME)
+    legacy_dir = os.path.join(install_or_repo_root, "acme_srv")
     log.debug(
         "Helper._default_acme_srv_cfg_file(): candidates preferred=%s "
         "nested=%s packaged=%s legacy=%s",
-        preferred_deploy_cfgs,
-        [path for path, _ in nested_deploy_cfgs],
-        packaged_cfg,
-        legacy_cfg,
+        [path for d in preferred_dirs for path in _acme_srv_config_paths(d)],
+        [path for d, _ in nested_dirs for path in _acme_srv_config_paths(d)],
+        _acme_srv_config_paths(pkg_dir),
+        _acme_srv_config_paths(legacy_dir),
     )
 
-    for deploy_cfg in preferred_deploy_cfgs:
-        if os.path.isfile(deploy_cfg):
+    for deploy_dir in preferred_dirs:
+        found = _first_existing_acme_srv_config(deploy_dir)
+        if found:
             log.debug(
                 "Helper._default_acme_srv_cfg_file() ended with preferred %s",
-                deploy_cfg,
+                found,
             )
-            return deploy_cfg
+            return found
 
-    for nested_cfg, preferred_cfg in nested_deploy_cfgs:
-        if os.path.isfile(nested_cfg):
-            _warn_acme_srv_cfg_path(nested_cfg, preferred_cfg, log)
+    for nested_dir, preferred_dir in nested_dirs:
+        found = _first_existing_acme_srv_config(nested_dir)
+        if found:
+            preferred = os.path.join(preferred_dir, os.path.basename(found))
+            _warn_acme_srv_cfg_path(found, preferred, log)
             log.debug(
                 "Helper._default_acme_srv_cfg_file() ended with nested %s",
-                nested_cfg,
+                found,
             )
-            return nested_cfg
+            return found
 
-    if os.path.isfile(packaged_cfg):
+    packaged = _first_existing_acme_srv_config(pkg_dir)
+    if packaged:
         log.debug(
             "Helper._default_acme_srv_cfg_file() ended with packaged %s",
-            packaged_cfg,
+            packaged,
         )
-        return packaged_cfg
+        return packaged
 
-    if os.path.isfile(legacy_cfg):
-        _warn_acme_srv_cfg_path(legacy_cfg, repo_cfg, log)
+    legacy = _first_existing_acme_srv_config(legacy_dir)
+    if legacy:
+        preferred = os.path.join(install_or_repo_root, os.path.basename(legacy))
+        _warn_acme_srv_cfg_path(legacy, preferred, log)
         log.debug(
             "Helper._default_acme_srv_cfg_file() ended with legacy %s",
-            legacy_cfg,
+            legacy,
         )
-        return legacy_cfg
+        return legacy
 
     log.debug(
         "Helper._default_acme_srv_cfg_file() ended with fallback %s",
-        preferred_deploy_cfgs[0],
+        fallback_cfg,
     )
-    return preferred_deploy_cfgs[0]
+    return fallback_cfg
+
+
+def _new_config_parser() -> configparser.ConfigParser:
+    """Return an empty ConfigParser matching historical load_config() settings."""
+    config = configparser.ConfigParser(interpolation=None)
+    config.optionxform = str
+    return config
+
+
+def _read_config_file(path: str) -> str:
+    """Read a config file as UTF-8. ``utf-8-sig`` strips a leading BOM."""
+    with open(path, encoding="utf-8-sig") as handle:
+        return handle.read()
+
+
+def _detect_config_format(content: str, path: str) -> str:
+    """Detect INI vs YAML from raw content on every call.
+
+    Extension (``.yaml``/``.yml`` vs ``.cfg``) is a tie-breaker only.
+    """
+    text = content.lstrip("\ufeff").lstrip()
+    if not text:
+        return "ini"
+
+    first_line = ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith(";"):
+            continue
+        first_line = stripped
+        break
+    if not first_line:
+        return "ini"
+
+    if first_line.startswith("["):
+        return "ini"
+    if (
+        first_line.startswith("{")
+        or first_line.startswith("---")
+        or first_line.startswith("-")
+    ):
+        return "yaml"
+    if ":" in first_line:
+        return "yaml"
+
+    ext = os.path.splitext(path)[1].lower()
+    if ext in _YAML_CONFIG_EXTENSIONS:
+        return "yaml"
+    return "ini"
+
+
+def _parse_ini(content: str) -> configparser.ConfigParser:
+    """Parse INI text into ConfigParser."""
+    config = _new_config_parser()
+    config.read_string(content)
+    return config
+
+
+def _yaml_value_to_option(
+    value: Any,
+    logger: logging.Logger,
+    section: str,
+    option: str,
+) -> Optional[str]:
+    """Normalize a YAML value to a ConfigParser option string.
+
+    ``null`` is omitted (returns ``None``) with a warning. Lists and dicts are
+    ``json.dumps``-encoded so existing ``json.loads`` helpers keep working.
+    Unsupported types (including ``datetime``/``date``) raise ``ValueError``.
+    """
+    if value is None:
+        logger.warning("Ignoring null YAML option %s.%s", section, option)
+        return None
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    raise ValueError(
+        f"Unsupported YAML type {type(value).__name__} for {section}.{option}"
+    )
+
+
+def _set_yaml_option(
+    config: configparser.ConfigParser,
+    section: str,
+    option: Any,
+    value: Any,
+    logger: logging.Logger,
+) -> None:
+    """Set one normalized YAML value on ``config``."""
+    if not isinstance(option, str):
+        raise ValueError(
+            f"YAML config key must be a string, got {type(option).__name__}: {option!r}"
+        )
+    converted = _yaml_value_to_option(value, logger, section, option)
+    if converted is None:
+        return
+    if section != "DEFAULT" and not config.has_section(section):
+        config.add_section(section)
+    config.set(section, option, converted)
+
+
+def _parse_yaml(content: str, logger: logging.Logger) -> configparser.ConfigParser:
+    """Parse YAML text and normalize it to ConfigParser.
+
+    Mapping values become sections. Scalar, list, and null values at the root
+    are stored under ``DEFAULT``. Non-mapping roots raise ``ValueError``.
+    """
+    data = yaml.load(content, Loader=_UniqueKeyLoader)
+    config = _new_config_parser()
+    if data is None:
+        return config
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"acme_srv YAML config root must be a mapping, got {type(data).__name__}"
+        )
+    for raw_key, value in data.items():
+        if not isinstance(raw_key, str):
+            raise ValueError(
+                "YAML config key must be a string, "
+                f"got {type(raw_key).__name__}: {raw_key!r}"
+            )
+        if isinstance(value, dict):
+            if raw_key != "DEFAULT" and not config.has_section(raw_key):
+                config.add_section(raw_key)
+            for option, option_value in value.items():
+                _set_yaml_option(config, raw_key, option, option_value, logger)
+        else:
+            _set_yaml_option(config, "DEFAULT", raw_key, value, logger)
+    return config
+
+
+def _parse_config_content(
+    content: str, path: str, logger: logging.Logger
+) -> Tuple[configparser.ConfigParser, str]:
+    """Detect format, parse, and return ``(config, format)``.
+
+    Format is re-detected on every call. If INI parsing fails, the same content
+    is retried as YAML. YAML parse errors are not caught.
+    """
+    cfg_format = _detect_config_format(content, path)
+    logger.debug(
+        "Detected acme_srv config format: %s (path=%s)",
+        cfg_format,
+        path,
+    )
+    if cfg_format == "yaml":
+        return _parse_yaml(content, logger), "yaml"
+    try:
+        return _parse_ini(content), "ini"
+    except configparser.Error:
+        logger.debug(
+            "INI parse failed, retrying as YAML (path=%s)",
+            path,
+        )
+        return _parse_yaml(content, logger), "yaml"
 
 
 def load_config(
@@ -526,24 +733,31 @@ def load_config(
         source = "default"
 
     log.debug("load_config(%s:%s)", mfilter, cfg_file)
-    config = configparser.ConfigParser(interpolation=None)
-    config.optionxform = str
-    read_ok = config.read(cfg_file, encoding="utf8")
-    if read_ok:
-        abs_path = os.path.abspath(cfg_file)
-        _LAST_LOADED_CFG = (abs_path, source)
-        # Only emit INFO when a configured app logger was passed. Module-level
-        # load_config() runs before logger_setup(); flush via
-        # log_loaded_acme_srv_cfg() afterwards.
-        if logger is not None:
-            _log_cfg_loaded_once(logger, abs_path, source)
-        else:
-            log.debug("Loaded acme_srv.cfg %s (%s)", abs_path, source)
-    else:
+    try:
+        content = _read_config_file(cfg_file)
+    except OSError:
         log.warning(
             "Helper.load_config(): could not read config file %s",
             cfg_file,
         )
+        log.debug(
+            "Helper.load_config() ended sections=%s",
+            [],
+        )
+        # needed for backward compatibility - returns an empty configparser object
+        return _new_config_parser()
+
+    config, cfg_format = _parse_config_content(content, cfg_file, log)
+    abs_path = os.path.abspath(cfg_file)
+    _LAST_LOADED_CFG = (abs_path, source, cfg_format)
+
+    # Only emit INFO when a configured app logger was passed. Module-level
+    # load_config() runs before logger_setup(); flush via
+    # log_loaded_acme_srv_cfg() afterwards.
+    if logger is not None:
+        _log_cfg_loaded_once(logger, abs_path, source, cfg_format)
+    else:
+        log.debug("Loaded acme_srv.cfg %s (%s, %s)", abs_path, source, cfg_format)
     log.debug(
         "Helper.load_config() ended sections=%s",
         list(config.sections()),

--- a/docs/acme_srv.md
+++ b/docs/acme_srv.md
@@ -7,6 +7,8 @@
 
 ## configuration options for acme2certifier
 
+INI (`acme_srv.cfg`) and YAML (`acme_srv.yaml` / `acme_srv.yml`) are equivalent. The shipped default remains INI (`acme2certifier/share/acme_srv.cfg`). See [YAML configuration](#yaml-configuration) for file detection and native lists.
+
 | Section         | Option                                | Description                                                                                                                                                                                                           | Values                                                                                                                  | Default                                     |
 | :-------------- | :------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------- | :------------------------------------------ |
 | `DEFAULT`       | `debug`                               | Debug mode                                                                                                                                                                                                            | True/False                                                                                                              | False                                       |
@@ -106,14 +108,36 @@ acme2certifier logs a startup warning when `server_name` is not present in
 
 Dynamic loading of CA/EAB/Hooks handlers from module names or filesystem paths
 is a by-design extensibility feature. If an attacker can modify `acme_srv.cfg`
+(or `acme_srv.yaml` / `acme_srv.yml`)
 or referenced plugin files, they can execute arbitrary Python code as the
 acme2certifier service user.
 
 Recommended mitigations:
 
-- Restrict write access to `acme_srv.cfg` and custom plugin paths
+- Restrict write access to `acme_srv.cfg` / `acme_srv.yaml` and custom plugin paths
 - Use read-only mounts for config/plugin files in production
 - Apply change-control / integrity monitoring for handler and hooks references
+
+## YAML configuration
+
+`load_config()` accepts INI or YAML and always returns `configparser.ConfigParser`. Format is detected from **file content on every load** (no format cache). The filename extension is a tie-breaker only.
+
+| File | Role |
+| :--- | :--- |
+| `acme_srv.cfg` | INI (default shipped format) |
+| `acme_srv.yaml` / `acme_srv.yml` | YAML |
+| `examples/acme_srv.yaml` | YAML equivalent of `examples/acme_srv.cfg` |
+| `ACME_SRV_CONFIGFILE` | Explicit path to either format |
+
+### Detection
+
+1. Strip a UTF-8 BOM and leading whitespace. An empty file is treated as INI (same as today).
+2. First non-comment line starting with `[` → INI.
+3. First non-comment line starting with `{`, `-`, or `---`, or a `SectionName:` mapping → YAML.
+4. Otherwise the extension decides (`.yaml`/`.yml` → YAML, else INI).
+5. If INI parsing fails, the **same file** is retried as YAML. Invalid YAML, duplicate keys, and unsupported types (for example unquoted dates) abort startup — a half-parsed config is not used.
+
+At each default search location, `acme_srv.cfg` is tried first, then `acme_srv.yaml`, then `acme_srv.yml`.
 
 Instructions for [Insta Certifier](certifier.md)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,22 +28,23 @@ The editable install (`-e`) puts `a2c-manage` and the other [CLI tools](../tools
 
 ```bash
 export ACME2CERTIFIER_BASE_DIR="$PWD"
-export ACME_SRV_CONFIGFILE="$PWD/acme_srv.cfg"
+export ACME_SRV_CONFIGFILE="$PWD/acme_srv.cfg"   # or acme_srv.yaml / acme_srv.yml
 export ACME2CERTIFIER_DEBUG=1
 ```
 
 | Variable                  | Role                                                           |
 | ------------------------- | -------------------------------------------------------------- |
 | `ACME2CERTIFIER_BASE_DIR` | Deploy root: Django `db.sqlite3`, relative `dbfile` / CA paths |
-| `ACME_SRV_CONFIGFILE`     | Absolute path to cfg (beats `/var/www/...` and `/opt/...`)     |
+| `ACME_SRV_CONFIGFILE`     | Absolute path to `acme_srv.cfg` or `acme_srv.yaml` / `.yml` (beats `/var/www/...` and `/opt/...`) |
 | `ACME2CERTIFIER_DEBUG`    | Django `DEBUG` (`1` / `true`)                                  |
 
 ## 3. Config and a local OpenSSL CA
 
-`acme_srv.cfg` at the repo root is gitignored.
+`acme_srv.cfg` (and `acme_srv.yaml` / `acme_srv.yml`) at the repo root is gitignored.
 
 ```bash
 cp acme2certifier/share/acme_srv.cfg acme_srv.cfg
+# or: cp examples/acme_srv.yaml acme_srv.yaml
 mkdir -p acme_srv/ca/certs
 cp test/ca/sub-ca-key.pem test/ca/sub-ca-cert.pem \
    test/ca/sub-ca-crl.pem test/ca/root-ca-cert.pem \

--- a/examples/acme_srv.yaml
+++ b/examples/acme_srv.yaml
@@ -1,0 +1,36 @@
+DEFAULT:
+  debug: false
+
+Nonce:
+  # disable nonce/signature checks. THIS IS A SEVERE SECURITY ISSUE!
+  # Ignored unless ACME2CERTIFIER_I_KNOW_THE_RISK=1 is set (checks stay enabled).
+  # Please use only for testing/debugging purposes.
+  nonce_check_disable: false
+  # signature_check_disable: false
+
+# Prefer handler_module, e.g.:
+# handler_module: acme2certifier.cahandlers.openssl_ca_handler
+# CA specific options
+CAhandler: {}
+
+DBhandler:
+  # handler: wsgi
+  # handler: django
+  # handler_module: acme2certifier.dbhandlers.wsgi_handler
+  # Or set ACME_SRV_DB_HANDLER=wsgi|django|<dotted.module> (cfg wins over env)
+  # Writable by www-data after DEB install (same tree as legacy deployments).
+  dbfile: /var/www/acme2certifier/acme_srv.db
+
+Certificate:
+  revocation_reason_check_disable: false
+
+Challenge:
+  # when true disable challenge validation. Challenge will be set to 'valid' without further checking
+  # THIS IS A SEVERE SECURTIY ISSUE! Please do only for testing/debugging purposes
+  challenge_validation_disable: false
+
+Order:
+  tnauthlist_support: false
+
+# Helper:
+#   log_format: "%(asctime)s - acme2certifier - %(levelname)s - %(message)s"

--- a/examples/install_scripts/a2c-rpm.sh
+++ b/examples/install_scripts/a2c-rpm.sh
@@ -428,6 +428,19 @@ normalize_dbhandler_mode() {
   esac
 }
 
+# True when the first non-empty, non-comment line is not an INI [section].
+cfg_is_yaml() {
+  local cfg="${1:-${CFG}}"
+  ${SUDO} awk '
+    BEGIN { rc=1 }
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*[#;]/ { next }
+    /^\[/ { rc=1; exit }
+    { rc=0; exit }
+    END { exit rc }
+  ' "${cfg}"
+}
+
 # Read [DBhandler] handler / handler_module from cfg (short name or empty).
 get_dbhandler_mode() {
   local cfg="${1:-${CFG}}"
@@ -436,16 +449,29 @@ get_dbhandler_mode() {
     echo ""
     return 0
   fi
-  raw="$(${SUDO} awk '
-    /^\[DBhandler\]/ { in_sec=1; next }
-    /^\[/ { in_sec=0 }
-    in_sec && /^[[:space:]]*#*[[:space:]]*handler(_module)?[[:space:]]*:/ {
-      sub(/^[^:]*:[[:space:]]*/, "")
-      gsub(/[[:space:]]/, "")
-      print
-      exit
-    }
-  ' "${cfg}" 2>/dev/null || true)"
+  if cfg_is_yaml "${cfg}"; then
+    raw="$(${SUDO} awk '
+      /^DBhandler:/ { in_sec=1; next }
+      in_sec && /^[^[:space:]#].*:/ { in_sec=0 }
+      in_sec && /^[[:space:]]*#*[[:space:]]*handler(_module)?[[:space:]]*:/ {
+        sub(/^[^:]*:[[:space:]]*/, "")
+        gsub(/[[:space:]]/, "")
+        print
+        exit
+      }
+    ' "${cfg}" 2>/dev/null || true)"
+  else
+    raw="$(${SUDO} awk '
+      /^\[DBhandler\]/ { in_sec=1; next }
+      /^\[/ { in_sec=0 }
+      in_sec && /^[[:space:]]*#*[[:space:]]*handler(_module)?[[:space:]]*:/ {
+        sub(/^[^:]*:[[:space:]]*/, "")
+        gsub(/[[:space:]]/, "")
+        print
+        exit
+      }
+    ' "${cfg}" 2>/dev/null || true)"
+  fi
   normalize_dbhandler_mode "${raw}"
 }
 
@@ -453,6 +479,18 @@ get_dbhandler_mode() {
 set_dbhandler_mode() {
   local mode="$1"
   echo "==> Setting DBhandler to ${mode}"
+  if cfg_is_yaml "${CFG}"; then
+    if ${SUDO} grep -q '^DBhandler:' "${CFG}"; then
+      ${SUDO} sed -i \
+        '/^DBhandler:/,/^[^[:space:]#]/{
+          /^[[:space:]]*#*[[:space:]]*handler[[:space:]]*:/d
+        }' "${CFG}"
+      ${SUDO} sed -i "/^DBhandler:/a\\  handler: ${mode}" "${CFG}"
+    else
+      printf '\nDBhandler:\n  handler: %s\n' "${mode}" | ${SUDO} tee -a "${CFG}" >/dev/null
+    fi
+    return 0
+  fi
   if ! ${SUDO} grep -q '^\[DBhandler\]' "${CFG}"; then
     printf '\n[DBhandler]\nhandler: %s\n' "${mode}" | ${SUDO} tee -a "${CFG}" >/dev/null
     return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,4 +110,14 @@ testpaths = ["test"]
 addopts = [
     "--cov=acme2certifier",
     "--cov-report=term:skip-covered",
+    "--cov-report=lcov",
 ]
+
+[tool.coverage.run]
+# Relative paths so IDE coverage (Markis / Testing) maps to workspace files.
+relative_files = true
+
+[tool.black]
+# py314 enables PEP 758 (except TypeError, ValueError without parens), which breaks
+# on Python <3.14 and fights other formatters/linters. Keep parentheses.
+target-version = ["py312"]

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -8481,6 +8481,113 @@ Order:
             any("could not read config file" in line for line in lcm.output)
         )
 
+    def test_638_unique_key_loader_non_mapping_node(self):
+        """_UniqueKeyLoader.construct_mapping delegates non-mapping nodes"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        loader = config_mod._UniqueKeyLoader("")
+        node = yaml.nodes.ScalarNode("tag:yaml.org,2002:str", "foo")
+        with self.assertRaises(yaml.constructor.ConstructorError):
+            loader.construct_mapping(node)
+
+    def test_639_detect_comments_only_is_ini(self):
+        """Comment-only content is treated as empty INI"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self.assertEqual(
+            config_mod._detect_config_format("# only\n; also\n\n", "acme_srv.cfg"),
+            "ini",
+        )
+
+    def test_640_detect_ambiguous_yaml_extension(self):
+        """Ambiguous content with a .yaml name is detected as YAML"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self.assertEqual(
+            config_mod._detect_config_format("debug = false\n", "acme_srv.yaml"),
+            "yaml",
+        )
+
+    def test_641_yaml_non_string_option_key_raises(self):
+        """Integer YAML option names fail the load"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir, "acme_srv.yaml", "Order:\n  1: foo\n"
+            )
+            with self.assertRaisesRegex(ValueError, "YAML config key must be a string"):
+                self.load_config(self.logger, None, cfg_path)
+
+    def test_642_set_yaml_option_adds_missing_section(self):
+        """_set_yaml_option creates a section when it does not exist"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        config = config_mod._new_config_parser()
+        config_mod._set_yaml_option(config, "Order", "foo", "bar", self.logger)
+        self.assertEqual(config.get("Order", "foo"), "bar")
+
+    def test_643_yaml_empty_document_returns_empty_config(self):
+        """A YAML document with only --- yields an empty ConfigParser"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.yaml", "---\n")
+            config = self.load_config(self.logger, None, cfg_path)
+        self.assertEqual(config_mod._LAST_LOADED_CFG[2], "yaml")
+        self.assertEqual(config.sections(), [])
+
+    def test_644_yaml_non_string_section_key_raises(self):
+        """Integer YAML section names fail the load"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.yaml", "1:\n  foo: bar\n")
+            with self.assertRaisesRegex(ValueError, "YAML config key must be a string"):
+                self.load_config(self.logger, None, cfg_path)
+
+    def test_645_yaml_top_level_scalar_goes_to_default(self):
+        """Root-level scalar keys are stored under DEFAULT"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.yaml", "debug: false\n")
+            config = self.load_config(self.logger, None, cfg_path)
+        self.assertFalse(config.getboolean("DEFAULT", "debug"))
+
+    def test_646_default_deploy_base_dir_fallback_when_dirs_missing(self):
+        """default_deploy_base_dir falls back when deploy roots are absent"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        env = os.environ.copy()
+        env.pop("ACME2CERTIFIER_BASE_DIR", None)
+        with patch.dict(os.environ, env, clear=True):
+            with patch(
+                "acme2certifier.acme_srv.helpers.config.os.path.isdir",
+                return_value=False,
+            ):
+                self.assertEqual(
+                    config_mod.default_deploy_base_dir(),
+                    "/var/www/acme2certifier",
+                )
+
+    def test_647_default_wsgi_dbfile_joins_deploy_base(self):
+        """default_wsgi_dbfile uses default_deploy_base_dir for acme_srv.db"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        with patch(
+            "acme2certifier.acme_srv.helpers.config.default_deploy_base_dir",
+            return_value="/custom/base",
+        ):
+            self.assertEqual(
+                config_mod.default_wsgi_dbfile(),
+                os.path.join("/custom/base", "acme_srv.db"),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -14,6 +14,7 @@ from unittest.mock import patch, MagicMock, Mock
 import dns.resolver
 import base64
 import requests
+import yaml
 
 sys.path.insert(0, ".")
 sys.path.insert(1, "..")
@@ -2313,7 +2314,7 @@ klGUNHG98CtsmlhrivhSTJWqSIOfyKGF
             with self.assertLogs("test_a2c", level="INFO") as lcm1:
                 self.load_config(self.logger, None, cfg_path)
             self.assertIn(
-                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit)",
+                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit, ini)",
                 lcm1.output,
             )
             with self.assertLogs("test_a2c", level="DEBUG") as lcm2:
@@ -2326,7 +2327,8 @@ klGUNHG98CtsmlhrivhSTJWqSIOfyKGF
             )
             self.assertTrue(
                 any(
-                    f"DEBUG:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit)" in line
+                    f"DEBUG:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit, ini)"
+                    in line
                     for line in lcm2.output
                 )
             )
@@ -2353,7 +2355,7 @@ klGUNHG98CtsmlhrivhSTJWqSIOfyKGF
                 with self.assertLogs("test_a2c", level="INFO") as lcm:
                     self.load_config(self.logger, None, None)
             self.assertIn(
-                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (ACME_SRV_CONFIGFILE)",
+                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (ACME_SRV_CONFIGFILE, ini)",
                 lcm.output,
             )
         finally:
@@ -2378,12 +2380,12 @@ klGUNHG98CtsmlhrivhSTJWqSIOfyKGF
             # Early load without configured logger must not consume the once-slot
             # on the app logger.
             self.load_config(None, None, cfg_path)
-            self.assertEqual(config_mod._LAST_LOADED_CFG, (abs_path, "explicit"))
+            self.assertEqual(config_mod._LAST_LOADED_CFG, (abs_path, "explicit", "ini"))
             self.assertNotIn(abs_path, config_mod._ACME_SRV_CFG_LOADED)
             with self.assertLogs("test_a2c", level="INFO") as lcm:
                 config_mod.log_loaded_acme_srv_cfg(self.logger)
             self.assertIn(
-                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit)",
+                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit, ini)",
                 lcm.output,
             )
         finally:
@@ -7948,6 +7950,536 @@ jX1vlY35Ofonc4+6dRVamBiF9A==
                 )
             )
         self.assertTrue(any("null byte in path" in msg for msg in lcm.output))
+
+    _YAML_CFG_INI = """\
+[DEFAULT]
+debug: False
+dns_server_list: ["192.0.2.53", "192.0.2.54"]
+
+[DBhandler]
+handler: wsgi
+dbfile: /var/www/acme2certifier/acme_srv.db
+
+[Order]
+tnauthlist_support: False
+allowed_domainlist: ["*.example.local", "foo.bar.local"]
+allowed_iplist: ["10.0.0.0/8"]
+header_info_list: ["HTTP_USER_AGENT"]
+profiles: {"short": "http://example.local/short", "long": "http://example.local/long"}
+"""
+
+    _YAML_CFG_YAML = """\
+DEFAULT:
+  debug: false
+  dns_server_list:
+    - 192.0.2.53
+    - 192.0.2.54
+DBhandler:
+  handler: wsgi
+  dbfile: /var/www/acme2certifier/acme_srv.db
+Order:
+  tnauthlist_support: false
+  allowed_domainlist:
+    - "*.example.local"
+    - foo.bar.local
+  allowed_iplist:
+    - 10.0.0.0/8
+  header_info_list:
+    - HTTP_USER_AGENT
+  profiles:
+    short: http://example.local/short
+    long: http://example.local/long
+"""
+
+    def _write_acme_cfg(self, directory, name, content):
+        """Write UTF-8 config text and return the path."""
+        cfg_path = os.path.join(directory, name)
+        with open(cfg_path, "w", encoding="utf8") as handle:
+            handle.write(content)
+        return cfg_path
+
+    def _reset_acme_srv_cfg_load_state(self, config_mod):
+        """Clear once-per-path load/warn state."""
+        config_mod._ACME_SRV_CFG_LOADED.clear()
+        config_mod._ACME_SRV_CFG_PATH_WARNED.clear()
+        config_mod._LAST_LOADED_CFG = None
+
+    def test_611_load_config_ini_regression(self):
+        """INI acme_srv.cfg still loads via ConfigParser"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI)
+            config = self.load_config(self.logger, None, cfg_path)
+        self.assertFalse(config.getboolean("DEFAULT", "debug"))
+        self.assertEqual(config.get("DBhandler", "handler"), "wsgi")
+        self.assertFalse(config.getboolean("Order", "tnauthlist_support"))
+
+    def test_612_load_config_yaml_equivalent(self):
+        """YAML loads the same options as the equivalent INI"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            ini_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI),
+            )
+            yaml_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML),
+            )
+        self.assertEqual(
+            yaml_cfg.getboolean("DEFAULT", "debug"),
+            ini_cfg.getboolean("DEFAULT", "debug"),
+        )
+        self.assertEqual(
+            yaml_cfg.get("DBhandler", "dbfile"),
+            ini_cfg.get("DBhandler", "dbfile"),
+        )
+        self.assertEqual(
+            yaml_cfg.getboolean("Order", "tnauthlist_support"),
+            ini_cfg.getboolean("Order", "tnauthlist_support"),
+        )
+
+    def test_613_detect_ini_content_with_yaml_name(self):
+        """Content starting with [ is INI even when the name is .yaml"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self.assertEqual(
+            config_mod._detect_config_format(
+                "[DEFAULT]\ndebug: False\n", "acme_srv.yaml"
+            ),
+            "ini",
+        )
+
+    def test_614_detect_yaml_content_with_cfg_name(self):
+        """Top-level SectionName: is YAML even when the name is .cfg"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self.assertEqual(
+            config_mod._detect_config_format(
+                "DEFAULT:\n  debug: false\n", "acme_srv.cfg"
+            ),
+            "yaml",
+        )
+
+    def test_615_load_ini_named_yaml(self):
+        """INI bytes in a .yaml file are parsed as INI"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_INI)
+            config = self.load_config(self.logger, None, cfg_path)
+            abs_path = os.path.abspath(cfg_path)
+        self.assertEqual(config_mod._LAST_LOADED_CFG, (abs_path, "explicit", "ini"))
+        self.assertFalse(config.getboolean("DEFAULT", "debug"))
+
+    def test_616_load_yaml_named_cfg(self):
+        """YAML bytes in a .cfg file are parsed as YAML"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_YAML)
+            config = self.load_config(self.logger, None, cfg_path)
+            abs_path = os.path.abspath(cfg_path)
+        self.assertEqual(config_mod._LAST_LOADED_CFG, (abs_path, "explicit", "yaml"))
+        self.assertFalse(config.getboolean("DEFAULT", "debug"))
+
+    def test_617_native_yaml_allowed_domainlist_matches_ini_json(self):
+        """Native YAML allowed_domainlist equals INI JSON via the helper"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            ini_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI),
+            )
+            yaml_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML),
+            )
+        self.assertEqual(
+            self.config_allowed_domainlist_load(self.logger, yaml_cfg),
+            self.config_allowed_domainlist_load(self.logger, ini_cfg),
+        )
+        self.assertEqual(
+            self.config_allowed_domainlist_load(self.logger, yaml_cfg),
+            ["*.example.local", "foo.bar.local"],
+        )
+
+    def test_618_native_yaml_allowed_iplist_matches_ini_json(self):
+        """Native YAML allowed_iplist equals INI JSON via the helper"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            ini_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI),
+            )
+            yaml_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML),
+            )
+        self.assertEqual(
+            self.config_allowed_iplist_load(self.logger, yaml_cfg),
+            self.config_allowed_iplist_load(self.logger, ini_cfg),
+        )
+
+    def test_619_native_yaml_header_info_list_matches_ini_json(self):
+        """Native YAML header_info_list equals INI JSON via the helper"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            ini_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI),
+            )
+            yaml_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML),
+            )
+        self.assertEqual(
+            self.config_headerinfo_load(self.logger, yaml_cfg),
+            self.config_headerinfo_load(self.logger, ini_cfg),
+        )
+        self.assertEqual(
+            self.config_headerinfo_load(self.logger, yaml_cfg),
+            "HTTP_USER_AGENT",
+        )
+
+    def test_620_native_yaml_profiles_match_ini_json(self):
+        """Native YAML profiles mapping equals INI JSON via the helper"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            ini_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI),
+            )
+            yaml_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML),
+            )
+        self.assertEqual(
+            self.config_profile_load(self.logger, yaml_cfg),
+            self.config_profile_load(self.logger, ini_cfg),
+        )
+        self.assertEqual(
+            self.config_profile_load(self.logger, yaml_cfg),
+            {
+                "short": "http://example.local/short",
+                "long": "http://example.local/long",
+            },
+        )
+
+    def test_621_native_yaml_dns_server_list_matches_ini_json(self):
+        """Native YAML dns_server_list equals INI JSON via the helper"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            ini_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.cfg", self._YAML_CFG_INI),
+            )
+            yaml_cfg = self.load_config(
+                self.logger,
+                None,
+                self._write_acme_cfg(tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML),
+            )
+        yaml_list, _pause = self.config_dns_server_list_load(self.logger, yaml_cfg)
+        ini_list, _pause_ini = self.config_dns_server_list_load(self.logger, ini_cfg)
+        self.assertEqual(yaml_list, ini_list)
+        self.assertEqual(yaml_list, ["192.0.2.53", "192.0.2.54"])
+
+    def test_622_invalid_yaml_raises(self):
+        """Malformed YAML aborts load instead of returning a partial config"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir, "acme_srv.yaml", "DEFAULT:\n  debug: [\n"
+            )
+            with self.assertRaises(yaml.YAMLError):
+                self.load_config(self.logger, None, cfg_path)
+
+    def test_623_duplicate_yaml_keys_raise(self):
+        """Duplicate YAML keys fail the load"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir,
+                "acme_srv.yaml",
+                "Order:\n  allowed_domainlist: []\n  allowed_domainlist: []\n",
+            )
+            with self.assertRaisesRegex(
+                yaml.constructor.ConstructorError, "duplicate key"
+            ):
+                self.load_config(self.logger, None, cfg_path)
+
+    def test_624_datetime_yaml_value_raises(self):
+        """Unquoted YAML dates are rejected"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir, "acme_srv.yaml", "DEFAULT:\n  when: 2024-01-01\n"
+            )
+            with self.assertRaisesRegex(ValueError, "Unsupported YAML type date"):
+                self.load_config(self.logger, None, cfg_path)
+
+    def test_625_non_mapping_yaml_root_raises(self):
+        """A YAML list document cannot become ConfigParser sections"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.yaml", "- foo\n- bar\n")
+            with self.assertRaisesRegex(ValueError, "root must be a mapping"):
+                self.load_config(self.logger, None, cfg_path)
+
+    def test_626_null_yaml_option_omitted_with_warning(self):
+        """YAML null options are skipped and logged"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir,
+                "acme_srv.yaml",
+                "DEFAULT:\n  debug: false\n  unused: null\n",
+            )
+            with self.assertLogs("test_a2c", level="WARNING") as lcm:
+                config = self.load_config(self.logger, None, cfg_path)
+        self.assertNotIn("unused", config["DEFAULT"])
+        self.assertFalse(config.getboolean("DEFAULT", "debug"))
+        self.assertTrue(
+            any(
+                "Ignoring null YAML option DEFAULT.unused" in line
+                for line in lcm.output
+            )
+        )
+
+    def test_627_yaml_yes_on_are_booleans(self):
+        """PyYAML 1.1 yes/on values become ConfigParser booleans"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir,
+                "acme_srv.yaml",
+                "DEFAULT:\n  debug: yes\nNonce:\n  nonce_check_disable: on\n",
+            )
+            config = self.load_config(self.logger, None, cfg_path)
+        self.assertTrue(config.getboolean("DEFAULT", "debug"))
+        self.assertTrue(config.getboolean("Nonce", "nonce_check_disable"))
+
+    def test_628_discovery_finds_yaml_when_cfg_missing(self):
+        """Default discovery uses acme_srv.yaml when acme_srv.cfg is absent"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+
+        def _isfile_for(path_set):
+            return lambda path: path in path_set
+
+        with patch(
+            "os.path.isfile",
+            side_effect=_isfile_for({"/var/www/acme2certifier/acme_srv.yaml"}),
+        ):
+            self.assertEqual(
+                config_mod._default_acme_srv_cfg_file(self.logger),
+                "/var/www/acme2certifier/acme_srv.yaml",
+            )
+
+    def test_629_discovery_prefers_cfg_over_yaml_same_location(self):
+        """At one location acme_srv.cfg wins over yaml/yml"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+
+        def _isfile_for(path_set):
+            return lambda path: path in path_set
+
+        with patch(
+            "os.path.isfile",
+            side_effect=_isfile_for(
+                {
+                    "/var/www/acme2certifier/acme_srv.cfg",
+                    "/var/www/acme2certifier/acme_srv.yaml",
+                    "/var/www/acme2certifier/acme_srv.yml",
+                }
+            ),
+        ):
+            self.assertEqual(
+                config_mod._default_acme_srv_cfg_file(self.logger),
+                "/var/www/acme2certifier/acme_srv.cfg",
+            )
+
+    def test_630_discovery_prefers_yaml_over_yml(self):
+        """acme_srv.yaml is tried before acme_srv.yml"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+
+        def _isfile_for(path_set):
+            return lambda path: path in path_set
+
+        with patch(
+            "os.path.isfile",
+            side_effect=_isfile_for(
+                {
+                    "/var/www/acme2certifier/acme_srv.yaml",
+                    "/var/www/acme2certifier/acme_srv.yml",
+                }
+            ),
+        ):
+            self.assertEqual(
+                config_mod._default_acme_srv_cfg_file(self.logger),
+                "/var/www/acme2certifier/acme_srv.yaml",
+            )
+
+    def test_631_discovery_fallback_remains_cfg(self):
+        """When nothing exists, discovery still returns the INI fallback path"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        with patch("os.path.isfile", return_value=False):
+            self.assertEqual(
+                config_mod._default_acme_srv_cfg_file(self.logger),
+                "/var/www/acme2certifier/acme_srv.cfg",
+            )
+
+    def test_632_discovery_yaml_at_preferred_beats_cfg_elsewhere(self):
+        """YAML at /var/www wins over cfg at /opt when the DEB path has no cfg"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+
+        def _isfile_for(path_set):
+            return lambda path: path in path_set
+
+        with patch(
+            "os.path.isfile",
+            side_effect=_isfile_for(
+                {
+                    "/var/www/acme2certifier/acme_srv.yaml",
+                    "/opt/acme2certifier/acme_srv.cfg",
+                }
+            ),
+        ):
+            self.assertEqual(
+                config_mod._default_acme_srv_cfg_file(self.logger),
+                "/var/www/acme2certifier/acme_srv.yaml",
+            )
+
+    def test_633_load_log_includes_yaml_format_once_per_path(self):
+        """Successful YAML load logs format at INFO once, then DEBUG"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML
+            )
+            abs_path = os.path.abspath(cfg_path)
+            with self.assertLogs("test_a2c", level="INFO") as lcm1:
+                self.load_config(self.logger, None, cfg_path)
+            self.assertIn(
+                f"INFO:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit, yaml)",
+                lcm1.output,
+            )
+            with self.assertLogs("test_a2c", level="DEBUG") as lcm2:
+                self.load_config(self.logger, None, cfg_path)
+            self.assertFalse(
+                any(
+                    line.startswith("INFO:test_a2c:Loaded acme_srv.cfg")
+                    for line in lcm2.output
+                )
+            )
+            self.assertTrue(
+                any(
+                    f"DEBUG:test_a2c:Loaded acme_srv.cfg {abs_path} (explicit, yaml)"
+                    in line
+                    for line in lcm2.output
+                )
+            )
+
+    def test_634_format_detected_on_every_parse(self):
+        """Format is re-detected on every load_config() call"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(
+                tmpdir, "acme_srv.yaml", self._YAML_CFG_YAML
+            )
+            expected = f"DEBUG:test_a2c:Detected acme_srv config format: yaml (path={cfg_path})"
+            with self.assertLogs("test_a2c", level="DEBUG") as lcm:
+                self.load_config(self.logger, None, cfg_path)
+                self.load_config(self.logger, None, cfg_path)
+        self.assertEqual(lcm.output.count(expected), 2)
+
+    def test_635_ini_parse_failure_retries_yaml(self):
+        """Ambiguous .cfg content that fails INI parse is retried as YAML"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        content = "%YAML 1.1\n---\nDEFAULT:\n  debug: false\n"
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.cfg", content)
+            self.assertEqual(config_mod._detect_config_format(content, cfg_path), "ini")
+            config = self.load_config(self.logger, None, cfg_path)
+        self.assertEqual(config_mod._LAST_LOADED_CFG[2], "yaml")
+        self.assertFalse(config.getboolean("DEFAULT", "debug"))
+
+    def test_636_empty_file_is_ini(self):
+        """Empty content keeps the historical empty-INI behavior"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = self._write_acme_cfg(tmpdir, "acme_srv.yaml", "")
+            config = self.load_config(self.logger, None, cfg_path)
+        self.assertEqual(config_mod._LAST_LOADED_CFG[2], "ini")
+        self.assertEqual(config.sections(), [])
+
+    def test_637_missing_file_warns_and_returns_empty(self):
+        """Unreadable path logs a warning and returns an empty ConfigParser"""
+        from acme2certifier.acme_srv.helpers import config as config_mod
+
+        self._reset_acme_srv_cfg_load_state(config_mod)
+        with TemporaryDirectory() as tmpdir:
+            cfg_path = os.path.join(tmpdir, "missing.cfg")
+            with self.assertLogs("test_a2c", level="WARNING") as lcm:
+                config = self.load_config(self.logger, None, cfg_path)
+        self.assertEqual(config.sections(), [])
+        self.assertTrue(
+            any("could not read config file" in line for line in lcm.output)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add YAML as an equivalent format for acme_srv.cfg. load_config() still returns configparser.ConfigParser. Format is detected from file content on every load (extension is a tie-breaker). Shipped default remains INI.
 New implementation accepts INI (acme_srv.cfg) and YAML (acme_srv.yaml / acme_srv.yml).

Discovery order: .cfg → .yaml → .yml.
