### PR TITLE
Refactor SQL handler for EAB

### DIFF
--- a/acme2certifier/eabhandlers/sql_handler.py
+++ b/acme2certifier/eabhandlers/sql_handler.py
@@ -6,9 +6,8 @@
 from __future__ import print_function
 
 from logging import Logger
-import psycopg2
+import pyodbc
 import re
-from mssql_python import connect
 from typing import Dict, List, Optional, Tuple
 
 from acme2certifier.acme_srv.helper import load_config, csr_cn_get, csr_san_get
@@ -231,59 +230,46 @@ class EABhandler(object):
         data_dic = {}
 
         if self.db_host and self.db_name and self.db_user and self.db_password:
-            SQL_QUERY = "SELECT key_id, profile FROM credentials WHERE STATUS = 1;"
+            sql_query = "SELECT key_id, profile FROM acme_credential WHERE enabled = 1;"
+            db_driver = ""
+
             if self.db_system == "mssql":
-                data_dic = self._load_mssql_profiles(SQL_QUERY)
+                db_driver = "DRIVER={ODBC Driver 18 for SQL Server}"
             elif self.db_system == "postgres":
-                data_dic = self._load_postgres_profiles(SQL_QUERY)
+                db_driver = "DRIVER={PostgreSQL}"
+
+            data_dic = self._load_profiles(db_driver, sql_query)
 
         self.logger.debug("EABhandler.key_file.load() ended: {%s}", bool(data_dic))
         return data_dic
 
-    def _load_mssql_profiles(self, sql_query: str) -> Dict[str, str]:
-        """Helper to load profiles from MSSQL"""
+    def _load_profiles(self, db_driver, sql_query: str) -> Dict[str,str]:
+        """Helper to load eab profiles from database"""
+        self.logger.debug("EABhandler._load_profiles()")
+
         data_dic = {}
+
         try:
             conn_str = (
-                "Server="
+                db_driver
+                + ";SERVER="
                 + self.db_host
-                + ";Database="
+                + ";DATABASE="
                 + self.db_name
-                + ";Encrypt=yes;UID="
+                + ";UID="
                 + self.db_user
                 + ";PWD="
                 + self.db_password
-                + ";TrustServerCertificate=yes"
+                + ";Encrypt=yes;TrustServerCertificate=yes"
             )
-            conn = connect(conn_str)
-            cursor = conn.cursor()
-            cursor.execute(sql_query)
-            rows = cursor.fetchall()
-            for row in rows:
-                data_dic[row.key_id] = row.profile
-            conn.close()
-        except Exception as err:
-            self.logger.error("EABhandler._load_mssql_profiles() error: %s", err)
-        return data_dic
-
-    def _load_postgres_profiles(self, sql_query: str) -> Dict[str, str]:
-        """Helper to load profiles from Postgres"""
-        data_dic = {}
-        try:
-            conn = psycopg2.connect(
-                host=self.db_host,
-                dbname=self.db_name,
-                user=self.db_user,
-                password=self.db_password,
-            )
+            conn = pyodbc.connect(conn_str)
             cursor = conn.cursor()
             cursor.execute(sql_query)
             rows = cursor.fetchall()
             for row in rows:
                 data_dic[str(row[0])] = str(row[1])
-            conn.close()
         except Exception as err:
-            self.logger.error("EABhandler._load_postgres_profiles() error: %s", err)
+            self.logger.error("EABhandler._load_profiles() error: %s", err)
         return data_dic
 
     def mac_key_get(self, key_id: str) -> Optional[str]:

--- a/docs/eab.md
+++ b/docs/eab.md
@@ -91,17 +91,17 @@ The `key_file` should contain key-value pairs in JSON format:
 
 ## SQL Handler
 
-The `sql_handler.py` script allows `kid` and `mac_key` (Base64 encoded) to be loaded from a database. SQL Handler supports PostgreSQL and SQL Server database systems.
+The `sql_handler.py` script allows `kid` and `mac_key` (Base64 encoded) to be loaded from a database. SQL Handler supports PostgreSQL and Microsoft SQL Server database systems.
 
 Using a database for storing EAB credentials is useful in use cases where many `acme2certifier` instances use the same credentials, for example in data centers using load balancing. Instead of maintaining multiple JSON files, credentials can be maintained using a single database instance.
 
 Using a database is beneficial also when rotating and managing `kid/mac_key` pairs in more complex scenarios, with the addition of an `account` table that can maintain information about the account related to each key.
 
-It is recommended to use the same [external database](external_database_support.md) for both `acme2certifier` and EAB.
-
 ### Database Schema
 
-The database schema includes two tables, one for actual credentials used by `acme2certifier` and another for managing accounts and credentials. Any number of credentials can be related to a single account. Only the credentials table is actually used by `acme2certifier`.
+The database schema includes two tables, one for actual credentials used by `acme2certifier` and another for managing accounts related to the credentials. Any number of credentials can be related to a single account.
+
+Only the `acme_credential` table is actually used by `acme2certifier` in the query `SELECT key_id, profile FROM acme_credential WHERE enabled = 1;`. You may implement any number additional columns for these tables if you wish, as they do not affect the functionality of this application.
 
 Schemas for the database systems differ in relation to fields that are used to maintain JSON data. SQL Server has `NVARCHAR` type for that, whereas PostgreSQL has `JSONB`. Schemas also have a status column to indicate if the credentials are active or not (value is 0 or 1).
 
@@ -110,19 +110,19 @@ Schemas for the database systems differ in relation to fields that are used to m
 Create a database and then these two tables. See [Usage](#usage) for entering some data in the tables. Then, [configure acme_srv.cfg](#activate-handler) with the database credentials that you have.
 
 ```sql
-CREATE TABLE account (
+CREATE TABLE acme_account (
     id SERIAL PRIMARY KEY,
-    name VARCHAR(127) NOT NULL,
-    contact VARCHAR(127)
+    name VARCHAR(256) NOT NULL,
+    email VARCHAR(320)
 );
 
-CREATE TABLE credentials (
+CREATE TABLE acme_credential (
     id SERIAL PRIMARY KEY,
-    account_id INT NOT NULL REFERENCES account (id),
+    account_id INT NOT NULL REFERENCES acme_account (id),
     key_id VARCHAR(63) NOT NULL,
+    description VARCHAR(127),
     profile JSONB,
-    description VARCHAR(255),
-    status SMALLINT NOT NULL
+    enabled SMALLINT NOT NULL
 );
 ```
 
@@ -131,19 +131,19 @@ CREATE TABLE credentials (
 Create a database and then these two tables. See [Usage](#usage) for entering some data in the tables. Then, [configure acme_srv.cfg](#activate-handler) with the database credentials that you have.
 
 ```sql
-CREATE TABLE account (
+CREATE TABLE acme_account (
     id INT IDENTITY(1,1) PRIMARY KEY,
-    name NVARCHAR(127) NOT NULL,
-    contact NVARCHAR(127)
+    name NVARCHAR(256) NOT NULL,
+    email NVARCHAR(320)
 );
 
-CREATE TABLE credentials (
+CREATE TABLE acme_credential (
     id INT IDENTITY(1,1) PRIMARY KEY,
-    account_id INT NOT NULL REFERENCES account (id),
+    account_id INT NOT NULL REFERENCES acme_account (id),
     key_id NVARCHAR(63) NOT NULL,
+    description NVARCHAR(127),
     profile NVARCHAR(MAX),
-    description NVARCHAR(255),
-    status TINYINT NOT NULL
+    enabled TINYINT NOT NULL
 );
 ```
 
@@ -152,16 +152,16 @@ CREATE TABLE credentials (
 In the simplest scenario, the database will have one account that all the keys are related to.
 
 ```sql
-INSERT INTO account (name, contact)
+INSERT INTO acme_account (name, email)
   VALUES ('myaccount', 'contact@myaccount.com');
 ```
 
-The `profile` column in `credentials` table should contain JSON data in the same format as it is used in JSON Handler.
+The `profile` column in `acme_credential` table should contain JSON data in the same format as it is used in JSON Handler.
 
 Example:
 
 ```sql
-INSERT INTO credentials (account_id, key_id, description, profile, status)
+INSERT INTO acme_credential (account_id, key_id, description, profile, enabled)
   VALUES (
     (SELECT id FROM account WHERE account.name = 'myaccount'),
     'keyid_03',
@@ -176,6 +176,12 @@ INSERT INTO credentials (account_id, key_id, description, profile, status)
   );
 ```
 
+### Install additional packages
+
+SQL handler uses [pyodbc](https://pypi.org/project/pyodbc/) for database connections and database drivers are also required. On your acme2certifier server, install the Python module with `pip install pyodbc`. Then, install `unixODBC` with your system's package manager.
+
+For SQL Server, follow these [instructions](https://learn.microsoft.com/en-us/sql/connect/odbc/microsoft-odbc-driver-for-sql-server) to install Microsoft ODBC 18. For PostgreSQL, see [psqlODBC](https://odbc.postgresql.org/) to get packages for your system.
+
 ### Activate Handler
 
 To activate this handler, configure the `EABhandler` section in `acme_srv.cfg` as follows. For `db_system`, enter either `mssql` or `postgres`.
@@ -184,12 +190,14 @@ To activate this handler, configure the `EABhandler` section in `acme_srv.cfg` a
 [EABhandler]
 eab_profiling: True
 eab_handler_module: acme2certifier.eabhandlers.sql_handler
-db_system: mssql, postgres
+db_system:
 db_host:
 db_name:
 db_user:
 db_password:
 ```
+
+Above, allowed values for `db_system` are either `mssql` or `postgres`.
 
 ## Keyfile Verification
 

--- a/docs/external_database_support.md
+++ b/docs/external_database_support.md
@@ -69,35 +69,6 @@ GRANT postgres TO acme2certifier;
 sudo apt-get install python3-django python3-psycopg2
 ```
 
-### When Using SQL Server
-
-_SQL Server support has not been tested in the [release regression](https://github.com/grindsa/acme2certifier/actions/workflows/django_tests.yml) to the same extent as the other two databases._
-
-Note that this part of the guide is written for **Red Hat Enterprise Linux 9**.
-
-It is assumed that SQL Server is already installed and running.
-
-- Open SQL Server Management Studio.
-
-- Create the acme2certifier database and database user:
-
-```SQL
-CREATE DATABASE acme2certifier;
-CREATE LOGIN acme2certifier WITH PASSWORD = 'a2c+passwd';
-CREATE USER acme2certifier FOR LOGIN acme2certifier;
-```
-
-- From Object Explorer, open acme2certifier → Security → Logins → acme2certifier Properties. Under User Mapping, map the user to the database and grant the required roles. Under Server Roles, grant `public` and `sysadmin` as needed so the acme2certifier user has full access to the database.
-
-- Install missing Python modules:
-
-```bash
-pip install mssql-django pyodbc
-sudo dnf install unixODBC
-```
-
-- Follow [these instructions](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15&tabs=redhat18-install%2Credhat17-install%2Cdebian8-install%2Credhat7-13-install%2Crhel7-offline#17) to install Microsoft ODBC 17.
-
 ## Install and Configure acme2certifier
 
 ### Debian-based deployment
@@ -214,26 +185,6 @@ DATABASES = {
     }
 }
 ```
-
-### Connecting to SQL Server
-
-- Modify `settings.py` and configure your database connection as below:
-
-```python
-DATABASES = {
-    "default": {
-        "ENGINE": "mssql",
-        "NAME": "acme2certifier",
-        "USER": "acme2certifier",
-        "PASSWORD": "a2c+passwd",
-        "HOST": "sqlserverdbsrv,1433",
-        "PORT": "",
-        "OPTIONS": {"driver": "ODBC Driver 17 for SQL Server"},
-    }
-}
-```
-
-- You may also need to disable some SELinux settings for Apache, depending on your server configuration.
 
 ## Finalize acme2certifier configuration
 

--- a/test/test_eabsql_handler.py
+++ b/test/test_eabsql_handler.py
@@ -21,15 +21,9 @@ class TestEABHandler(unittest.TestCase):
         import sys
         import types
 
-        sys.modules["psycopg2"] = types.ModuleType("psycopg2")
-        sys.modules["psycopg2"].connect = MagicMock()
-        mssql_mock = types.ModuleType("mssql_python")
+        sys.modules["pyodbc"] = types.ModuleType("pyodbc")
+        sys.modules["pyodbc"].connect = MagicMock()
 
-        def dummy_connect(*args, **kwargs):
-            return None
-
-        mssql_mock.connect = dummy_connect
-        sys.modules["mssql_python"] = mssql_mock
         import logging
 
         logging.basicConfig(level=logging.CRITICAL)
@@ -338,70 +332,66 @@ class TestEABHandler(unittest.TestCase):
         self.eabhandler.db_name = None
         self.eabhandler.db_user = None
         self.eabhandler.db_password = None
+        self.eabhandler.db_system = None
         result = self.eabhandler.key_file_load()
         self.assertEqual(result, {})
 
-    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_mssql_profiles")
-    def test_031_key_file_load_mssql(self, mock_load_mssql):
-        """MSSQL: should call _load_mssql_profiles and return its result"""
+    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_profiles")
+    def test_031_key_file_load_mssql(self, mock_load):
+        """MSSQL: should call _load_profiles and return its result"""
         self.eabhandler.db_host = "host"
         self.eabhandler.db_name = "name"
         self.eabhandler.db_user = "user"
         self.eabhandler.db_password = "pass"
         self.eabhandler.db_system = "mssql"
-        mock_load_mssql.return_value = {"key": "profile"}
+        mock_load.return_value = {"key": "profile"}
         result = self.eabhandler.key_file_load()
         self.assertEqual(result, {"key": "profile"})
-        mock_load_mssql.assert_called_once()
+        mock_load.assert_called_once()
 
-    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_postgres_profiles")
-    def test_032_key_file_load_postgres(self, mock_load_postgres):
-        """Postgres: should call _load_postgres_profiles and return its result"""
+    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_profiles")
+    def test_032_key_file_load_postgres(self, mock_load):
+        """Postgres: should call _load_profiles and return its result"""
         self.eabhandler.db_host = "host"
         self.eabhandler.db_name = "name"
         self.eabhandler.db_user = "user"
         self.eabhandler.db_password = "pass"
         self.eabhandler.db_system = "postgres"
-        mock_load_postgres.return_value = {"key": "profile"}
+        mock_load.return_value = {"key": "profile"}
         result = self.eabhandler.key_file_load()
         self.assertEqual(result, {"key": "profile"})
-        mock_load_postgres.assert_called_once()
+        mock_load.assert_called_once()
 
-    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_mssql_profiles")
-    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_postgres_profiles")
-    def test_033_key_file_load_error(self, mock_postgres, mock_mssql):
+    @patch("acme2certifier.eabhandlers.sql_handler.EABhandler._load_profiles")
+    def test_033_key_file_load_error(self, mock_load):
         """Invalid db_system: should return empty dict"""
         self.eabhandler.db_host = "host"
         self.eabhandler.db_name = "name"
         self.eabhandler.db_user = "user"
         self.eabhandler.db_password = "pass"
         self.eabhandler.db_system = "invalid"
-        mock_postgres.return_value = {}
-        mock_mssql.return_value = {}
+        mock_load.return_value = {}
         result = self.eabhandler.key_file_load()
         self.assertEqual(result, {})
 
-    @patch("acme2certifier.eabhandlers.sql_handler.connect")
+    @patch("acme2certifier.eabhandlers.sql_handler.pyodbc.connect")
     def test_034_load_mssql_profiles_success(self, mock_connect):
         """Successful fetch: should return dict with profiles"""
         self.eabhandler.db_host = "host"
         self.eabhandler.db_name = "name"
         self.eabhandler.db_user = "user"
         self.eabhandler.db_password = "pass"
-        # Mock MSSQL connection and cursor
+        self.eabhandler.db_system = "mssql"
+
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
-        mock_cursor.fetchall.return_value = [
-            MagicMock(key_id="id1", profile="profile1"),
-            MagicMock(key_id="id2", profile="profile2"),
-        ]
+        mock_cursor.fetchall.return_value =  [('id1', 'profile1'), ('id2', 'profile2')]
         mock_connect.return_value = mock_conn
-        result = self.eabhandler._load_mssql_profiles("SELECT ...")
+        result = self.eabhandler._load_profiles("mssql", "SELECT ...")
         self.assertEqual(result, {"id1": "profile1", "id2": "profile2"})
-        mock_conn.close.assert_called_once()
 
-    @patch("acme2certifier.eabhandlers.sql_handler.connect")
+    @patch("acme2certifier.eabhandlers.sql_handler.pyodbc.connect")
     def test_035_load_mssql_profiles_empty(self, mock_connect):
         """Empty result: should return empty dict"""
         mock_conn = MagicMock()
@@ -409,35 +399,36 @@ class TestEABHandler(unittest.TestCase):
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.fetchall.return_value = []
         mock_connect.return_value = mock_conn
-        result = self.eabhandler._load_mssql_profiles("SELECT ...")
+        result = self.eabhandler._load_profiles("mssql", "SELECT ...")
         self.assertEqual(result, {})
 
-    @patch("acme2certifier.eabhandlers.sql_handler.connect")
+    @patch("acme2certifier.eabhandlers.sql_handler.pyodbc.connect")
     def test_036_load_mssql_profiles_exception(self, mock_connect):
         """Exception: should log error and return empty dict"""
         mock_connect.side_effect = Exception("connection error")
         with self.assertLogs("test_a2c", level="ERROR") as lcm:
-            result = self.eabhandler._load_mssql_profiles("SELECT ...")
+            result = self.eabhandler._load_profiles("mssql", "SELECT ...")
         self.assertEqual(result, {})
         self.assertTrue(any("error" in msg.lower() for msg in lcm.output))
 
-    @patch("acme2certifier.eabhandlers.sql_handler.psycopg2.connect")
+    @patch("acme2certifier.eabhandlers.sql_handler.pyodbc.connect")
     def test_037_load_postgres_profiles_success(self, mock_connect):
         """Successful fetch: should return dict with profiles"""
         self.eabhandler.db_host = "host"
         self.eabhandler.db_name = "name"
         self.eabhandler.db_user = "user"
         self.eabhandler.db_password = "pass"
+        self.eabhandler.db_system = "postgres"
+
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.fetchall.return_value = [("id1", "profile1"), ("id2", "profile2")]
         mock_connect.return_value = mock_conn
-        result = self.eabhandler._load_postgres_profiles("SELECT ...")
+        result = self.eabhandler._load_profiles("postgres", "SELECT ...")
         self.assertEqual(result, {"id1": "profile1", "id2": "profile2"})
-        mock_conn.close.assert_called_once()
 
-    @patch("acme2certifier.eabhandlers.sql_handler.psycopg2.connect")
+    @patch("acme2certifier.eabhandlers.sql_handler.pyodbc.connect")
     def test_038_load_postgres_profiles_empty(self, mock_connect):
         """Empty result: should return empty dict"""
         mock_conn = MagicMock()
@@ -447,16 +438,15 @@ class TestEABHandler(unittest.TestCase):
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.fetchall.return_value = []
         mock_connect.return_value = mock_conn
-        result = self.eabhandler._load_postgres_profiles("SELECT ...")
+        result = self.eabhandler._load_profiles("postgres", "SELECT ...")
         self.assertEqual(result, {})
-        self.assertTrue(mock_conn.close.called)
 
-    @patch("acme2certifier.eabhandlers.sql_handler.psycopg2.connect")
-    def test_039_load_postgres_profiles_exception(self, mock_connect):
+    @patch("acme2certifier.eabhandlers.sql_handler.pyodbc.connect")
+    def test_039_load_profiles_exception(self, mock_connect):
         """Exception: should log error and return empty dict"""
         mock_connect.side_effect = Exception("connection error")
         with self.assertLogs("test_a2c", level="ERROR") as lcm:
-            result = self.eabhandler._load_postgres_profiles("SELECT ...")
+            result = self.eabhandler._load_profiles("postgres", "SELECT ...")
         self.assertEqual(result, {})
         self.assertTrue(any("error" in msg.lower() for msg in lcm.output))
 
@@ -488,6 +478,7 @@ class TestEABHandler(unittest.TestCase):
         self.eabhandler.db_name = None
         self.eabhandler.db_user = None
         self.eabhandler.db_password = None
+        self.eabhandler.db_system = None
         with self.assertLogs("test_a2c", level="ERROR") as lcm:
             result = self.eabhandler.mac_key_get("key1")
         self.assertIsNone(result)


### PR DESCRIPTION
This PR will refactor SQL handler for EAB as implemented in https://github.com/grindsa/acme2certifier/pull/303.

- Removes the requirement for Python modules mssql_python and psycopg2, and uses pyodbc instead
- For MS SQL Server usage, lowers minimum required Python version to 3.9, when mssql_python module required 3.10
- Changes database schema used by SQL handler. If you have SQL handler in use, please have a look at documentation for EAB for the changes that are minor
- Removes the section for SQL Server in External Databases documentation because SQL Server data types are not fully compatible with acme2certifier SQL queries