### PR TITLE
 [min] Enforce account binding on ACME resources and ARI

### DIFF
--- a/.github/actions/wf_specific/error_tests/resource_ownership_checks/action.yml
+++ b/.github/actions/wf_specific/error_tests/resource_ownership_checks/action.yml
@@ -1,0 +1,187 @@
+name: "resource_ownership_checks"
+description: "Cross-account order poll/finalize must return 403 unauthorized"
+inputs:
+  NAME_SPACE:
+    description: "Docker network namespace"
+    required: false
+    default: "acme"
+  DEPLOYMENT_TYPE:
+    description: "Deployment type"
+    required: false
+    default: "container"
+  ACME_SERVER:
+    description: "ACME server hostname"
+    required: false
+    default: "acme-srv"
+  HTTP_PORT:
+    description: "ACME server HTTP port"
+    required: false
+    default: "80"
+  ACME_CFG:
+    description: "Host path to acme_srv.cfg"
+    required: false
+    default: "examples/Docker/data/acme_srv.cfg"
+  TEST_DOMAIN:
+    description: "Prevalidated DNS identifier for victim order"
+    required: false
+    default: "crossacct.acme"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Enable prevalidated_domainlist for ownership test"
+      if: ${{ inputs.DEPLOYMENT_TYPE == 'container' }}
+      run: |
+        set -euo pipefail
+        MARKER="# resource-ownership CI"
+        if ! grep -qF "${MARKER}" "${ACME_CFG}"; then
+          sudo tee -a "${ACME_CFG}" >/dev/null <<EOF
+
+        [Authorization]
+        ${MARKER}
+        prevalidated_domainlist: ["${TEST_DOMAIN}"]
+        EOF
+        fi
+        grep -n 'prevalidated_domainlist' "${ACME_CFG}"
+        cd examples/Docker/
+        docker compose restart
+      shell: bash
+      env:
+        ACME_CFG: ${{ inputs.ACME_CFG }}
+        TEST_DOMAIN: ${{ inputs.TEST_DOMAIN }}
+
+    - name: "Wait for ACME directory after prevalidation enable"
+      if: ${{ inputs.DEPLOYMENT_TYPE == 'container' }}
+      uses: ./.github/actions/wait_for_directory
+      with:
+        NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
+        CHECK_HTTPS: "false"
+        HTTP_PORT: ${{ inputs.HTTP_PORT }}
+
+    - name: "Prepare victim acmeshell script"
+      working-directory: acmeshell
+      run: |
+        set -euo pipefail
+        rm -f acmeshell.victim.log victim.order.url victim.finalize.url
+        cat <<EOT > victim.shell
+        newAccount -contacts=victim-ownership@bar.local,
+        newOrder -identifiers=${TEST_DOMAIN}
+        getAuthz -order=0 -identifier=${TEST_DOMAIN}
+        poll -order=0 -status=ready
+        getOrder -order=0
+        EOT
+      shell: bash
+      env:
+        TEST_DOMAIN: ${{ inputs.TEST_DOMAIN }}
+
+    - name: "Run victim flow (order ready)"
+      working-directory: acmeshell
+      run: |
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/victim.shell &> /acmeshell/acmeshell.victim.log'
+        cat acmeshell.victim.log
+      shell: bash
+
+    - name: "Extract victim order and finalize URLs from log"
+      working-directory: acmeshell
+      run: |
+        set -euo pipefail
+        grep -q '"status": "ready"' acmeshell.victim.log
+        grep -oE 'http://acme-srv/acme/order/[^"/]+/finalize' acmeshell.victim.log | tail -1 > victim.finalize.url
+        grep -oE 'http://acme-srv/acme/order/[^"/]+' acmeshell.victim.log | grep -v finalize | tail -1 > victim.order.url
+        test -s victim.finalize.url
+        test -s victim.order.url
+        echo "order=$(cat victim.order.url)"
+        echo "finalize=$(cat victim.finalize.url)"
+      shell: bash
+
+    - name: "Prepare attacker CSR and shell script"
+      working-directory: acmeshell
+      run: |
+        set -euo pipefail
+        ORDER_URL="$(cat victim.order.url)"
+        FINALIZE_URL="$(cat victim.finalize.url)"
+        openssl req -new -newkey rsa:2048 -nodes \
+          -keyout attacker.key -outform DER -out attacker.csr.der \
+          -subj "/CN=${TEST_DOMAIN}" \
+          -addext "subjectAltName=DNS:${TEST_DOMAIN}"
+        CSR_B64="$(python3 - <<'PY'
+        import base64, pathlib
+        der = pathlib.Path("attacker.csr.der").read_bytes()
+        print(base64.urlsafe_b64encode(der).rstrip(b"=").decode())
+        PY
+        )"
+        BODY="$(python3 -c "import json; print(json.dumps({'csr': '${CSR_B64}'}))")"
+        cat <<EOT > attacker.shell
+        newAccount -contacts=attacker-ownership@bar.local,
+        post -noData ${ORDER_URL}
+        post -body='${BODY}' ${FINALIZE_URL}
+        EOT
+      shell: bash
+      env:
+        TEST_DOMAIN: ${{ inputs.TEST_DOMAIN }}
+
+    - name: "Run attacker cross-account poll and finalize"
+      working-directory: acmeshell
+      continue-on-error: true
+      run: |
+        docker exec alma bash -c '/acmeshell/acmeshell -directory http://acme-srv -postAsGet=true -printResponses -printRequests -autoregister=false --account="" -in /acmeshell/attacker.shell &> /acmeshell/acmeshell.attacker.log'
+        cat acmeshell.attacker.log
+      shell: bash
+
+    - name: "Check acmeshell log for unauthorized on cross-account poll"
+      working-directory: acmeshell
+      run: |
+        grep "urn:ietf:params:acme:error:unauthorized" acmeshell.attacker.log
+      shell: bash
+
+    - name: "Check acmeshell log for unauthorized on cross-account finalize"
+      working-directory: acmeshell
+      run: |
+        grep -c "urn:ietf:params:acme:error:unauthorized" acmeshell.attacker.log | awk '$1 >= 2'
+      shell: bash
+
+    - name: "Check attacker did not receive a valid order or certificate"
+      working-directory: acmeshell
+      run: |
+        ! grep -E '"status": "valid"|/acme/cert/' acmeshell.attacker.log
+      shell: bash
+
+    - name: "Check a2c logs for ownership denial WARNING"
+      uses: ./.github/actions/logs_assert
+      with:
+        DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
+        COMPOSE_SERVICE: ${{ inputs.ACME_SERVER }}
+        PATTERN: "resource access denied: unauthorized account="
+        FLUSH: "false"
+
+    - name: "Check a2c logs for ACME problem (unauthorized ownership)"
+      uses: ./.github/actions/logs_assert
+      with:
+        DEPLOYMENT_TYPE: ${{ inputs.DEPLOYMENT_TYPE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
+        COMPOSE_SERVICE: ${{ inputs.ACME_SERVER }}
+        PATTERN: "ACME problem code=403 type=urn:ietf:params:acme:error:unauthorized"
+
+    - name: "Remove prevalidated_domainlist ownership test block"
+      if: ${{ always() && inputs.DEPLOYMENT_TYPE == 'container' }}
+      run: |
+        set -euo pipefail
+        if grep -qF '# resource-ownership CI' "${ACME_CFG}"; then
+          sudo sed -i '/# resource-ownership CI/,$d' "${ACME_CFG}"
+        fi
+        cd examples/Docker/
+        docker compose restart
+      shell: bash
+      env:
+        ACME_CFG: ${{ inputs.ACME_CFG }}
+
+    - name: "Wait for ACME directory after cfg restore"
+      if: ${{ always() && inputs.DEPLOYMENT_TYPE == 'container' }}
+      uses: ./.github/actions/wait_for_directory
+      with:
+        NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        ACME_SERVER: ${{ inputs.ACME_SERVER }}
+        CHECK_HTTPS: "false"
+        HTTP_PORT: ${{ inputs.HTTP_PORT }}

--- a/acme2certifier/acme_srv/authorization.py
+++ b/acme2certifier/acme_srv/authorization.py
@@ -29,6 +29,12 @@ from acme2certifier.acme_srv.helpers.domain_utils import (
     is_email_whitelisted,
 )
 from acme2certifier.acme_srv.helpers.global_variables import DB_ERROR_MSG
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    log_ownership_denial,
+    ownership_lookup_failed,
+    ownership_unauthorized,
+    resource_owner_matches,
+)
 from acme2certifier.acme_srv.message import Message
 from acme2certifier.acme_srv.nonce import Nonce
 
@@ -1057,50 +1063,106 @@ class Authorization(object):
             self.logger.error("Authorization error: %s", err)
             return {"code": 404, "header": {}, "data": {"error": str(err)}}
 
+    def _lookup_authorization_owner_account(self, authz_name: str) -> Optional[str]:
+        """Return the account that owns an authorization."""
+        authz = self.repository.find_authorization_by_name(
+            authz_name, ["order__account__name"]
+        )
+        if not authz:
+            return None
+        return authz.get("order__account__name")
+
+    def _check_authorization_ownership(
+        self, authz_name: str, account_name: Optional[str]
+    ) -> Tuple[int, str, str]:
+        """Verify the requester owns the authorization."""
+        try:
+            owner = self._lookup_authorization_owner_account(authz_name)
+        except AuthorizationError:
+            return ownership_lookup_failed()
+        if not resource_owner_matches(account_name, owner):
+            log_ownership_denial(self.logger, account_name, "authorization", authz_name)
+            return ownership_unauthorized()
+        return (200, None, None)
+
+    def _expire_authorizations_if_enabled(self) -> None:
+        """Expire invalid authorizations unless expiry checks are disabled."""
+        if self.config.expiry_check_disable:
+            return
+        try:
+            self.invalidate()
+        except Exception as err:
+            self.logger.warning("Failed to expire authorizations: %s", err)
+
+    def _authorization_payload_from_url(
+        self, url: str, code: int, message: str, detail: str
+    ) -> Tuple[int, str, str, Dict[str, Any]]:
+        """Load authorization details for a POST body, or return an ACME error tuple."""
+        try:
+            auth_info = self.get_authorization_details(url)
+        except AuthorizationError as err:
+            self.logger.error("Authorization error: %s", err)
+            return (
+                403,
+                "urn:ietf:params:acme:error:unauthorized",
+                "authorization error",
+                {},
+            )
+        if not auth_info:
+            return (
+                403,
+                "urn:ietf:params:acme:error:unauthorized",
+                "authorization lookup failed",
+                {},
+            )
+        return code, message, detail, {"data": auth_info}
+
+    def _process_valid_post(
+        self,
+        protected: Dict[str, Any],
+        account_name: Optional[str],
+        code: int,
+        message: str,
+        detail: str,
+    ) -> Tuple[int, str, str, Dict[str, Any]]:
+        """Handle a successfully authenticated authorization POST."""
+        if "url" not in protected:
+            return (
+                400,
+                "urn:ietf:params:acme:error:malformed",
+                "url is missing in protected",
+                {},
+            )
+        authz_name = self.business_logic.extract_authorization_name_from_url(
+            protected["url"], self.server_name
+        )
+        own_code, own_message, own_detail = self._check_authorization_ownership(
+            authz_name, account_name
+        )
+        if own_code != 200:
+            return own_code, own_message, own_detail, {}
+        return self._authorization_payload_from_url(
+            protected["url"], code, message, detail
+        )
+
     def handle_post_request(self, content: str) -> Dict[str, str]:
         """Handle POST request for authorization"""
         self.logger.debug("Authorization.handle_post_request()")
+        self._expire_authorizations_if_enabled()
 
-        # Expire invalid authorizations if not disabled
-        if not self.config.expiry_check_disable:
-            try:
-                self.invalidate()  # Call public method for backward compatibility
-            except Exception as err:
-                self.logger.warning("Failed to expire authorizations: %s", err)
-                # Continue with processing - don't fail the request
-
-        # Validate message
         code, message, detail, protected, _payload, account_name = self.message.check(
             content
         )
-
-        response_dic = {}
+        response_dic: Dict[str, Any] = {}
         if code == 200:
-            if "url" not in protected:
-                code = 400
-                message = "urn:ietf:params:acme:error:malformed"
-                detail = "url is missing in protected"
-            else:
-                try:
-                    auth_info = self.get_authorization_details(protected["url"])
-                    if auth_info:
-                        response_dic["data"] = auth_info
-                    else:
-                        code = 403
-                        message = "urn:ietf:params:acme:error:unauthorized"
-                        detail = "authorization lookup failed"
-                except AuthorizationError as err:
-                    self.logger.error("Authorization error: %s", err)
-                    code = 403
-                    message = "urn:ietf:params:acme:error:unauthorized"
-                    detail = "authorization error"
+            code, message, detail, response_dic = self._process_valid_post(
+                protected, account_name, code, message, detail
+            )
 
-        # Prepare response
         status_dic = {"code": code, "type": message, "detail": detail}
         response_dic = self.message.prepare_response(
             response_dic, status_dic, account_name=account_name
         )
-
         self.logger.debug(
             "Authorization.handle_post_request() returns: %s", json.dumps(response_dic)
         )

--- a/acme2certifier/acme_srv/certificate.py
+++ b/acme2certifier/acme_srv/certificate.py
@@ -463,17 +463,44 @@ class Certificate(object):
         )
         return result
 
-    def _check_certificate_reusability(self, csr: str) -> Tuple[None, str, str, str]:
+    def _lookup_order_account_name(self, order_name: str) -> Optional[str]:
+        """Return the account that owns an order."""
+        self.logger.debug("Certificate._lookup_order_account_name(%s)", order_name)
+        try:
+            order_dic = self.repository.order_lookup(
+                "name", order_name, ["account__name"]
+            )
+        except Exception as err_:
+            self.logger.critical(
+                f"{DB_ERROR_MSG}: failed to look up order owner: %s", err_
+            )
+            return None
+        if not order_dic:
+            return None
+        return order_dic.get("account__name")
+
+    def _check_certificate_reusability(
+        self, csr: str, account_name: Optional[str]
+    ) -> Tuple[None, str, str, str]:
         """Check if an existing certificate can be reused"""
         self.logger.debug(
-            "Certificate._check_certificate_reusability(%s)",
+            "Certificate._check_certificate_reusability(%s, account=%s)",
             self.config.cert_reusage_timeframe,
+            account_name,
         )
         try:
             result_dic = self.repository.search_certificates(
                 "csr",
                 csr,
-                ("cert", "cert_raw", "expire_uts", "issue_uts", "created_at", "id"),
+                (
+                    "cert",
+                    "cert_raw",
+                    "expire_uts",
+                    "issue_uts",
+                    "created_at",
+                    "id",
+                    "order__account__name",
+                ),
             )
         except Exception as err_:
             self.logger.critical(
@@ -513,9 +540,12 @@ class Certificate(object):
                     certificate["expire_uts"],
                 )
                 # check if there certificates within reusage timeframe
+                # Require same owning account; skip reuse when account is unknown.
                 if (
                     certificate["cert_raw"]
                     and certificate["cert"]
+                    and account_name
+                    and certificate.get("order__account__name") == account_name
                     and uts - self.config.cert_reusage_timeframe <= uts_create
                     and uts <= certificate["expire_uts"]
                 ):
@@ -775,18 +805,21 @@ class Certificate(object):
         )
         return csr_check_result
 
-    def _process_certificate_enrollment(self, csr: str) -> Tuple[str, str, str, str]:
+    def _process_certificate_enrollment(
+        self, csr: str, order_name: Optional[str] = None
+    ) -> Tuple[str, str, str, str]:
         self.logger.debug("Certificate._process_certificate_enrollment()")
 
         poll_identifier = None
         error = None
+        account_name = self._lookup_order_account_name(order_name) if order_name else None
         if self.config.cert_reusage_timeframe:
             (
                 error,
                 certificate,
                 certificate_raw,
                 poll_identifier,
-            ) = self._check_certificate_reusability(csr)
+            ) = self._check_certificate_reusability(csr, account_name)
         else:
             certificate = None
             certificate_raw = None
@@ -1000,7 +1033,7 @@ class Certificate(object):
             certificate_raw,
             poll_identifier,
             cert_reusage,
-        ) = self._process_certificate_enrollment(csr)
+        ) = self._process_certificate_enrollment(csr, order_name)
         if certificate:
             result, error = self._store_certificate_and_update_order(
                 certificate,

--- a/acme2certifier/acme_srv/certificate.py
+++ b/acme2certifier/acme_srv/certificate.py
@@ -39,6 +39,13 @@ from acme2certifier.acme_srv.helpers.global_variables import (
     ENROLLMENT_FAILED_DETAIL,
     DB_ERROR_MSG,
 )
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    ResourceOwnershipLookupError,
+    log_ownership_denial,
+    ownership_lookup_failed,
+    ownership_unauthorized,
+    resource_owner_matches,
+)
 
 
 # CertificateLogger moved from certificate_logger.py
@@ -335,6 +342,41 @@ class Certificate(object):
             result,
         )
         return result
+
+    def _lookup_certificate_owner_account(self, certificate_name: str) -> Optional[str]:
+        """Return the account that owns a certificate, or None if missing."""
+        self.logger.debug(
+            "Certificate._lookup_certificate_owner_account(%s)", certificate_name
+        )
+        try:
+            cert_dic = self.repository.certificate_lookup(
+                "name", certificate_name, ["order__account__name"]
+            )
+        except Exception as err_:
+            self.logger.critical(
+                f"{DB_ERROR_MSG}: failed to look up certificate owner: %s", err_
+            )
+            raise ResourceOwnershipLookupError(
+                f"failed to look up certificate owner for {certificate_name}"
+            ) from err_
+        if not cert_dic:
+            return None
+        return cert_dic.get("order__account__name")
+
+    def _check_certificate_ownership(
+        self, certificate_name: str, account_name: Optional[str]
+    ) -> Tuple[int, str, str]:
+        """Verify the requester owns the certificate."""
+        try:
+            owner = self._lookup_certificate_owner_account(certificate_name)
+        except ResourceOwnershipLookupError:
+            return ownership_lookup_failed()
+        if not resource_owner_matches(account_name, owner):
+            log_ownership_denial(
+                self.logger, account_name, "certificate", certificate_name
+            )
+            return ownership_unauthorized()
+        return (200, None, None)
 
     def _validate_certificate_authorization(
         self, identifier_dic: Dict[str, str], certificate: str
@@ -1634,10 +1676,73 @@ class Certificate(object):
                 "detail": "Response formatting failed",
             }
 
+    def _resolve_certificate_ownership(
+        self, certificate_name: str, account_name: Optional[str]
+    ) -> Tuple[int, str, str]:
+        """Run ownership check and map unexpected errors to a lookup failure."""
+        try:
+            return self._check_certificate_ownership(certificate_name, account_name)
+        except Exception as err:
+            self.logger.error("Error checking certificate ownership: %s", err)
+            return ownership_lookup_failed()
+
+    def _load_certificate_details_response(
+        self, url: str, code: int, message: str, detail: str
+    ) -> Tuple[int, str, str, Dict[str, str]]:
+        """Load certificate details, or return an ACME error tuple."""
+        try:
+            response_dic = self.get_certificate_details(url)
+        except Exception as err:
+            self.logger.error("Error getting certificate details: %s", err)
+            return (
+                500,
+                self.err_msg_dic["serverinternal"],
+                "Certificate retrieval failed",
+                {},
+            )
+        if response_dic["code"] in (400, 403, 500):
+            return (
+                response_dic["code"],
+                response_dic["data"],
+                response_dic.get("detail"),
+                response_dic,
+            )
+        return code, message, detail, response_dic
+
+    def _process_valid_certificate_request(
+        self,
+        protected: Dict[str, str],
+        account_name: Optional[str],
+        code: int,
+        message: str,
+        detail: str,
+    ) -> Tuple[int, str, str, Dict[str, str]]:
+        """Handle a successfully authenticated certificate POST."""
+        if "url" not in protected:
+            return (
+                400,
+                self.err_msg_dic["malformed"],
+                "url missing in protected header",
+                {},
+            )
+        certificate_name = string_sanitize(
+            self.logger,
+            protected["url"].replace(
+                f'{self.server_name}{self.path_dic["cert_path"]}', ""
+            ),
+        )
+        own_code, own_message, own_detail = self._resolve_certificate_ownership(
+            certificate_name, account_name
+        )
+        if own_code != 200:
+            return own_code, own_message, own_detail, {}
+        return self._load_certificate_details_response(
+            protected["url"], code, message, detail
+        )
+
     def process_certificate_request(self, content: str) -> Dict[str, str]:
         """Process certificate request with improved error handling and reduced complexity"""
         try:
-            # Validate input
             validation_errors = self._validate_input_parameters(content=content)
             if validation_errors:
                 self.logger.error(self.INVALID_INPUT_PARAMS_MSG, validation_errors)
@@ -1646,8 +1751,6 @@ class Certificate(object):
                 )
 
             self.logger.debug("Certificate.process_certificate_request()")
-
-            # Validate and parse message
             (
                 code,
                 message,
@@ -1657,37 +1760,20 @@ class Certificate(object):
                 account_name,
             ) = self._validate_certificate_request_message(content)
 
-            response_dic = {}
-
+            response_dic: Dict[str, str] = {}
             if code == 200:
-                if "url" in protected:
-                    try:
-                        response_dic = self.get_certificate_details(protected["url"])
-                        # Update error details if certificate retrieval failed
-                        if response_dic["code"] in (400, 403, 500):
-                            code = response_dic["code"]
-                            message = response_dic["data"]
-                            detail = response_dic.get("detail")
-                    except Exception as err:
-                        self.logger.error("Error getting certificate details: %s", err)
-                        code = 500
-                        message = self.err_msg_dic["serverinternal"]
-                        detail = "Certificate retrieval failed"
-                        response_dic = {}
-                else:
-                    code = 400
-                    message = self.err_msg_dic["malformed"]
-                    detail = "url missing in protected header"
-                    response_dic = {}
+                code, message, detail, response_dic = (
+                    self._process_valid_certificate_request(
+                        protected, account_name, code, message, detail
+                    )
+                )
 
-            # Prepare final response
             final_response = self._prepare_certificate_response(
                 response_dic, code, message, detail, account_name=account_name
             )
-
-            result_code = final_response.get("code", "no code found")
             self.logger.debug(
-                "Certificate.process_certificate_request() ended with: %s", result_code
+                "Certificate.process_certificate_request() ended with: %s",
+                final_response.get("code", "no code found"),
             )
             return final_response
 

--- a/acme2certifier/acme_srv/challenge.py
+++ b/acme2certifier/acme_srv/challenge.py
@@ -21,6 +21,13 @@ from acme2certifier.acme_srv.helper import (
     config_dns_server_list_load,
 )
 from acme2certifier.acme_srv.helpers.global_variables import DB_ERROR_MSG
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    ResourceOwnershipLookupError,
+    log_ownership_denial,
+    ownership_lookup_failed,
+    ownership_unauthorized,
+    resource_owner_matches,
+)
 from acme2certifier.acme_srv.db_handler import DBstore
 from acme2certifier.acme_srv.message import Message
 
@@ -332,6 +339,29 @@ class DatabaseChallengeRepository(ChallengeRepository):
             self.logger.critical(f"{DB_ERROR_MSG}: failed to get account JWK: %s", err)
             raise DatabaseError(f"Failed to get account JWK: {err}") from err
 
+    def get_challenge_owner_account_name(self, challenge_name: str) -> Optional[str]:
+        """Get account name for the order that owns a challenge."""
+        self.logger.debug(
+            "DatabaseChallengeRepository.get_challenge_owner_account_name(%s)",
+            challenge_name,
+        )
+        try:
+            challenge_dic = self.dbstore.challenge_lookup(
+                "name",
+                challenge_name,
+                ["authorization__order__account__name"],
+            )
+            if challenge_dic and "authorization__order__account__name" in challenge_dic:
+                return challenge_dic["authorization__order__account__name"]
+            return None
+        except Exception as err:
+            self.logger.critical(
+                f"{DB_ERROR_MSG}: failed to get challenge owner account: %s", err
+            )
+            raise DatabaseError(
+                f"Failed to get challenge owner account: {err}"
+            ) from err
+
     def get_authorization_account_name(self, authorization_name: str) -> Optional[str]:
         """Get account name for an authorization."""
         self.logger.debug(
@@ -425,6 +455,19 @@ class Challenge:
         self.logger.debug("Challenge._create_error_response() called")
         status_dic = {"code": code, "type": message, "detail": detail}
         return self.message.prepare_response({}, status_dic, account_name=account_name)
+
+    def _check_challenge_ownership(
+        self, challenge_name: str, account_name: Optional[str]
+    ) -> Tuple[int, str, str]:
+        """Verify the requester owns the challenge."""
+        try:
+            owner = self.repository.get_challenge_owner_account_name(challenge_name)
+        except DatabaseError as err:
+            raise ResourceOwnershipLookupError(str(err)) from err
+        if not resource_owner_matches(account_name, owner):
+            log_ownership_denial(self.logger, account_name, "challenge", challenge_name)
+            return ownership_unauthorized()
+        return (200, None, None)
 
     def _create_success_response(self, response_dic: Dict[str, Any]) -> Dict[str, str]:
         """Create standardized success response."""
@@ -1386,6 +1429,20 @@ class Challenge:
                     400,
                     self.err_msg_dic["malformed"],
                     f"invalid challenge: {challenge_name}",
+                    account_name=account_name,
+                )
+
+            try:
+                own_code, own_message, own_detail = self._check_challenge_ownership(
+                    challenge_name, account_name
+                )
+            except ResourceOwnershipLookupError:
+                own_code, own_message, own_detail = ownership_lookup_failed()
+            if own_code != 200:
+                return self._create_error_response(
+                    own_code,
+                    own_message,
+                    own_detail,
                     account_name=account_name,
                 )
 

--- a/acme2certifier/acme_srv/helpers/resource_ownership.py
+++ b/acme2certifier/acme_srv/helpers/resource_ownership.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Account-to-resource ownership checks for authenticated ACME requests."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Tuple
+
+UNAUTHORIZED_TYPE = "urn:ietf:params:acme:error:unauthorized"
+SERVER_INTERNAL_TYPE = "urn:ietf:params:acme:error:serverInternal"
+OWNERSHIP_DENIED_DETAIL = "Unauthorized"
+
+
+class ResourceOwnershipLookupError(Exception):
+    """Raised when the owning account cannot be loaded from the database."""
+
+
+def resource_owner_matches(
+    requester_account: Optional[str], resource_owner: Optional[str]
+) -> bool:
+    """Return True only when both accounts are non-empty and equal."""
+    if not requester_account or not resource_owner:
+        return False
+    return requester_account == resource_owner
+
+
+def ownership_unauthorized() -> Tuple[int, str, str]:
+    """Standard ACME response tuple for an ownership violation."""
+    return (403, UNAUTHORIZED_TYPE, OWNERSHIP_DENIED_DETAIL)
+
+
+def ownership_lookup_failed() -> Tuple[int, str, str]:
+    """Standard ACME response tuple for an owner lookup database failure."""
+    return (500, SERVER_INTERNAL_TYPE, "Database error")
+
+
+def log_ownership_denial(
+    logger: logging.Logger,
+    requester_account: Optional[str],
+    resource_type: str,
+    resource_name: str,
+) -> None:
+    """Log a cross-account or missing-owner access attempt."""
+    logger.warning(
+        "resource access denied: unauthorized account=%s resource=%s name=%s",
+        requester_account,
+        resource_type,
+        resource_name,
+    )

--- a/acme2certifier/acme_srv/order.py
+++ b/acme2certifier/acme_srv/order.py
@@ -32,6 +32,11 @@ from acme2certifier.acme_srv.helpers.global_variables import (
     ENROLLMENT_FAILED_DETAIL,
     DB_ERROR_MSG,
 )
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    log_ownership_denial,
+    ownership_unauthorized,
+    resource_owner_matches,
+)
 from acme2certifier.acme_srv.message import Message
 
 
@@ -1192,7 +1197,7 @@ class Order(object):
         return result
 
     def _get_order_account_name(self, order_name: str) -> Optional[str]:
-        """Lookup account name for an order (needed for EAB profile at finalize)."""
+        """Return the account that owns an order, or None if missing/unavailable."""
         self.logger.debug("Order._get_order_account_name(%s)", order_name)
         try:
             order_dic = self.repository.order_lookup(
@@ -1206,6 +1211,16 @@ class Order(object):
         if not order_dic:
             return None
         return order_dic.get("account__name") or order_dic.get("account")
+
+    def _check_order_ownership(
+        self, order_name: str, account_name: Optional[str]
+    ) -> Tuple[int, str, str]:
+        """Verify the requester owns the order."""
+        owner = self._get_order_account_name(order_name)
+        if not resource_owner_matches(account_name, owner):
+            log_ownership_denial(self.logger, account_name, "order", order_name)
+            return ownership_unauthorized()
+        return (200, None, None)
 
     def _header_info_lookup(self, header: Optional[Dict[str, Any]]) -> str:
         """lookup header information and serialize them in a string"""
@@ -1656,26 +1671,35 @@ class Order(object):
         return response_dic
 
     def _parse_order_message(
-        self, protected: Dict[str, str], payload: Dict[str, str], header: str = None
+        self,
+        protected: Dict[str, str],
+        payload: Dict[str, str],
+        header: str = None,
+        account_name: Optional[str] = None,
     ) -> Tuple[int, str, str, str, str]:
         """parse new order message"""
         self.logger.debug("Order._parse_order_message()")
 
         order_name = certificate_name = None
+        code = message = detail = None
 
         if "url" in protected:
             order_name = self._name_get(protected["url"])
             if order_name:
                 order_dic = self.get_order_details(order_name)
                 if order_dic:
-                    (
-                        code,
-                        message,
-                        detail,
-                        certificate_name,
-                    ) = self._process_order_request(
-                        order_name, protected, payload, header
+                    code, message, detail = self._check_order_ownership(
+                        order_name, account_name
                     )
+                    if code == 200:
+                        (
+                            code,
+                            message,
+                            detail,
+                            certificate_name,
+                        ) = self._process_order_request(
+                            order_name, protected, payload, header
+                        )
                 else:
                     self.logger.warning(
                         "Order request failed: order not found order=%s",
@@ -1720,7 +1744,9 @@ class Order(object):
                 detail,
                 certificate_name,
                 order_name,
-            ) = self._parse_order_message(protected, payload, header)
+            ) = self._parse_order_message(
+                protected, payload, header, account_name=account_name
+            )
 
             if code == 200:
                 # create response

--- a/acme2certifier/acme_srv/renewalinfo.py
+++ b/acme2certifier/acme_srv/renewalinfo.py
@@ -20,6 +20,12 @@ from acme2certifier.acme_srv.helper import (
     b64_decode,
 )
 from acme2certifier.acme_srv.helpers.global_variables import DB_ERROR_MSG
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    ResourceOwnershipLookupError,
+    log_ownership_denial,
+    ownership_unauthorized,
+    resource_owner_matches,
+)
 
 
 @dataclass
@@ -56,6 +62,7 @@ class RenewalinfoRepository:
                     "expire_uts",
                     "issue_uts",
                     "created_at",
+                    "order__account__name",
                 ),
             )
         except Exception as err_:
@@ -63,7 +70,9 @@ class RenewalinfoRepository:
                 f"{DB_ERROR_MSG}: failed to look up certificate for renewal info (draft01): %s",
                 err_,
             )
-            return None
+            raise ResourceOwnershipLookupError(
+                f"failed to look up certificate for certid {certid_hex}"
+            ) from err_
 
     def get_certificates_by_serial(self, serial):
         """Retrieve certificates by serial from database."""
@@ -401,12 +410,26 @@ class Renewalinfo(object):
             _detail,
             _protected,
             payload,
-            _account_name,
+            account_name,
         ) = self.message.check(content)
         response_dic = {}
         if code == 200 and "certid" in payload and "replaced" in payload:
-            cert_dic = self._lookup_certificate_by_renewalinfo(payload["certid"])
+            try:
+                cert_dic = self._lookup_certificate_by_renewalinfo(payload["certid"])
+            except ResourceOwnershipLookupError:
+                response_dic["code"] = 500
+                return response_dic
             if cert_dic and payload["replaced"]:
+                owner = cert_dic.get("order__account__name")
+                if not resource_owner_matches(account_name, owner):
+                    log_ownership_denial(
+                        self.logger,
+                        account_name,
+                        "certificate",
+                        cert_dic.get("name", payload["certid"]),
+                    )
+                    response_dic["code"] = ownership_unauthorized()[0]
+                    return response_dic
                 cert_dic["replaced"] = True
                 cert_id = self.repository.add_certificate(cert_dic)
                 response_dic["code"] = 200 if cert_id else 400

--- a/acme2certifier/acme_srv/renewalinfo.py
+++ b/acme2certifier/acme_srv/renewalinfo.py
@@ -2,7 +2,7 @@
 """Renewalinfo class: ACME renewal info handler with separated config and repository helpers."""
 
 from __future__ import print_function
-from typing import Dict
+from typing import Dict, Optional, Tuple
 from dataclasses import dataclass
 from acme2certifier.acme_srv.db_handler import DBstore
 from acme2certifier.acme_srv.message import Message
@@ -23,6 +23,7 @@ from acme2certifier.acme_srv.helpers.global_variables import DB_ERROR_MSG
 from acme2certifier.acme_srv.helpers.resource_ownership import (
     ResourceOwnershipLookupError,
     log_ownership_denial,
+    ownership_lookup_failed,
     ownership_unauthorized,
     resource_owner_matches,
 )
@@ -93,6 +94,7 @@ class RenewalinfoRepository:
                     "issue_uts",
                     "aki",
                     "created_at",
+                    "order__account__name",
                 ],
             )
         except Exception as err_:
@@ -106,6 +108,13 @@ class RenewalinfoRepository:
         """Add or update certificate in database."""
         self.logger.debug("RenewalinfoRepository.add_certificate()")
         return self.dbstore.certificate_add(data_dic)
+
+    def mark_certificate_replaced(self, cert_name: str) -> int:
+        """Set replaced=True for an existing certificate without rewriting other columns."""
+        self.logger.debug(
+            "RenewalinfoRepository.mark_certificate_replaced(%s)", cert_name
+        )
+        return self.dbstore.certificate_replaced_update(cert_name)
 
     def get_housekeeping_param(self, name):
         """Retrieve housekeeping parameter by name from database."""
@@ -401,40 +410,65 @@ class Renewalinfo(object):
             response_dic["data"] = self.err_msg_dic["malformed"]
         return response_dic
 
+    def _problem_response(
+        self,
+        status: Tuple[int, str, str],
+        account_name: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Build an ACME problem document the same way order/certificate handlers do."""
+        code, message, detail = status
+        return self.message.prepare_response(
+            {},
+            {"code": code, "type": message, "detail": detail},
+            account_name=account_name,
+        )
+
     def update(self, content: str) -> Dict[str, str]:
         """Update renewal info (backwards compatible public method)"""
         self.logger.debug("Renewalinfo.update()")
         (
             code,
-            _message,
-            _detail,
+            message,
+            detail,
             _protected,
             payload,
             account_name,
         ) = self.message.check(content)
-        response_dic = {}
-        if code == 200 and "certid" in payload and "replaced" in payload:
-            try:
-                cert_dic = self._lookup_certificate_by_renewalinfo(payload["certid"])
-            except ResourceOwnershipLookupError:
-                response_dic["code"] = 500
-                return response_dic
-            if cert_dic and payload["replaced"]:
-                owner = cert_dic.get("order__account__name")
-                if not resource_owner_matches(account_name, owner):
-                    log_ownership_denial(
-                        self.logger,
-                        account_name,
-                        "certificate",
-                        cert_dic.get("name", payload["certid"]),
-                    )
-                    response_dic["code"] = ownership_unauthorized()[0]
-                    return response_dic
-                cert_dic["replaced"] = True
-                cert_id = self.repository.add_certificate(cert_dic)
-                response_dic["code"] = 200 if cert_id else 400
-            else:
-                response_dic["code"] = 400
-        else:
-            response_dic["code"] = 400
-        return response_dic
+        if code != 200:
+            return self._problem_response((code, message, detail), account_name)
+        if "certid" not in payload or "replaced" not in payload:
+            return self._problem_response(
+                (400, self.err_msg_dic["malformed"], "certid or replaced missing"),
+                account_name,
+            )
+        try:
+            cert_dic = self._lookup_certificate_by_renewalinfo(payload["certid"])
+        except ResourceOwnershipLookupError:
+            return self._problem_response(ownership_lookup_failed(), account_name)
+        if not cert_dic or not payload["replaced"]:
+            return self._problem_response(
+                (400, self.err_msg_dic["malformed"], "certificate not found"),
+                account_name,
+            )
+        owner = cert_dic.get("order__account__name")
+        if not resource_owner_matches(account_name, owner):
+            log_ownership_denial(
+                self.logger,
+                account_name,
+                "certificate",
+                cert_dic.get("name", payload["certid"]),
+            )
+            return self._problem_response(ownership_unauthorized(), account_name)
+        cert_name = cert_dic.get("name")
+        if not cert_name:
+            return self._problem_response(
+                (400, self.err_msg_dic["malformed"], "certificate name missing"),
+                account_name,
+            )
+        cert_id = self.repository.mark_certificate_replaced(cert_name)
+        if not cert_id:
+            return self._problem_response(
+                (400, self.err_msg_dic["malformed"], "certificate update failed"),
+                account_name,
+            )
+        return {"code": 200}

--- a/acme2certifier/dbhandlers/django_handler.py
+++ b/acme2certifier/dbhandlers/django_handler.py
@@ -356,6 +356,20 @@ class DBstore(object):
         self.logger.debug("DBStore.certificate_add() ended with :%s", obj.id)
         return obj.id
 
+    def certificate_replaced_update(self, cert_name: str) -> int:
+        """Set replaced=True for an existing certificate; leave other columns unchanged."""
+        self.logger.debug("DBStore.certificate_replaced_update(%s)", cert_name)
+        cert = Certificate.objects.filter(name=cert_name).first()
+        if not cert:
+            self.logger.debug("DBStore.certificate_replaced_update() ended with: 0")
+            return 0
+        cert.replaced = True
+        cert.save(update_fields=["replaced"])
+        self.logger.debug(
+            "DBStore.certificate_replaced_update() ended with: %s", cert.id
+        )
+        return cert.id
+
     def certificate_account_check(self, account_name: str, certificate: str) -> str:
         """check issuer against certificate"""
         self.logger.debug("DBStore.certificate_account_check(%s)", account_name)

--- a/acme2certifier/dbhandlers/wsgi_handler.py
+++ b/acme2certifier/dbhandlers/wsgi_handler.py
@@ -1278,6 +1278,23 @@ class DBstore(object):
         self.logger.debug("DBStore.certificate_add() ended with: %s", rid)
         return rid
 
+    def certificate_replaced_update(self, cert_name: str) -> int:
+        """Set replaced=True for an existing certificate; leave other columns unchanged."""
+        self.logger.debug("DBStore.certificate_replaced_update(%s)", cert_name)
+        exists = self._certificate_search("name", cert_name)
+        if not exists:
+            self.logger.debug("DBStore.certificate_replaced_update() ended with: 0")
+            return 0
+        self._db_open()
+        self.cursor.execute(
+            """UPDATE Certificate SET replaced = 1 WHERE name = :name""",
+            {"name": cert_name},
+        )
+        self._db_close()
+        rid = dict_from_row(exists)["id"]
+        self.logger.debug("DBStore.certificate_replaced_update() ended with: %s", rid)
+        return rid
+
     def certificate_delete(self, mkey: str, string: str):
         """delete certificate from table"""
         self.logger.debug("DBStore.certificate_delete(%s:%s)", mkey, string)

--- a/acme2certifier/django_app/views.py
+++ b/acme2certifier/django_app/views.py
@@ -480,6 +480,12 @@ def renewalinfo(request):
                 # generate additional header elements
                 for element in response_dic["header"]:
                     response[element] = response_dic["header"][element]
+            elif response_dic.get("code", 200) >= 400 and response_dic.get("data"):
+                response = JsonResponse(
+                    status=response_dic["code"], data=response_dic["data"]
+                )
+                for element in response_dic.get("header", {}):
+                    response[element] = response_dic["header"][element]
             else:
                 response = HttpResponse(status=response_dic["code"])
 

--- a/acme2certifier/share/acme2certifier_wsgi.py
+++ b/acme2certifier/share/acme2certifier_wsgi.py
@@ -450,8 +450,8 @@ def renewalinfo(environ, start_response):
         if environ["REQUEST_METHOD"] == "POST":
             request_body = get_request_body(environ)
             response_dic = renewalinfo_.update(request_body)
-            # create header
-            headers = create_header(response_dic, False)
+            error_body = response_dic.get("code", 200) >= 400 and "data" in response_dic
+            headers = create_header(response_dic, error_body)
             start_response(
                 f'{response_dic["code"]} {HTTP_CODE_DIC[response_dic["code"]]}', headers
             )
@@ -460,6 +460,8 @@ def renewalinfo(environ, start_response):
             log_response(
                 LOGGER, environ["REMOTE_ADDR"], environ["PATH_INFO"], response_dic
             )
+            if error_body:
+                return [json.dumps(response_dic["data"], indent=2).encode("utf-8")]
             return []
 
         elif environ["REQUEST_METHOD"] == "GET":

--- a/test/test_authorization.py
+++ b/test/test_authorization.py
@@ -1847,24 +1847,29 @@ class TestAuthorization(unittest.TestCase):
         ):
             self.authorization.message = self.mock_message
             with patch.object(
-                self.authorization, "get_authorization_details", return_value={}
-            ) as mock_get_details:
+                self.authorization,
+                "_lookup_authorization_owner_account",
+                return_value="account",
+            ):
                 with patch.object(
-                    self.mock_message,
-                    "prepare_response",
-                    return_value={"error": "unauthorized"},
-                ) as mock_prepare_response:
-                    result = self.authorization.handle_post_request(
-                        '{"test": "content"}'
-                    )
-                    mock_prepare_response.assert_called_once()
-                    status_dic = mock_prepare_response.call_args[0][1]
-                    expected_status_dic = {
-                        "code": 403,
-                        "type": "urn:ietf:params:acme:error:unauthorized",
-                        "detail": "authorization lookup failed",
-                    }
-                    self.assertEqual(status_dic, expected_status_dic)
+                    self.authorization, "get_authorization_details", return_value={}
+                ) as mock_get_details:
+                    with patch.object(
+                        self.mock_message,
+                        "prepare_response",
+                        return_value={"error": "unauthorized"},
+                    ) as mock_prepare_response:
+                        result = self.authorization.handle_post_request(
+                            '{"test": "content"}'
+                        )
+                        mock_prepare_response.assert_called_once()
+                        status_dic = mock_prepare_response.call_args[0][1]
+                        expected_status_dic = {
+                            "code": 403,
+                            "type": "urn:ietf:params:acme:error:unauthorized",
+                            "detail": "authorization lookup failed",
+                        }
+                        self.assertEqual(status_dic, expected_status_dic)
         self.assertIsInstance(result, dict)
         self.assertEqual(result.get("error"), "unauthorized")
 
@@ -1886,25 +1891,30 @@ class TestAuthorization(unittest.TestCase):
             self.authorization.message = self.mock_message
             with patch.object(
                 self.authorization,
-                "get_authorization_details",
-                side_effect=AuthorizationError("Auth error"),
-            ) as mock_get_details:
+                "_lookup_authorization_owner_account",
+                return_value="account",
+            ):
                 with patch.object(
-                    self.mock_message,
-                    "prepare_response",
-                    return_value={"error": "unauthorized"},
-                ) as mock_prepare_response:
-                    result = self.authorization.handle_post_request(
-                        '{"test": "content"}'
-                    )
-                    mock_prepare_response.assert_called_once()
-                    status_dic = mock_prepare_response.call_args[0][1]
-                    expected_status_dic = {
-                        "code": 403,
-                        "type": "urn:ietf:params:acme:error:unauthorized",
-                        "detail": "authorization error",
-                    }
-                    self.assertEqual(status_dic, expected_status_dic)
+                    self.authorization,
+                    "get_authorization_details",
+                    side_effect=AuthorizationError("Auth error"),
+                ) as mock_get_details:
+                    with patch.object(
+                        self.mock_message,
+                        "prepare_response",
+                        return_value={"error": "unauthorized"},
+                    ) as mock_prepare_response:
+                        result = self.authorization.handle_post_request(
+                            '{"test": "content"}'
+                        )
+                        mock_prepare_response.assert_called_once()
+                        status_dic = mock_prepare_response.call_args[0][1]
+                        expected_status_dic = {
+                            "code": 403,
+                            "type": "urn:ietf:params:acme:error:unauthorized",
+                            "detail": "authorization error",
+                        }
+                        self.assertEqual(status_dic, expected_status_dic)
         self.assertIsInstance(result, dict)
         self.assertEqual(result.get("error"), "unauthorized")
 
@@ -1926,25 +1936,30 @@ class TestAuthorization(unittest.TestCase):
             self.authorization.message = self.mock_message
             with patch.object(
                 self.authorization,
-                "get_authorization_details",
-                return_value={"foo": "bar"},
-            ) as mock_get_details:
+                "_lookup_authorization_owner_account",
+                return_value="account",
+            ):
                 with patch.object(
-                    self.mock_message,
-                    "prepare_response",
-                    return_value={"error": "unauthorized"},
-                ) as mock_prepare_response:
-                    result = self.authorization.handle_post_request(
-                        '{"test": "content"}'
-                    )
-                    mock_prepare_response.assert_called_once()
-                    status_dic = mock_prepare_response.call_args[0][1]
-                    expected_status_dic = {
-                        "code": 200,
-                        "type": "message",
-                        "detail": "detail",
-                    }
-                    self.assertEqual(status_dic, expected_status_dic)
+                    self.authorization,
+                    "get_authorization_details",
+                    return_value={"foo": "bar"},
+                ) as mock_get_details:
+                    with patch.object(
+                        self.mock_message,
+                        "prepare_response",
+                        return_value={"error": "unauthorized"},
+                    ) as mock_prepare_response:
+                        result = self.authorization.handle_post_request(
+                            '{"test": "content"}'
+                        )
+                        mock_prepare_response.assert_called_once()
+                        status_dic = mock_prepare_response.call_args[0][1]
+                        expected_status_dic = {
+                            "code": 200,
+                            "type": "message",
+                            "detail": "detail",
+                        }
+                        self.assertEqual(status_dic, expected_status_dic)
         self.assertIsInstance(result, dict)
         self.assertEqual(result.get("error"), "unauthorized")
 
@@ -2685,6 +2700,32 @@ class TestAuthorization(unittest.TestCase):
         )
         self.mock_logger.debug.assert_any_call(
             "Authorization._apply_eab_and_domain_whitelist() - apply prevalidated_emaillist from eab profile."
+        )
+
+    def test_070_lookup_authorization_owner_account_missing(self):
+        """_lookup_authorization_owner_account returns None when authz is missing"""
+        self.authorization.repository = Mock()
+        self.authorization.repository.find_authorization_by_name.return_value = None
+        self.assertIsNone(
+            self.authorization._lookup_authorization_owner_account("missing")
+        )
+        self.authorization.repository.find_authorization_by_name.assert_called_once_with(
+            "missing", ["order__account__name"]
+        )
+
+    def test_071_check_authorization_ownership_db_error(self):
+        """_check_authorization_ownership maps AuthorizationError to lookup failure"""
+        from acme2certifier.acme_srv.helpers.resource_ownership import (
+            ownership_lookup_failed,
+        )
+
+        self.authorization.repository = Mock()
+        self.authorization.repository.find_authorization_by_name.side_effect = (
+            AuthorizationError("db fail")
+        )
+        self.assertEqual(
+            self.authorization._check_authorization_ownership("authz", "acc"),
+            ownership_lookup_failed(),
         )
 
 

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -890,17 +890,18 @@ class TestCertificate(unittest.TestCase):
                 "cert_raw": "r",
                 "created_at": 1,
                 "id": 1,
+                "order__account__name": "acct1",
             }
         ]
         with patch("acme2certifier.acme_srv.certificate.uts_now", return_value=2):
-            result = self.cert._check_certificate_reusability("csr")
+            result = self.cert._check_certificate_reusability("csr", "acct1")
             self.assertIsInstance(result, tuple)
 
     def test_051_check_certificate_reusability_db_error(self):
         self.cert.repository.search_certificates.side_effect = Exception("fail")
         with patch("acme2certifier.acme_srv.certificate.uts_now", return_value=2):
             with self.assertLogs("test_a2c", level="CRITICAL") as lcm:
-                result = self.cert._check_certificate_reusability("csr")
+                result = self.cert._check_certificate_reusability("csr", None)
                 self.assertIsInstance(result, tuple)
             self.assertIn(
                 "CRITICAL:test_a2c:Database error: failed to search for certificate reusage: fail",
@@ -910,7 +911,7 @@ class TestCertificate(unittest.TestCase):
     def test_052_check_certificate_reusability_none_found(self):
         self.cert.repository.search_certificates.return_value = None
         with patch("acme2certifier.acme_srv.certificate.uts_now", return_value=2):
-            result = self.cert._check_certificate_reusability("csr")
+            result = self.cert._check_certificate_reusability("csr", None)
             self.assertIsInstance(result, tuple)
 
     def test_053_handle_enrollment_error(self):
@@ -1255,7 +1256,7 @@ class TestCertificate(unittest.TestCase):
             "Reusability error"
         )
         with self.assertLogs(self.cert.logger, level="CRITICAL") as log:
-            result = self.cert._check_certificate_reusability("csr")
+            result = self.cert._check_certificate_reusability("csr", None)
             self.assertEqual(result, (None, None, None, None))
         self.assertIn(
             "CRITICAL:test_a2c:Database error: failed to search for certificate reusage: Reusability error",
@@ -2957,14 +2958,38 @@ class TestCertificate(unittest.TestCase):
             "cert_raw": "raw_value",
             "created_at": 1,
             "id": 42,
+            "order__account__name": "acct1",
         }
         self.cert.repository.search_certificates.return_value = [cert_data]
         self.cert.config.cert_reusage_timeframe = 2  # Ensure reuse block is entered
         with patch("acme2certifier.acme_srv.certificate.uts_now", return_value=2):
-            _, cert, cert_raw, message = self.cert._check_certificate_reusability("csr")
+            _, cert, cert_raw, message = self.cert._check_certificate_reusability(
+                "csr", "acct1"
+            )
             self.assertEqual(cert, "cert_value")
             self.assertEqual(cert_raw, "raw_value")
             self.assertIn("reused certificate from id: 42", message)
+
+    def test_186b_check_certificate_reusability_account_scoped(self):
+        """Reuse must be scoped to the requesting account."""
+        cert_data = {
+            "expire_uts": 9999999999,
+            "issue_uts": 1,
+            "cert": "cert_value",
+            "cert_raw": "raw_value",
+            "created_at": 1,
+            "id": 43,
+            "order__account__name": "other-account",
+        }
+        self.cert.repository.search_certificates.return_value = [cert_data]
+        self.cert.config.cert_reusage_timeframe = 2
+        with patch("acme2certifier.acme_srv.certificate.uts_now", return_value=2):
+            _, cert, cert_raw, message = self.cert._check_certificate_reusability(
+                "csr", "requesting-account"
+            )
+        self.assertIsNone(cert)
+        self.assertIsNone(cert_raw)
+        self.assertIsNone(message)
 
     def test_187_process_enrollment_and_store_certificate_log_exception(self):
         """Test _process_enrollment_and_store_certificate covers log_certificate_issuance exception branch (lines 930-933)."""

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -3285,9 +3285,7 @@ class TestCertificate(unittest.TestCase):
         self.cert.repository.certificate_lookup.return_value = {
             "order__account__name": "owner"
         }
-        self.assertEqual(
-            self.cert._lookup_certificate_owner_account("cert1"), "owner"
-        )
+        self.assertEqual(self.cert._lookup_certificate_owner_account("cert1"), "owner")
         self.cert.repository.certificate_lookup.assert_called_once_with(
             "name", "cert1", ["order__account__name"]
         )

--- a/test/test_certificate.py
+++ b/test/test_certificate.py
@@ -1755,7 +1755,10 @@ class TestCertificate(unittest.TestCase):
             patch.object(
                 self.cert,
                 "_validate_certificate_request_message",
-                return_value=(200, "ok", "", {"url": "http://test.com"}, {}, ""),
+                return_value=(200, "ok", "", {"url": "http://test.com"}, {}, "acc"),
+            ),
+            patch.object(
+                self.cert, "_lookup_certificate_owner_account", return_value="acc"
             ),
             patch.object(
                 self.cert,
@@ -1772,7 +1775,7 @@ class TestCertificate(unittest.TestCase):
                 400,
                 "data",
                 "error",
-                account_name="",
+                account_name="acc",
             )
 
     def test_123_process_certificate_request_missing_url(self):
@@ -1798,7 +1801,10 @@ class TestCertificate(unittest.TestCase):
             patch.object(
                 self.cert,
                 "_validate_certificate_request_message",
-                return_value=(200, "ok", "", {"url": "http://test.com"}, {}, ""),
+                return_value=(200, "ok", "", {"url": "http://test.com"}, {}, "acc"),
+            ),
+            patch.object(
+                self.cert, "_lookup_certificate_owner_account", return_value="acc"
             ),
             patch.object(
                 self.cert,
@@ -3272,6 +3278,76 @@ class TestCertificate(unittest.TestCase):
         self.assertIn(
             "WARNING:test_a2c:Certificate poll failed: ca timeout certificate=cert order=order rejected=False",
             log.output,
+        )
+
+    def test_201_lookup_certificate_owner_account_success(self):
+        """_lookup_certificate_owner_account returns order__account__name"""
+        self.cert.repository.certificate_lookup.return_value = {
+            "order__account__name": "owner"
+        }
+        self.assertEqual(
+            self.cert._lookup_certificate_owner_account("cert1"), "owner"
+        )
+        self.cert.repository.certificate_lookup.assert_called_once_with(
+            "name", "cert1", ["order__account__name"]
+        )
+
+    def test_202_lookup_certificate_owner_account_missing(self):
+        """_lookup_certificate_owner_account returns None when cert is missing"""
+        self.cert.repository.certificate_lookup.return_value = None
+        self.assertIsNone(self.cert._lookup_certificate_owner_account("cert1"))
+
+    def test_203_lookup_certificate_owner_account_db_error(self):
+        """_lookup_certificate_owner_account logs critical and raises on DB error"""
+        from acme2certifier.acme_srv.helpers.resource_ownership import (
+            ResourceOwnershipLookupError,
+        )
+
+        self.cert.repository.certificate_lookup.side_effect = Exception("fail")
+        with self.assertLogs("test_a2c", level="CRITICAL") as lcm:
+            with self.assertRaises(ResourceOwnershipLookupError):
+                self.cert._lookup_certificate_owner_account("cert1")
+        self.assertIn(
+            "CRITICAL:test_a2c:Database error: failed to look up certificate owner: fail",
+            lcm.output,
+        )
+
+    def test_204_check_certificate_ownership_lookup_error(self):
+        """_check_certificate_ownership maps lookup errors to 500"""
+        from acme2certifier.acme_srv.helpers.resource_ownership import (
+            ResourceOwnershipLookupError,
+            ownership_lookup_failed,
+        )
+
+        with patch.object(
+            self.cert,
+            "_lookup_certificate_owner_account",
+            side_effect=ResourceOwnershipLookupError("db"),
+        ):
+            self.assertEqual(
+                self.cert._check_certificate_ownership("cert1", "acc"),
+                ownership_lookup_failed(),
+            )
+
+    def test_205_resolve_certificate_ownership_unexpected_error(self):
+        """_resolve_certificate_ownership maps unexpected errors to lookup failure"""
+        from acme2certifier.acme_srv.helpers.resource_ownership import (
+            ownership_lookup_failed,
+        )
+
+        with patch.object(
+            self.cert,
+            "_check_certificate_ownership",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertLogs("test_a2c", level="ERROR") as lcm:
+                self.assertEqual(
+                    self.cert._resolve_certificate_ownership("cert1", "acc"),
+                    ownership_lookup_failed(),
+                )
+        self.assertIn(
+            "ERROR:test_a2c:Error checking certificate ownership: boom",
+            lcm.output,
         )
 
 

--- a/test/test_challenge.py
+++ b/test/test_challenge.py
@@ -286,6 +286,31 @@ class TestDatabaseChallengeRepository(unittest.TestCase):
             )
         )
 
+    def test_018_get_challenge_owner_account_name_success(self):
+        self.dbstore.challenge_lookup.return_value = {
+            "authorization__order__account__name": "owner"
+        }
+        self.assertEqual(self.repo.get_challenge_owner_account_name("c1"), "owner")
+        self.dbstore.challenge_lookup.assert_called_once_with(
+            "name",
+            "c1",
+            ["authorization__order__account__name"],
+        )
+
+    def test_019_get_challenge_owner_account_name_none(self):
+        self.dbstore.challenge_lookup.return_value = {}
+        self.assertIsNone(self.repo.get_challenge_owner_account_name("c1"))
+
+    def test_020_get_challenge_owner_account_name_db_error(self):
+        self.dbstore.challenge_lookup.side_effect = Exception("db fail")
+        with self.assertLogs("test_a2c", level="CRITICAL") as lcm:
+            with self.assertRaises(self.DatabaseError):
+                self.repo.get_challenge_owner_account_name("c1")
+        self.assertIn(
+            "CRITICAL:test_a2c:Database error: failed to get challenge owner account: db fail",
+            lcm.output,
+        )
+
 
 class TestChallenge(unittest.TestCase):
     def setUp(self):
@@ -984,6 +1009,7 @@ class TestChallenge(unittest.TestCase):
                 "c1", "dns-01", "tok", "pending", "authz", "dns", "val", "url"
             )
         )
+        self.challenge.repository.get_challenge_owner_account_name.return_value = "acc"
         self.challenge._handle_challenge_validation_request = Mock(
             return_value={"status": "ok"}
         )
@@ -3325,6 +3351,52 @@ class TestChallenge(unittest.TestCase):
         validation_result = Mock(error_message="", details={"url": "http://ex/"})
         reason = self.challenge._format_challenge_validation_reason(validation_result)
         self.assertEqual(reason, "url=http://ex/")
+
+    def test_144_check_challenge_ownership_db_error(self):
+        """_check_challenge_ownership wraps DatabaseError as ownership lookup error"""
+        from acme2certifier.acme_srv.challenge_error_handling import DatabaseError
+        from acme2certifier.acme_srv.helpers.resource_ownership import (
+            ResourceOwnershipLookupError,
+        )
+
+        self.challenge.repository.get_challenge_owner_account_name.side_effect = (
+            DatabaseError("db fail")
+        )
+        with self.assertRaises(ResourceOwnershipLookupError):
+            self.challenge._check_challenge_ownership("c1", "acc")
+
+    def test_145_process_challenge_request_ownership_lookup_failed(self):
+        """process_challenge_request returns 500 when ownership lookup fails"""
+        from acme2certifier.acme_srv.helpers.resource_ownership import (
+            ResourceOwnershipLookupError,
+        )
+
+        self.challenge._ensure_components_initialized = Mock()
+        self.challenge.message.check.return_value = (
+            200,
+            None,
+            None,
+            {"url": "u"},
+            {},
+            "acc",
+        )
+        self.challenge._extract_challenge_name_from_url = Mock(return_value="c1")
+        self.challenge.repository.get_challenge_by_name.return_value = (
+            self.ChallengeInfo(
+                "c1", "dns-01", "tok", "pending", "authz", "dns", "val", "url"
+            )
+        )
+        self.challenge._check_challenge_ownership = Mock(
+            side_effect=ResourceOwnershipLookupError("db")
+        )
+        self.challenge._create_error_response = Mock(
+            return_value={"code": 500, "type": "serverInternal"}
+        )
+        result = self.challenge.process_challenge_request("content")
+        self.assertEqual(result["code"], 500)
+        self.challenge._create_error_response.assert_called_once()
+        args = self.challenge._create_error_response.call_args
+        self.assertEqual(args[0][0], 500)
 
 
 if __name__ == "__main__":

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -31,35 +31,35 @@ from acme2certifier.acme_srv.renewalinfo import Renewalinfo
 
 
 class TestResourceOwnershipHelper:
-    def test_resource_owner_matches_equal_accounts(self) -> None:
+    def test_001_owner_matches_equal_accounts(self) -> None:
         assert resource_owner_matches("acct-a", "acct-a") is True
 
-    def test_resource_owner_matches_different_accounts(self) -> None:
+    def test_002_owner_matches_different_accounts(self) -> None:
         assert resource_owner_matches("acct-a", "acct-b") is False
 
-    def test_resource_owner_matches_missing_requester(self) -> None:
+    def test_003_owner_matches_missing_requester(self) -> None:
         assert resource_owner_matches(None, "acct-a") is False
         assert resource_owner_matches("", "acct-a") is False
 
-    def test_resource_owner_matches_missing_owner(self) -> None:
+    def test_004_owner_matches_missing_owner(self) -> None:
         assert resource_owner_matches("acct-a", None) is False
         assert resource_owner_matches("acct-a", "") is False
 
-    def test_ownership_unauthorized_tuple(self) -> None:
+    def test_005_unauthorized_tuple(self) -> None:
         assert ownership_unauthorized() == (
             403,
             UNAUTHORIZED_TYPE,
             OWNERSHIP_DENIED_DETAIL,
         )
 
-    def test_ownership_lookup_failed_tuple(self) -> None:
+    def test_006_lookup_failed_tuple(self) -> None:
         code, msg, _detail = ownership_lookup_failed()
         assert code == 500
         assert msg == "urn:ietf:params:acme:error:serverInternal"
 
 
 class TestTkauthFailClosed:
-    def test_perform_validation_fails_closed_without_ack(self) -> None:
+    def test_007_validation_fails_closed_without_ack(self) -> None:
         logger = Mock(spec=logging.Logger)
         validator = TkauthChallengeValidator(logger)
         context = ChallengeContext(
@@ -75,7 +75,7 @@ class TestTkauthFailClosed:
         assert result.invalid is True
         assert result.error_message == NOT_IMPLEMENTED_MSG
 
-    def test_perform_validation_succeeds_when_acknowledged(self) -> None:
+    def test_008_validation_succeeds_when_acknowledged(self) -> None:
         logger = logging.getLogger("test_hardening_tkauth")
         validator = TkauthChallengeValidator(logger)
         context = ChallengeContext(
@@ -95,7 +95,9 @@ class TestOrderResourceOwnership:
     @pytest.fixture
     def order(self):
         models_mock = MagicMock()
-        with patch.dict("sys.modules", {"acme2certifier.acme_srv.db_handler": models_mock}):
+        with patch.dict(
+            "sys.modules", {"acme2certifier.acme_srv.db_handler": models_mock}
+        ):
             logging.basicConfig(level=logging.CRITICAL)
             logger = logging.getLogger("test_hardening_order")
             from acme2certifier.acme_srv.order import Order
@@ -111,7 +113,7 @@ class TestOrderResourceOwnership:
             }
             yield order_obj
 
-    def test_cross_account_order_request_denied(self, order) -> None:
+    def test_009_account_order_request_denied(self, order) -> None:
         order.message.check.return_value = (
             200,
             None,
@@ -124,7 +126,9 @@ class TestOrderResourceOwnership:
             order, "get_order_details", return_value={"status": "ready"}
         ), patch.object(
             order, "_get_order_account_name", return_value="victim-acct"
-        ), patch.object(order, "_process_order_request") as mock_process:
+        ), patch.object(
+            order, "_process_order_request"
+        ) as mock_process:
             order.message.prepare_response.side_effect = lambda resp, status, **_: {
                 **resp,
                 **status,
@@ -134,7 +138,7 @@ class TestOrderResourceOwnership:
         assert result["code"] == 403
         assert result["type"] == UNAUTHORIZED_TYPE
 
-    def test_same_account_order_request_allowed(self, order) -> None:
+    def test_010_account_order_request_allowed(self, order) -> None:
         order.message.check.return_value = (
             200,
             None,
@@ -155,11 +159,13 @@ class TestOrderResourceOwnership:
             order,
             "_process_order_request",
             return_value=(200, None, None, None),
-        ), patch.object(order, "get_order_details", return_value={"status": "ready"}):
+        ), patch.object(
+            order, "get_order_details", return_value={"status": "ready"}
+        ):
             result = order.parse_order_content("content")
         assert result["code"] == 200
 
-    def test_order_owner_lookup_unavailable_denied(self, order) -> None:
+    def test_011_owner_lookup_unavailable_denied(self, order) -> None:
         order.message.check.return_value = (
             200,
             None,
@@ -206,7 +212,7 @@ class TestCertificateResourceOwnership:
         )
         yield cert
 
-    def test_cross_account_certificate_download_denied(self, certificate) -> None:
+    def test_012_account_certificate_download_denied(self, certificate) -> None:
         certificate._validate_certificate_request_message = MagicMock(
             return_value=(
                 200,
@@ -225,7 +231,7 @@ class TestCertificateResourceOwnership:
         assert result["code"] == 403
         assert result["type"] == UNAUTHORIZED_TYPE
 
-    def test_same_account_certificate_download_allowed(self, certificate) -> None:
+    def test_013_account_certificate_download_allowed(self, certificate) -> None:
         certificate._validate_certificate_request_message = MagicMock(
             return_value=(
                 200,
@@ -239,7 +245,9 @@ class TestCertificateResourceOwnership:
         with patch.object(
             certificate, "_lookup_certificate_owner_account", return_value="owner"
         ), patch.object(
-            certificate, "get_certificate_details", return_value={"code": 200, "data": "pem"}
+            certificate,
+            "get_certificate_details",
+            return_value={"code": 200, "data": "pem"},
         ):
             result = certificate.process_certificate_request("content")
         assert result["code"] == 200
@@ -270,7 +278,7 @@ class TestChallengeResourceOwnership:
         )
         yield ch
 
-    def test_cross_account_challenge_post_denied(self, challenge) -> None:
+    def test_014_account_challenge_post_denied(self, challenge) -> None:
         challenge.message.check.return_value = (
             200,
             None,
@@ -287,7 +295,7 @@ class TestChallengeResourceOwnership:
         mock_handle.assert_not_called()
         assert result["code"] == 403
 
-    def test_same_account_challenge_post_allowed(self, challenge) -> None:
+    def test_015_account_challenge_post_allowed(self, challenge) -> None:
         challenge.message.check.return_value = (
             200,
             None,
@@ -298,7 +306,9 @@ class TestChallengeResourceOwnership:
         )
         challenge.repository.get_challenge_owner_account_name.return_value = "owner"
         with patch.object(
-            challenge, "_handle_challenge_validation_request", return_value={"code": 200}
+            challenge,
+            "_handle_challenge_validation_request",
+            return_value={"code": 200},
         ):
             result = challenge.process_challenge_request("content")
         assert result["code"] == 200
@@ -315,7 +325,7 @@ class TestAuthorizationResourceOwnership:
         auth.business_logic.extract_authorization_name_from_url.return_value = "authz1"
         yield auth
 
-    def test_cross_account_authorization_post_denied(self, authorization) -> None:
+    def test_016_account_authorization_post_denied(self, authorization) -> None:
         authorization.message.check.return_value = (
             200,
             "ok",
@@ -337,7 +347,7 @@ class TestAuthorizationResourceOwnership:
         assert result["code"] == 403
         assert result["type"] == UNAUTHORIZED_TYPE
 
-    def test_same_account_authorization_post_allowed(self, authorization) -> None:
+    def test_017_account_authorization_post_allowed(self, authorization) -> None:
         authorization.message.check.return_value = (
             200,
             "ok",
@@ -349,7 +359,9 @@ class TestAuthorizationResourceOwnership:
         authorization.repository.find_authorization_by_name.return_value = {
             "order__account__name": "owner"
         }
-        authorization.get_authorization_details = MagicMock(return_value={"status": "valid"})
+        authorization.get_authorization_details = MagicMock(
+            return_value={"status": "valid"}
+        )
         authorization.message.prepare_response.side_effect = lambda resp, status, **_: {
             **resp,
             **status,
@@ -357,7 +369,7 @@ class TestAuthorizationResourceOwnership:
         result = authorization.handle_post_request("content")
         assert result["code"] == 200
 
-    def test_authorization_owner_lookup_db_error_returns_500(self, authorization) -> None:
+    def test_018_owner_lookup_db_error_returns_500(self, authorization) -> None:
         authorization.message.check.return_value = (
             200,
             "ok",
@@ -385,7 +397,7 @@ class TestRenewalinfoResourceOwnership:
         info.repository = MagicMock()
         yield info
 
-    def test_cross_account_replaced_update_denied(self, renewalinfo) -> None:
+    def test_019_account_replaced_update_denied(self, renewalinfo) -> None:
         renewalinfo.message.check.return_value = (
             200,
             None,
@@ -394,15 +406,24 @@ class TestRenewalinfoResourceOwnership:
             {"certid": "cid", "replaced": True},
             "attacker",
         )
+        renewalinfo.message.prepare_response.side_effect = lambda resp, status, **_: {
+            **resp,
+            "code": status["code"],
+            "data": {
+                "status": status["code"],
+                "type": status.get("type"),
+                "detail": status.get("detail"),
+            },
+            "header": {},
+        }
         renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
             return_value={"name": "cert1", "order__account__name": "victim"}
         )
-        with patch.object(renewalinfo.repository, "add_certificate") as mock_add:
-            result = renewalinfo.update("content")
-        mock_add.assert_not_called()
+        result = renewalinfo.update("content")
+        renewalinfo.repository.mark_certificate_replaced.assert_not_called()
         assert result["code"] == 403
 
-    def test_same_account_replaced_update_allowed(self, renewalinfo) -> None:
+    def test_020_account_replaced_update_allowed(self, renewalinfo) -> None:
         renewalinfo.message.check.return_value = (
             200,
             None,
@@ -414,6 +435,9 @@ class TestRenewalinfoResourceOwnership:
         renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
             return_value={"name": "cert1", "order__account__name": "owner"}
         )
-        renewalinfo.repository.add_certificate.return_value = True
+        renewalinfo.repository.mark_certificate_replaced.return_value = True
         result = renewalinfo.update("content")
         assert result["code"] == 200
+        renewalinfo.repository.mark_certificate_replaced.assert_called_once_with(
+            "cert1"
+        )

--- a/test/test_hardening.py
+++ b/test/test_hardening.py
@@ -1,0 +1,419 @@
+# -*- coding: utf-8 -*-
+"""Security hardening regression tests."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from acme2certifier.acme_srv.authorization import Authorization, AuthorizationError
+from acme2certifier.acme_srv.challenge import Challenge, ChallengeInfo
+from acme2certifier.acme_srv.challenge_validators.base import ChallengeContext
+from acme2certifier.acme_srv.challenge_validators.tkauth_validator import (
+    NOT_IMPLEMENTED_MSG,
+    TkauthChallengeValidator,
+)
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    OWNERSHIP_DENIED_DETAIL,
+    UNAUTHORIZED_TYPE,
+    ownership_lookup_failed,
+    ownership_unauthorized,
+    resource_owner_matches,
+)
+from acme2certifier.acme_srv.helpers.security_gate import SECURITY_DISABLE_ACK_ENV
+from acme2certifier.acme_srv.renewalinfo import Renewalinfo
+
+
+class TestResourceOwnershipHelper:
+    def test_resource_owner_matches_equal_accounts(self) -> None:
+        assert resource_owner_matches("acct-a", "acct-a") is True
+
+    def test_resource_owner_matches_different_accounts(self) -> None:
+        assert resource_owner_matches("acct-a", "acct-b") is False
+
+    def test_resource_owner_matches_missing_requester(self) -> None:
+        assert resource_owner_matches(None, "acct-a") is False
+        assert resource_owner_matches("", "acct-a") is False
+
+    def test_resource_owner_matches_missing_owner(self) -> None:
+        assert resource_owner_matches("acct-a", None) is False
+        assert resource_owner_matches("acct-a", "") is False
+
+    def test_ownership_unauthorized_tuple(self) -> None:
+        assert ownership_unauthorized() == (
+            403,
+            UNAUTHORIZED_TYPE,
+            OWNERSHIP_DENIED_DETAIL,
+        )
+
+    def test_ownership_lookup_failed_tuple(self) -> None:
+        code, msg, _detail = ownership_lookup_failed()
+        assert code == 500
+        assert msg == "urn:ietf:params:acme:error:serverInternal"
+
+
+class TestTkauthFailClosed:
+    def test_perform_validation_fails_closed_without_ack(self) -> None:
+        logger = Mock(spec=logging.Logger)
+        validator = TkauthChallengeValidator(logger)
+        context = ChallengeContext(
+            challenge_name="c1",
+            token="tok",
+            jwk_thumbprint="thumb",
+            authorization_type="dns",
+            authorization_value="example.com",
+        )
+        with patch.dict(os.environ, {SECURITY_DISABLE_ACK_ENV: ""}, clear=False):
+            result = validator.perform_validation(context)
+        assert result.success is False
+        assert result.invalid is True
+        assert result.error_message == NOT_IMPLEMENTED_MSG
+
+    def test_perform_validation_succeeds_when_acknowledged(self) -> None:
+        logger = logging.getLogger("test_hardening_tkauth")
+        validator = TkauthChallengeValidator(logger)
+        context = ChallengeContext(
+            challenge_name="c1",
+            token="tok",
+            jwk_thumbprint="thumb",
+            authorization_type="dns",
+            authorization_value="example.com",
+        )
+        with patch.dict(os.environ, {SECURITY_DISABLE_ACK_ENV: "1"}, clear=False):
+            result = validator.perform_validation(context)
+        assert result.success is True
+        assert result.invalid is False
+
+
+class TestOrderResourceOwnership:
+    @pytest.fixture
+    def order(self):
+        models_mock = MagicMock()
+        with patch.dict("sys.modules", {"acme2certifier.acme_srv.db_handler": models_mock}):
+            logging.basicConfig(level=logging.CRITICAL)
+            logger = logging.getLogger("test_hardening_order")
+            from acme2certifier.acme_srv.order import Order
+
+            order_obj = Order(debug=True, server_name="http://srv", logger=logger)
+            order_obj.message = MagicMock()
+            order_obj.repository = MagicMock()
+            order_obj.error_msg_dic = {
+                "malformed": "urn:ietf:params:acme:error:malformed",
+                "ordernotready": "urn:ietf:params:acme:error:orderNotReady",
+                "serverinternal": "urn:ietf:params:acme:error:serverInternal",
+                "unauthorized": UNAUTHORIZED_TYPE,
+            }
+            yield order_obj
+
+    def test_cross_account_order_request_denied(self, order) -> None:
+        order.message.check.return_value = (
+            200,
+            None,
+            None,
+            {"url": "http://srv/acme/order/victim"},
+            {},
+            "attacker",
+        )
+        with patch.object(order, "_name_get", return_value="victim"), patch.object(
+            order, "get_order_details", return_value={"status": "ready"}
+        ), patch.object(
+            order, "_get_order_account_name", return_value="victim-acct"
+        ), patch.object(order, "_process_order_request") as mock_process:
+            order.message.prepare_response.side_effect = lambda resp, status, **_: {
+                **resp,
+                **status,
+            }
+            result = order.parse_order_content("content")
+        mock_process.assert_not_called()
+        assert result["code"] == 403
+        assert result["type"] == UNAUTHORIZED_TYPE
+
+    def test_same_account_order_request_allowed(self, order) -> None:
+        order.message.check.return_value = (
+            200,
+            None,
+            None,
+            {"url": "http://srv/acme/order/owner"},
+            {},
+            "owner-acct",
+        )
+        order.message.prepare_response.side_effect = lambda resp, status, **_: {
+            **resp,
+            **status,
+        }
+        with patch.object(order, "_name_get", return_value="owner"), patch.object(
+            order, "get_order_details", return_value={"status": "ready"}
+        ), patch.object(
+            order, "_get_order_account_name", return_value="owner-acct"
+        ), patch.object(
+            order,
+            "_process_order_request",
+            return_value=(200, None, None, None),
+        ), patch.object(order, "get_order_details", return_value={"status": "ready"}):
+            result = order.parse_order_content("content")
+        assert result["code"] == 200
+
+    def test_order_owner_lookup_unavailable_denied(self, order) -> None:
+        order.message.check.return_value = (
+            200,
+            None,
+            None,
+            {"url": "http://srv/acme/order/victim"},
+            {},
+            "attacker",
+        )
+        order.message.prepare_response.side_effect = lambda resp, status, **_: {
+            **resp,
+            **status,
+        }
+        with patch.object(order, "_name_get", return_value="victim"), patch.object(
+            order, "get_order_details", return_value={"status": "ready"}
+        ), patch.object(order, "_get_order_account_name", return_value=None):
+            result = order.parse_order_content("content")
+        assert result["code"] == 403
+        assert result["type"] == UNAUTHORIZED_TYPE
+
+
+class TestCertificateResourceOwnership:
+    @pytest.fixture
+    def certificate(self):
+        logging.basicConfig(level=logging.CRITICAL)
+        logger = logging.getLogger("test_hardening_cert")
+        from acme2certifier.acme_srv.certificate import Certificate
+
+        cert = Certificate(debug=True, srv_name="http://srv", logger=logger)
+        cert.message = MagicMock()
+        cert.repository = MagicMock()
+        cert.path_dic = {"cert_path": "/acme/cert/"}
+        cert.err_msg_dic = {
+            "malformed": "urn:ietf:params:acme:error:malformed",
+            "serverinternal": "urn:ietf:params:acme:error:serverInternal",
+            "unauthorized": UNAUTHORIZED_TYPE,
+        }
+        cert._prepare_certificate_response = MagicMock(
+            side_effect=lambda resp, code, msg, detail, **_: {
+                "code": code,
+                "type": msg,
+                "detail": detail,
+                "data": resp,
+            }
+        )
+        yield cert
+
+    def test_cross_account_certificate_download_denied(self, certificate) -> None:
+        certificate._validate_certificate_request_message = MagicMock(
+            return_value=(
+                200,
+                None,
+                None,
+                {"url": "http://srv/acme/cert/cert1"},
+                {},
+                "attacker",
+            )
+        )
+        with patch.object(
+            certificate, "_lookup_certificate_owner_account", return_value="victim"
+        ), patch.object(certificate, "get_certificate_details") as mock_get:
+            result = certificate.process_certificate_request("content")
+        mock_get.assert_not_called()
+        assert result["code"] == 403
+        assert result["type"] == UNAUTHORIZED_TYPE
+
+    def test_same_account_certificate_download_allowed(self, certificate) -> None:
+        certificate._validate_certificate_request_message = MagicMock(
+            return_value=(
+                200,
+                None,
+                None,
+                {"url": "http://srv/acme/cert/cert1"},
+                {},
+                "owner",
+            )
+        )
+        with patch.object(
+            certificate, "_lookup_certificate_owner_account", return_value="owner"
+        ), patch.object(
+            certificate, "get_certificate_details", return_value={"code": 200, "data": "pem"}
+        ):
+            result = certificate.process_certificate_request("content")
+        assert result["code"] == 200
+
+
+class TestChallengeResourceOwnership:
+    @pytest.fixture
+    def challenge(self):
+        logging.basicConfig(level=logging.CRITICAL)
+        logger = logging.getLogger("test_hardening_challenge")
+        from acme2certifier.acme_srv.challenge import Challenge
+
+        ch = Challenge(debug=True, srv_name="http://srv", logger=logger)
+        ch.message = MagicMock()
+        ch.repository = MagicMock()
+        ch.err_msg_dic = {"malformed": "urn:ietf:params:acme:error:malformed"}
+        ch._ensure_components_initialized = Mock()
+        ch._extract_challenge_name_from_url = Mock(return_value="chal1")
+        ch._create_error_response = MagicMock(
+            side_effect=lambda code, msg, detail, **_: {
+                "code": code,
+                "type": msg,
+                "detail": detail,
+            }
+        )
+        ch.repository.get_challenge_by_name.return_value = ChallengeInfo(
+            "chal1", "dns-01", "tok", "pending", "authz1", "dns", "example.com", "url"
+        )
+        yield ch
+
+    def test_cross_account_challenge_post_denied(self, challenge) -> None:
+        challenge.message.check.return_value = (
+            200,
+            None,
+            None,
+            {"url": "http://srv/acme/chall/chal1"},
+            {},
+            "attacker",
+        )
+        challenge.repository.get_challenge_owner_account_name.return_value = "victim"
+        with patch.object(
+            challenge, "_handle_challenge_validation_request"
+        ) as mock_handle:
+            result = challenge.process_challenge_request("content")
+        mock_handle.assert_not_called()
+        assert result["code"] == 403
+
+    def test_same_account_challenge_post_allowed(self, challenge) -> None:
+        challenge.message.check.return_value = (
+            200,
+            None,
+            None,
+            {"url": "http://srv/acme/chall/chal1"},
+            {},
+            "owner",
+        )
+        challenge.repository.get_challenge_owner_account_name.return_value = "owner"
+        with patch.object(
+            challenge, "_handle_challenge_validation_request", return_value={"code": 200}
+        ):
+            result = challenge.process_challenge_request("content")
+        assert result["code"] == 200
+
+
+class TestAuthorizationResourceOwnership:
+    @pytest.fixture
+    def authorization(self):
+        auth = Authorization(debug=True, srv_name="http://srv", logger=MagicMock())
+        auth.config.expiry_check_disable = True
+        auth.message = MagicMock()
+        auth.repository = MagicMock()
+        auth.business_logic = MagicMock()
+        auth.business_logic.extract_authorization_name_from_url.return_value = "authz1"
+        yield auth
+
+    def test_cross_account_authorization_post_denied(self, authorization) -> None:
+        authorization.message.check.return_value = (
+            200,
+            "ok",
+            "",
+            {"url": "http://srv/acme/authz/authz1"},
+            {},
+            "attacker",
+        )
+        authorization.repository.find_authorization_by_name.return_value = {
+            "order__account__name": "victim"
+        }
+        authorization.message.prepare_response.side_effect = lambda resp, status, **_: {
+            **resp,
+            **status,
+        }
+        with patch.object(authorization, "get_authorization_details") as mock_get:
+            result = authorization.handle_post_request("content")
+        mock_get.assert_not_called()
+        assert result["code"] == 403
+        assert result["type"] == UNAUTHORIZED_TYPE
+
+    def test_same_account_authorization_post_allowed(self, authorization) -> None:
+        authorization.message.check.return_value = (
+            200,
+            "ok",
+            "",
+            {"url": "http://srv/acme/authz/authz1"},
+            {},
+            "owner",
+        )
+        authorization.repository.find_authorization_by_name.return_value = {
+            "order__account__name": "owner"
+        }
+        authorization.get_authorization_details = MagicMock(return_value={"status": "valid"})
+        authorization.message.prepare_response.side_effect = lambda resp, status, **_: {
+            **resp,
+            **status,
+        }
+        result = authorization.handle_post_request("content")
+        assert result["code"] == 200
+
+    def test_authorization_owner_lookup_db_error_returns_500(self, authorization) -> None:
+        authorization.message.check.return_value = (
+            200,
+            "ok",
+            "",
+            {"url": "http://srv/acme/authz/authz1"},
+            {},
+            "owner",
+        )
+        authorization.repository.find_authorization_by_name.side_effect = (
+            AuthorizationError("db")
+        )
+        authorization.message.prepare_response.side_effect = lambda resp, status, **_: {
+            **resp,
+            **status,
+        }
+        result = authorization.handle_post_request("content")
+        assert result["code"] == 500
+
+
+class TestRenewalinfoResourceOwnership:
+    @pytest.fixture
+    def renewalinfo(self):
+        info = Renewalinfo(debug=True, srv_name="http://srv", logger=MagicMock())
+        info.message = MagicMock()
+        info.repository = MagicMock()
+        yield info
+
+    def test_cross_account_replaced_update_denied(self, renewalinfo) -> None:
+        renewalinfo.message.check.return_value = (
+            200,
+            None,
+            None,
+            None,
+            {"certid": "cid", "replaced": True},
+            "attacker",
+        )
+        renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
+            return_value={"name": "cert1", "order__account__name": "victim"}
+        )
+        with patch.object(renewalinfo.repository, "add_certificate") as mock_add:
+            result = renewalinfo.update("content")
+        mock_add.assert_not_called()
+        assert result["code"] == 403
+
+    def test_same_account_replaced_update_allowed(self, renewalinfo) -> None:
+        renewalinfo.message.check.return_value = (
+            200,
+            None,
+            None,
+            None,
+            {"certid": "cid", "replaced": True},
+            "owner",
+        )
+        renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
+            return_value={"name": "cert1", "order__account__name": "owner"}
+        )
+        renewalinfo.repository.add_certificate.return_value = True
+        result = renewalinfo.update("content")
+        assert result["code"] == 200

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -697,7 +697,7 @@ class TestOrderClass(unittest.TestCase):
         with patch.object(self.order, "_name_get", return_value="order"):
             with patch.object(
                 self.order, "get_order_details", return_value={"status": "ok"}
-            ):
+            ), patch.object(self.order, "_get_order_account_name", return_value="acc"):
                 with patch.object(
                     self.order,
                     "_process_order_request",
@@ -714,7 +714,9 @@ class TestOrderClass(unittest.TestCase):
                         _detail,
                         _cert,
                         _order,
-                    ) = self.order._parse_order_message({"url": "url"}, {}, None)
+                    ) = self.order._parse_order_message(
+                        {"url": "url"}, {}, None, account_name="acc"
+                    )
                     self.assertEqual(code, 200)
             # url in protected, order_name, no order_dic
             with patch.object(self.order, "get_order_details", return_value={}):

--- a/test/test_renewalinfo.py
+++ b/test/test_renewalinfo.py
@@ -15,8 +15,23 @@ from acme2certifier.acme_srv.renewalinfo import (
     RenewalinfoRepository,
 )
 from acme2certifier.acme_srv.helpers.resource_ownership import (
+    OWNERSHIP_DENIED_DETAIL,
+    UNAUTHORIZED_TYPE,
     ResourceOwnershipLookupError,
 )
+
+
+def _acme_prepare_response(response_dic, status_dic, *args, **kwargs):
+    result = dict(response_dic or {})
+    result["code"] = status_dic["code"]
+    if status_dic.get("code", 200) >= 400:
+        result["data"] = {
+            "status": status_dic["code"],
+            "type": status_dic.get("type"),
+            "detail": status_dic.get("detail"),
+        }
+    result.setdefault("header", {})
+    return result
 
 
 class TestRenewalinfoConfig(unittest.TestCase):
@@ -33,36 +48,58 @@ class TestRenewalinfoRepository(unittest.TestCase):
         self.logger = MagicMock()
         self.repo = RenewalinfoRepository(self.mock_dbstore, self.logger)
 
-    def test_001_get_certificate_by_certid_success(self):
+    def test_002_get_certificate_by_certid_success(self):
         self.mock_dbstore.certificate_lookup.return_value = {"foo": "bar"}
         result = self.repo.get_certificate_by_certid("abc")
         self.assertEqual(result, {"foo": "bar"})
 
-    def test_002_get_certificate_by_certid_exception(self):
+    def test_003_get_certificate_by_certid_exception(self):
         self.mock_dbstore.certificate_lookup.side_effect = Exception("fail")
         with self.assertRaises(ResourceOwnershipLookupError):
             self.repo.get_certificate_by_certid("abc")
 
-    def test_003_get_certificates_by_serial_success(self):
+    def test_004_get_certificates_by_serial_success(self):
         self.mock_dbstore.certificates_search.return_value = [{"foo": "bar"}]
         result = self.repo.get_certificates_by_serial("serial")
         self.assertEqual(result, [{"foo": "bar"}])
+        self.mock_dbstore.certificates_search.assert_called_once_with(
+            "serial",
+            "serial",
+            operant="is",
+            vlist=[
+                "id",
+                "name",
+                "cert",
+                "cert_raw",
+                "expire_uts",
+                "issue_uts",
+                "aki",
+                "created_at",
+                "order__account__name",
+            ],
+        )
 
-    def test_004_get_certificates_by_serial_exception(self):
+    def test_005_get_certificates_by_serial_exception(self):
         self.mock_dbstore.certificates_search.side_effect = Exception("fail")
         result = self.repo.get_certificates_by_serial("serial")
         self.assertEqual(result, [])
         self.logger.critical.assert_called()
 
-    def test_005_add_certificate(self):
+    def test_006_add_certificate(self):
         self.repo.add_certificate({"foo": "bar"})
         self.mock_dbstore.certificate_add.assert_called_with({"foo": "bar"})
 
-    def test_006_get_housekeeping_param(self):
+    def test_007_mark_certificate_replaced(self):
+        self.mock_dbstore.certificate_replaced_update.return_value = 7
+        result = self.repo.mark_certificate_replaced("cert1")
+        self.assertEqual(result, 7)
+        self.mock_dbstore.certificate_replaced_update.assert_called_once_with("cert1")
+
+    def test_008_get_housekeeping_param(self):
         self.repo.get_housekeeping_param("name")
         self.mock_dbstore.hkparameter_get.assert_called_with("name")
 
-    def test_007_add_housekeeping_param(self):
+    def test_009_add_housekeeping_param(self):
         self.repo.add_housekeeping_param({"foo": "bar"})
         self.mock_dbstore.hkparameter_add.assert_called_with({"foo": "bar"})
 
@@ -111,8 +148,9 @@ class TestRenewalinfo(unittest.TestCase):
         )
         self.renewalinfo.config = self.mock_config
         self.renewalinfo.repository = self.mock_repository
+        self.mock_message.prepare_response.side_effect = _acme_prepare_response
 
-    def test_001_get_housekeeping_triggers_update(self):
+    def test_010_get_housekeeping_triggers_update(self):
         self.mock_repository.get_housekeeping_param.return_value = False
         self.mock_repository.add_housekeeping_param.return_value = True
         self.mock_repository.get_certificate_by_certid.return_value = {
@@ -132,7 +170,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertIn("data", result)
             self.renewalinfo._update_certificate_table_with_serial_and_aki.assert_called()
 
-    def test_002_get_returns_404(self):
+    def test_011_get_returns_404(self):
         self.mock_repository.get_housekeeping_param.return_value = True
         self.renewalinfo._get_renewalinfo_data = MagicMock(return_value={})
         with patch(
@@ -142,7 +180,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(result["code"], 404)
             self.assertEqual(result["data"], "malf")
 
-    def test_003_get_returns_400_on_exception(self):
+    def test_012_get_returns_400_on_exception(self):
         self.mock_repository.get_housekeeping_param.return_value = True
         self.renewalinfo._get_renewalinfo_data = MagicMock(
             side_effect=Exception("fail")
@@ -154,7 +192,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(result["code"], 400)
             self.assertEqual(result["data"], "malf")
 
-    def test_004_update_success(self):
+    def test_013_update_success(self):
         self.mock_message.check.return_value = (
             200,
             None,
@@ -164,19 +202,24 @@ class TestRenewalinfo(unittest.TestCase):
             "owner-acct",
         )
         self.mock_repository.get_certificate_by_certid.return_value = {
+            "name": "cert1",
             "expire_uts": 100000,
             "issue_uts": 90000,
             "order__account__name": "owner-acct",
         }
-        self.mock_repository.add_certificate.return_value = True
+        self.mock_repository.mark_certificate_replaced.return_value = True
         with patch(
             "acme2certifier.acme_srv.renewalinfo.certid_hex_get",
             return_value=(None, "hex"),
         ):
             result = self.renewalinfo.update("content")
             self.assertEqual(result["code"], 200)
+            self.mock_repository.mark_certificate_replaced.assert_called_once_with(
+                "cert1"
+            )
+            self.mock_repository.add_certificate.assert_not_called()
 
-    def test_005_update_failure(self):
+    def test_014_update_failure(self):
         self.mock_message.check.return_value = (
             200,
             None,
@@ -193,7 +236,7 @@ class TestRenewalinfo(unittest.TestCase):
             result = self.renewalinfo.update("content")
             self.assertEqual(result["code"], 400)
 
-    def test_006_update_payload_missing(self):
+    def test_015_update_payload_missing(self):
         self.mock_message.check.return_value = (
             200,
             None,
@@ -209,7 +252,7 @@ class TestRenewalinfo(unittest.TestCase):
             result = self.renewalinfo.update("content")
             self.assertEqual(result["code"], 400)
 
-    def test_007_lookup_certificate_by_renewalinfo_dot(self):
+    def test_016_lookup_certificate_by_renewalinfo_dot(self):
         self.renewalinfo._extract_serial_and_aki_from_string = MagicMock(
             return_value=("serial", "aki")
         )
@@ -219,7 +262,7 @@ class TestRenewalinfo(unittest.TestCase):
         result = self.renewalinfo._lookup_certificate_by_renewalinfo("serial.aki")
         self.assertEqual(result, {"foo": "bar"})
 
-    def test_008_lookup_certificate_by_renewalinfo_nodot(self):
+    def test_017_lookup_certificate_by_renewalinfo_nodot(self):
         with patch(
             "acme2certifier.acme_srv.renewalinfo.certid_hex_get",
             return_value=(None, "hex"),
@@ -230,25 +273,25 @@ class TestRenewalinfo(unittest.TestCase):
             result = self.renewalinfo._lookup_certificate_by_renewalinfo("foo")
             self.assertEqual(result, {"foo": "bar"})
 
-    def test_009_generate_renewalinfo_window_force(self):
+    def test_018_generate_renewalinfo_window_force(self):
         cert_dic = {"expire_uts": 100000, "issue_uts": 90000}
         self.renewalinfo.config.renewal_force = True
         with patch("acme2certifier.acme_srv.renewalinfo.uts_now", return_value=100000):
             result = self.renewalinfo._generate_renewalinfo_window(cert_dic)
             self.assertIn("suggestedWindow", result)
 
-    def test_010_generate_renewalinfo_window_normal(self):
+    def test_019_generate_renewalinfo_window_normal(self):
         cert_dic = {"expire_uts": 100000, "issue_uts": 90000}
         self.renewalinfo.config.renewal_force = False
         result = self.renewalinfo._generate_renewalinfo_window(cert_dic)
         self.assertIn("suggestedWindow", result)
 
-    def test_011_generate_renewalinfo_window_empty(self):
+    def test_020_generate_renewalinfo_window_empty(self):
         cert_dic = {}
         result = self.renewalinfo._generate_renewalinfo_window(cert_dic)
         self.assertEqual(result, {})
 
-    def test_012_generate_renewalinfo_window_no_expire_uts(self):
+    def test_021_generate_renewalinfo_window_no_expire_uts(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         # cert_dic missing 'expire_uts' key
@@ -270,7 +313,7 @@ class TestRenewalinfo(unittest.TestCase):
             renewalinfo._generate_renewalinfo_window(cert_dic)
             mock_uts_now.assert_called_once()
 
-    def test_013_extract_serial_and_aki_from_string_valid(self):
+    def test_022_extract_serial_and_aki_from_string_valid(self):
         with patch(
             "acme2certifier.acme_srv.renewalinfo.b64_decode", return_value=b"abc"
         ):
@@ -280,11 +323,11 @@ class TestRenewalinfo(unittest.TestCase):
                 result = self.renewalinfo._extract_serial_and_aki_from_string("foo.bar")
                 self.assertEqual(result, ("616263", "616263"))
 
-    def test_014_extract_serial_and_aki_from_string_invalid(self):
+    def test_023_extract_serial_and_aki_from_string_invalid(self):
         result = self.renewalinfo._extract_serial_and_aki_from_string("foo")
         self.assertEqual(result, (None, None))
 
-    def test_015_load_configuration_all_valid(self):
+    def test_024_load_configuration_all_valid(self):
         class DummyConfig:
             def getboolean(self, section, key, fallback=None):
                 return True
@@ -315,7 +358,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(self.renewalinfo.config.renewalthreshold_pctg, 99.9)
             self.assertEqual(self.renewalinfo.config.retry_after_timeout, 12345)
 
-    def test_016_load_configuration_defaults(self):
+    def test_025_load_configuration_defaults(self):
         class DummyConfig:
             def getboolean(self, section, key, fallback=None):
                 return fallback
@@ -342,7 +385,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(self.renewalinfo.config.renewalthreshold_pctg, 85.0)
             self.assertEqual(self.renewalinfo.config.retry_after_timeout, 86400)
 
-    def test_017_load_configuration_renewal_force_error(self):
+    def test_026_load_configuration_renewal_force_error(self):
         class DummyConfig:
             def getboolean(self, section, key, fallback=None):
                 raise Exception("failbool")
@@ -368,7 +411,7 @@ class TestRenewalinfo(unittest.TestCase):
             # Should fallback to default False
             self.assertFalse(self.renewalinfo.config.renewal_force)
 
-    def test_018_load_configuration_renewalthreshold_pctg_error(self):
+    def test_027_load_configuration_renewalthreshold_pctg_error(self):
         class DummyConfig:
             def getboolean(self, section, key, fallback=None):
                 return False
@@ -398,7 +441,7 @@ class TestRenewalinfo(unittest.TestCase):
             )
             self.assertEqual(self.renewalinfo.config.renewalthreshold_pctg, 85.0)
 
-    def test_019_load_configuration_retry_after_timeout_error(self):
+    def test_028_load_configuration_retry_after_timeout_error(self):
         class DummyConfig:
             def getboolean(self, section, key, fallback=None):
                 return False
@@ -430,13 +473,13 @@ class TestRenewalinfo(unittest.TestCase):
             )
             self.assertEqual(self.renewalinfo.config.retry_after_timeout, 86400)
 
-    def test_020_exit_does_nothing_and_returns_none(self):
+    def test_029_exit_does_nothing_and_returns_none(self):
         renewalinfo = self.renewalinfo
         # __exit__ should just return None and not raise
         result = renewalinfo.__exit__(None, None, None)
         self.assertIsNone(result)
 
-    def test_021_context_manager_usage(self):
+    def test_030_context_manager_usage(self):
         # Ensure __enter__ and __exit__ work in a with-statement
         renewalinfo = self.renewalinfo
         with patch.object(renewalinfo, "_load_configuration") as mock_load_config:
@@ -444,7 +487,7 @@ class TestRenewalinfo(unittest.TestCase):
                 mock_load_config.assert_called_once()
                 self.assertIs(ri, renewalinfo)
 
-    def test_022_update_certificate_table_with_serial_and_aki_success(self):
+    def test_031_update_certificate_table_with_serial_and_aki_success(self):
         renewalinfo = self.renewalinfo
         mock_logger = MagicMock()
         renewalinfo.logger = mock_logger
@@ -484,7 +527,7 @@ class TestRenewalinfo(unittest.TestCase):
             "Renewalinfo._update_certificate_table_with_serial_and_aki(%s) - done", 1
         )
 
-    def test_023_update_certificate_table_with_serial_and_aki_db_error(self):
+    def test_032_update_certificate_table_with_serial_and_aki_db_error(self):
         renewalinfo = self.renewalinfo
         mock_logger = MagicMock()
         renewalinfo.logger = mock_logger
@@ -504,7 +547,7 @@ class TestRenewalinfo(unittest.TestCase):
         # No add_certificate calls
         renewalinfo.repository.add_certificate.assert_not_called()
 
-    def test_024_get_compat_success(self):
+    def test_033_get_compat_success(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         renewalinfo.repository = MagicMock()
@@ -520,7 +563,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertIn("data", result)
             self.assertIn("header", result)
 
-    def test_025_get_compat_404(self):
+    def test_034_get_compat_404(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         renewalinfo.repository = MagicMock()
@@ -534,7 +577,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(result["code"], 404)
             self.assertEqual(result["data"], "malf")
 
-    def test_026_get_compat_400(self):
+    def test_035_get_compat_400(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         renewalinfo.repository = MagicMock()
@@ -548,10 +591,11 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(result["code"], 400)
             self.assertEqual(result["data"], "malf")
 
-    def test_027_update_compat_success(self):
+    def test_036_update_compat_success(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         renewalinfo.message = MagicMock()
+        renewalinfo.message.prepare_response.side_effect = _acme_prepare_response
         renewalinfo.repository = MagicMock()
         renewalinfo.err_msg_dic = {"malformed": "malf"}
         renewalinfo.message.check.return_value = (
@@ -563,16 +607,25 @@ class TestRenewalinfo(unittest.TestCase):
             "owner",
         )
         renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
-            return_value={"foo": "bar", "order__account__name": "owner"}
+            return_value={
+                "name": "cert1",
+                "foo": "bar",
+                "order__account__name": "owner",
+            }
         )
-        renewalinfo.repository.add_certificate.return_value = True
+        renewalinfo.repository.mark_certificate_replaced.return_value = True
         result = renewalinfo.update("content")
         self.assertEqual(result["code"], 200)
+        renewalinfo.repository.mark_certificate_replaced.assert_called_once_with(
+            "cert1"
+        )
+        renewalinfo.repository.add_certificate.assert_not_called()
 
-    def test_028_update_compat_failure(self):
+    def test_037_update_compat_failure(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         renewalinfo.message = MagicMock()
+        renewalinfo.message.prepare_response.side_effect = _acme_prepare_response
         renewalinfo.repository = MagicMock()
         renewalinfo.err_msg_dic = {"malformed": "malf"}
         renewalinfo.message.check.return_value = (
@@ -587,10 +640,11 @@ class TestRenewalinfo(unittest.TestCase):
         result = renewalinfo.update("content")
         self.assertEqual(result["code"], 400)
 
-    def test_029_update_compat_payload_missing(self):
+    def test_038_update_compat_payload_missing(self):
         renewalinfo = self.renewalinfo
         renewalinfo.logger = MagicMock()
         renewalinfo.message = MagicMock()
+        renewalinfo.message.prepare_response.side_effect = _acme_prepare_response
         renewalinfo.repository = MagicMock()
         renewalinfo.err_msg_dic = {"malformed": "malf"}
         renewalinfo.message.check.return_value = (
@@ -604,7 +658,7 @@ class TestRenewalinfo(unittest.TestCase):
         result = renewalinfo.update("content")
         self.assertEqual(result["code"], 400)
 
-    def test_030_lookup_certificate_by_serial_and_aki_found(self):
+    def test_039_lookup_certificate_by_serial_and_aki_found(self):
         # Setup: cert_list contains a cert with matching aki
         cert = {"aki": "aki123", "foo": "bar"}
         self.renewalinfo.repository.get_certificates_by_serial.return_value = [cert]
@@ -616,7 +670,7 @@ class TestRenewalinfo(unittest.TestCase):
             "serial123"
         )
 
-    def test_031_lookup_certificate_by_serial_and_aki_leading_zero(self):
+    def test_040_lookup_certificate_by_serial_and_aki_leading_zero(self):
         # Setup: first call returns empty, second returns a cert with matching aki
         cert = {"aki": "aki456", "foo": "baz"}
         self.renewalinfo.repository.get_certificates_by_serial.side_effect = [
@@ -633,7 +687,7 @@ class TestRenewalinfo(unittest.TestCase):
         self.renewalinfo.repository.get_certificates_by_serial.assert_any_call("0123")
         self.renewalinfo.repository.get_certificates_by_serial.assert_any_call("123")
 
-    def test_032_lookup_certificate_by_serial_and_aki_not_found(self):
+    def test_041_lookup_certificate_by_serial_and_aki_not_found(self):
         # Setup: cert_list does not contain a cert with matching aki
         self.renewalinfo.repository.get_certificates_by_serial.return_value = [
             {"aki": "other"}
@@ -643,13 +697,13 @@ class TestRenewalinfo(unittest.TestCase):
         )
         self.assertEqual(result, {})
 
-    def test_033_lookup_certificate_by_serial_and_aki_empty_list(self):
+    def test_042_lookup_certificate_by_serial_and_aki_empty_list(self):
         # Setup: cert_list is empty
         self.renewalinfo.repository.get_certificates_by_serial.return_value = []
         result = self.renewalinfo._lookup_certificate_by_serial_and_aki("serial", "aki")
         self.assertEqual(result, {})
 
-    def test_034_get_renewalinfo_data(self):
+    def test_043_get_renewalinfo_data(self):
         # Setup: _lookup_certificate_by_renewalinfo and _generate_renewalinfo_window are called
         cert_dic = {"expire_uts": 100000, "issue_uts": 90000}
         renewalinfo_dic = {
@@ -668,7 +722,7 @@ class TestRenewalinfo(unittest.TestCase):
         self.renewalinfo._generate_renewalinfo_window.assert_called_once_with(cert_dic)
         self.assertEqual(result, renewalinfo_dic)
 
-    def test_035__load_ca_handler_success(self):
+    def test_044__load_ca_handler_success(self):
         # Patch ca_handler_load to return a mock module with CAhandler attribute
         mock_cahandler_class = MagicMock()
         mock_module = MagicMock()
@@ -683,7 +737,7 @@ class TestRenewalinfo(unittest.TestCase):
             )
             self.assertIs(self.renewalinfo.cahandler, mock_cahandler_class)
 
-    def test_036__load_ca_handler_failure(self):
+    def test_045__load_ca_handler_failure(self):
         # Patch ca_handler_load to return None
         with patch(
             "acme2certifier.acme_srv.renewalinfo.ca_handler_load", return_value=None
@@ -695,7 +749,7 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertIsNone(self.renewalinfo.cahandler)
             self.mock_logger.critical.assert_called_with("No ca_handler loaded")
 
-    def test_037_get_with_cahandler_lookup(self):
+    def test_046_get_with_cahandler_lookup(self):
         # Simulate config.renewalinfo_lookup True and cahandler with lookup_renewalinfo
         self.renewalinfo.config.renewalinfo_lookup = True
         self.renewalinfo.config.acme_url = "https://acme.example.com"
@@ -717,10 +771,11 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertIn("data", result)
             self.assertEqual(result["data"], {"foo": "bar"})
 
-    def test_038_update_ownership_lookup_error_returns_500(self):
+    def test_047_update_ownership_lookup_error_returns_500(self):
         """update() returns 500 when certificate ownership lookup fails"""
         renewalinfo = self.renewalinfo
         renewalinfo.message = MagicMock()
+        renewalinfo.message.prepare_response.side_effect = _acme_prepare_response
         renewalinfo.message.check.return_value = (
             200,
             None,
@@ -734,6 +789,28 @@ class TestRenewalinfo(unittest.TestCase):
         )
         result = renewalinfo.update("content")
         self.assertEqual(result["code"], 500)
+        self.assertEqual(
+            result["data"]["type"], "urn:ietf:params:acme:error:serverInternal"
+        )
+
+    def test_048_update_cross_account_returns_403_problem(self):
+        """update() returns an ACME unauthorized problem for a foreign certid"""
+        self.mock_message.check.return_value = (
+            200,
+            None,
+            None,
+            None,
+            {"certid": "cid", "replaced": True},
+            "attacker",
+        )
+        self.renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
+            return_value={"name": "cert1", "order__account__name": "victim"}
+        )
+        result = self.renewalinfo.update("content")
+        self.assertEqual(result["code"], 403)
+        self.assertEqual(result["data"]["type"], UNAUTHORIZED_TYPE)
+        self.assertEqual(result["data"]["detail"], OWNERSHIP_DENIED_DETAIL)
+        self.mock_repository.mark_certificate_replaced.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/test_renewalinfo.py
+++ b/test/test_renewalinfo.py
@@ -14,6 +14,9 @@ from acme2certifier.acme_srv.renewalinfo import (
     RenewalinfoConfig,
     RenewalinfoRepository,
 )
+from acme2certifier.acme_srv.helpers.resource_ownership import (
+    ResourceOwnershipLookupError,
+)
 
 
 class TestRenewalinfoConfig(unittest.TestCase):
@@ -37,9 +40,8 @@ class TestRenewalinfoRepository(unittest.TestCase):
 
     def test_002_get_certificate_by_certid_exception(self):
         self.mock_dbstore.certificate_lookup.side_effect = Exception("fail")
-        result = self.repo.get_certificate_by_certid("abc")
-        self.assertIsNone(result)
-        self.logger.critical.assert_called()
+        with self.assertRaises(ResourceOwnershipLookupError):
+            self.repo.get_certificate_by_certid("abc")
 
     def test_003_get_certificates_by_serial_success(self):
         self.mock_dbstore.certificates_search.return_value = [{"foo": "bar"}]
@@ -159,11 +161,12 @@ class TestRenewalinfo(unittest.TestCase):
             None,
             None,
             {"certid": "foo", "replaced": True},
-            None,
+            "owner-acct",
         )
         self.mock_repository.get_certificate_by_certid.return_value = {
             "expire_uts": 100000,
             "issue_uts": 90000,
+            "order__account__name": "owner-acct",
         }
         self.mock_repository.add_certificate.return_value = True
         with patch(
@@ -557,10 +560,10 @@ class TestRenewalinfo(unittest.TestCase):
             None,
             None,
             {"certid": "foo", "replaced": True},
-            None,
+            "owner",
         )
         renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
-            return_value={"foo": "bar"}
+            return_value={"foo": "bar", "order__account__name": "owner"}
         )
         renewalinfo.repository.add_certificate.return_value = True
         result = renewalinfo.update("content")
@@ -713,6 +716,24 @@ class TestRenewalinfo(unittest.TestCase):
             self.assertEqual(result["code"], 201)
             self.assertIn("data", result)
             self.assertEqual(result["data"], {"foo": "bar"})
+
+    def test_038_update_ownership_lookup_error_returns_500(self):
+        """update() returns 500 when certificate ownership lookup fails"""
+        renewalinfo = self.renewalinfo
+        renewalinfo.message = MagicMock()
+        renewalinfo.message.check.return_value = (
+            200,
+            None,
+            None,
+            None,
+            {"certid": "cid", "replaced": True},
+            "owner",
+        )
+        renewalinfo._lookup_certificate_by_renewalinfo = MagicMock(
+            side_effect=ResourceOwnershipLookupError("db")
+        )
+        result = renewalinfo.update("content")
+        self.assertEqual(result["code"], 500)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Authenticated access to orders, authorizations, challenges, and certificates is denied when the requester is not the owning account (403 unauthorized).
- Certificate CSR reuse is limited to certificates owned by the same account.
- ARI renewalInfo POST (replaced) requires ownership of the certid; failures return ACME problem documents (Django/WSGI include the JSON body) 
- replaced is set via a dedicated DB update that does not rewrite other certificate columns.
