### PR TITLE
[min] Fix ARI certid parse and lookup error responses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,20 @@ This is a high-level summary of the most important changes. For a full list of
 changes, see the [git commit log](https://github.com/grindsa/acme2certifier/commits)
 and pick the appropriate release branch.
 
+## Changes in 0.45.3
+
+**Bug Fixes and Improvements**:
+
+- #380 - Unknown or empty ARI lookups now return an ACME problem document instead of a bare malformed string.
+- #381 - Extract ARI certid from the URL path (last path segment), so GET /acme/renewal-info/{certid} still works when the request scheme/host does not match server_name (typical reverse-proxy http vs https mismatch).
+- CA lookup that returns 2xx with an empty body is treated as certificate not found (404).
+
+## Changes in 0.45.2
+
+**Bug Fixes and Improvements**:
+
+- Remove Django admin URL mount; `django.contrib.admin` was already absent from `INSTALLED_APPS`, so 0.45.1 Django deployments failed at startup with `LookupError: No installed app with label 'admin'` (nginx/uWSGI 502 on `/directory`)
+
 ## Changes in 0.45.1
 
 **Bug Fixes and Improvements**:

--- a/acme2certifier/acme_srv/renewalinfo.py
+++ b/acme2certifier/acme_srv/renewalinfo.py
@@ -19,6 +19,7 @@ from acme2certifier.acme_srv.helper import (
     b64_url_recode,
     b64_decode,
     duration_to_seconds,
+    parse_url,
 )
 from acme2certifier.acme_srv.helpers.global_variables import DB_ERROR_MSG
 from acme2certifier.acme_srv.helpers.resource_ownership import (
@@ -364,12 +365,13 @@ class Renewalinfo(object):
         return renewalinfo_dic
 
     def _parse_renewalinfo_string_from_url(self, url: str) -> str:
+        """Extract ARI certid from a request URL, ignoring scheme and host."""
         self.logger.debug("Renewalinfo._parse_renewalinfo_string_from_url()")
-        url = url.replace(
-            f'{self.server_name}{self.path_dic["renewalinfo"].rstrip("/")}', ""
+        url_dic = parse_url(self.logger, url)
+        path = url_dic.get("path") or url
+        renewalinfo_string = string_sanitize(
+            self.logger, path.rstrip("/").rsplit("/", 1)[-1]
         )
-        url = url.lstrip("/")
-        renewalinfo_string = string_sanitize(self.logger, url)
         self.logger.debug(
             "Renewalinfo._parse_renewalinfo_string_from_url() - renewalinfo_string: %s",
             renewalinfo_string,
@@ -434,9 +436,7 @@ class Renewalinfo(object):
             return {
                 "code": rc_code,
                 "data": renewalinfo_dic,
-                "header": {
-                    "Retry-After": f"{self.config.retry_after_timeout}"
-                },
+                "header": {"Retry-After": f"{self.config.retry_after_timeout}"},
             }
         if not rc_code or rc_code < 400:
             rc_code = 404
@@ -445,9 +445,7 @@ class Renewalinfo(object):
             if rc_code == 404
             else "failed to get renewal information"
         )
-        return self._problem_response(
-            (rc_code, self.err_msg_dic["malformed"], detail)
-        )
+        return self._problem_response((rc_code, self.err_msg_dic["malformed"], detail))
 
     def _problem_response(
         self,

--- a/acme2certifier/acme_srv/renewalinfo.py
+++ b/acme2certifier/acme_srv/renewalinfo.py
@@ -430,15 +430,24 @@ class Renewalinfo(object):
                 self.logger.error("Error when getting renewal information: %s", err_)
                 renewalinfo_dic = {}
                 rc_code = 400
-        response_dic = {"code": rc_code}
         if renewalinfo_dic:
-            response_dic["data"] = renewalinfo_dic
-            response_dic["header"] = {
-                "Retry-After": f"{self.config.retry_after_timeout}"
+            return {
+                "code": rc_code,
+                "data": renewalinfo_dic,
+                "header": {
+                    "Retry-After": f"{self.config.retry_after_timeout}"
+                },
             }
-        else:
-            response_dic["data"] = self.err_msg_dic["malformed"]
-        return response_dic
+        if not rc_code or rc_code < 400:
+            rc_code = 404
+        detail = (
+            "certificate not found"
+            if rc_code == 404
+            else "failed to get renewal information"
+        )
+        return self._problem_response(
+            (rc_code, self.err_msg_dic["malformed"], detail)
+        )
 
     def _problem_response(
         self,

--- a/acme2certifier/acme_srv/version.py
+++ b/acme2certifier/acme_srv/version.py
@@ -4,5 +4,5 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) pyproject.toml can read it via tool.setuptools.dynamic
 # 3) runtime code can import the same value
-__version__ = "0.45.1"
+__version__ = "0.45.3"
 __dbversion__ = "0.41"

--- a/test/test_django_views.py
+++ b/test/test_django_views.py
@@ -661,6 +661,37 @@ class TestDjangoViews(unittest.TestCase):
         self.assertTrue(inst.update.called)
         self.assertTrue(mock_log.called)
 
+    @patch(f"{_VIEWS}.log_response")
+    @patch(f"{_VIEWS}.get_url", return_value="http://srv")
+    def test_045_renewalinfo_get_404_problem_document_issue380(
+        self, _url, mock_log
+    ) -> None:
+        """GET ARI 404 serializes an ACME problem document (issue #380)."""
+        cm, inst = self._cm(
+            get={
+                "code": 404,
+                "data": {
+                    "status": 404,
+                    "type": "urn:ietf:params:acme:error:malformed",
+                    "detail": "certificate not found",
+                },
+            }
+        )
+        with patch(f"{_VIEWS}.Renewalinfo", return_value=cm):
+            resp = self.views.renewalinfo(
+                self._meta(
+                    self.rf.get(
+                        "/acme/renewal-info/42Z0u3BojSxdTg6mSo-bNyKcgpI.AOpUG6fnb-IW4i8A52l4K28"
+                    )
+                )
+            )
+        self.assertEqual(404, resp.status_code)
+        body = json.loads(resp.content)
+        self.assertEqual("urn:ietf:params:acme:error:malformed", body["type"])
+        self.assertEqual("certificate not found", body["detail"])
+        self.assertTrue(inst.get.called)
+        self.assertTrue(mock_log.called)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -1220,7 +1220,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         value = None
         self.assertFalse(self.convert_string_to_byte(value))
 
-    def test_097_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_097_helper_get_url(self, _mock_load_cfg):
         """get_url https"""
         data_dic = {
             "HTTP_HOST": "http_host",
@@ -1229,7 +1233,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         }
         self.assertEqual("https://http_host", self.get_url(data_dic, False))
 
-    def test_098_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_098_helper_get_url(self, _mock_load_cfg):
         """get_url http"""
         data_dic = {
             "HTTP_HOST": "http_host",
@@ -1238,7 +1246,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         }
         self.assertEqual("http://http_host", self.get_url(data_dic, False))
 
-    def test_099_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_099_helper_get_url(self, _mock_load_cfg):
         """get_url http wsgi.scheme"""
         data_dic = {
             "HTTP_HOST": "http_host",
@@ -1248,12 +1260,20 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         }
         self.assertEqual("wsgi.url_scheme://http_host", self.get_url(data_dic, False))
 
-    def test_100_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_100_helper_get_url(self, _mock_load_cfg):
         """get_url https include_path true bot no pathinfo"""
         data_dic = {"HTTP_HOST": "http_host", "SERVER_PORT": "443"}
         self.assertEqual("https://http_host", self.get_url(data_dic, True))
 
-    def test_101_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_101_helper_get_url(self, _mock_load_cfg):
         """get_url https and path info"""
         data_dic = {
             "HTTP_HOST": "http_host",
@@ -1262,7 +1282,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         }
         self.assertEqual("https://http_hostpath_info", self.get_url(data_dic, True))
 
-    def test_102_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_102_helper_get_url(self, _mock_load_cfg):
         """get_url wsgi.url and pathinfo"""
         data_dic = {
             "HTTP_HOST": "http_host",
@@ -1274,7 +1298,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
             "wsgi.url_scheme://http_hostpath_info", self.get_url(data_dic, True)
         )
 
-    def test_103_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_103_helper_get_url(self, _mock_load_cfg):
         """get_url http and pathinfo"""
         data_dic = {
             "HTTP_HOST": "http_host",
@@ -1283,12 +1311,20 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         }
         self.assertEqual("http://http_hostpath_info", self.get_url(data_dic, True))
 
-    def test_104_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_104_helper_get_url(self, _mock_load_cfg):
         """get_url without hostinfo"""
         data_dic = {"SERVER_PORT": "80", "PATH_INFO": "path_info"}
         self.assertEqual("http://localhost", self.get_url(data_dic, False))
 
-    def test_105_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_105_helper_get_url(self, _mock_load_cfg):
         """get_url without SERVER_PORT"""
         data_dic = {"HTTP_HOST": "http_host"}
         self.assertEqual("http://http_host", self.get_url(data_dic, True))
@@ -1909,7 +1945,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         """validate email containing "-" in user"""
         self.assertTrue(self.validate_email(self.logger, "foo-foo@example.com"))
 
-    def test_149_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_149_helper_get_url(self, _mock_load_cfg):
         """get_url with xforwarded https"""
         data_dic = {
             "HTTP_X_FORWARDED_PROTO": "https",
@@ -1919,7 +1959,11 @@ Otme28/kpJxmW3iOMkqN9BE+qAkggFDeNoxPtXRyP2PrRgbaj94e1uznsyni7CYw
         }
         self.assertEqual("https://http_host", self.get_url(data_dic, False))
 
-    def test_150_helper_get_url(self):
+    @patch(
+        "acme2certifier.acme_srv.helpers.network.load_config",
+        return_value=configparser.ConfigParser(),
+    )
+    def test_150_helper_get_url(self, _mock_load_cfg):
         """get_url with xforwarded http"""
         data_dic = {
             "HTTP_X_FORWARDED_PROTO": "http",

--- a/test/test_renewalinfo.py
+++ b/test/test_renewalinfo.py
@@ -999,6 +999,52 @@ class TestRenewalinfo(unittest.TestCase):
         self.assertEqual(result["code"], 400)
         self.assertEqual(result["data"]["detail"], "certificate update failed")
 
+    def test_062_parse_renewalinfo_string_from_url_path_only(self):
+        result = self.renewalinfo._parse_renewalinfo_string_from_url(
+            "/acme/renewal-info/foo"
+        )
+        self.assertEqual(result, "foo")
+
+    def test_063_parse_renewalinfo_string_from_url_scheme_mismatch(self):
+        """Reverse proxy: request is http while server_name is https (#381)."""
+        self.renewalinfo.server_name = "https://127.0.0.1:8001"
+        ident = "42Z0u3BojSxdTg6mSo-bNyKcgpI.AOpUG6fnb-IW4i8A52l4K28"
+        result = self.renewalinfo._parse_renewalinfo_string_from_url(
+            f"http://127.0.0.1:8001/acme/renewal-info/{ident}"
+        )
+        self.assertEqual(result, ident)
+
+    def test_064_parse_renewalinfo_string_from_url_query_and_slash(self):
+        ident = "42Z0u3BojSxdTg6mSo-bNyKcgpI.AOpUG6fnb-IW4i8A52l4K28"
+        result = self.renewalinfo._parse_renewalinfo_string_from_url(
+            f"https://acme.example.com/acme/renewal-info/{ident}/?x=1"
+        )
+        self.assertEqual(result, ident)
+
+    def test_065_parse_renewalinfo_string_from_url_bare_ident(self):
+        ident = "42Z0u3BojSxdTg6mSo-bNyKcgpI.AOpUG6fnb-IW4i8A52l4K28"
+        result = self.renewalinfo._parse_renewalinfo_string_from_url(ident)
+        self.assertEqual(result, ident)
+
+    def test_066_get_cahandler_empty_result_forces_404(self):
+        """CA lookup with 2xx and empty body is treated as certificate not found."""
+        self.renewalinfo.config.renewalinfo_lookup = True
+        self.renewalinfo.config.acme_url = "https://acme.example.com"
+        mock_cahandler_instance = MagicMock()
+        mock_cahandler_instance.lookup_renewalinfo.return_value = (200, {})
+        mock_cahandler_class = MagicMock()
+        mock_cahandler_class.return_value.__enter__.return_value = (
+            mock_cahandler_instance
+        )
+        mock_cahandler_class.return_value.__exit__.return_value = None
+        self.renewalinfo.cahandler = mock_cahandler_class
+        with patch(
+            "acme2certifier.acme_srv.renewalinfo.string_sanitize", return_value="foo"
+        ):
+            result = self.renewalinfo.get("/acme/renewal-info/foo")
+        self.assertEqual(result["code"], 404)
+        self.assertEqual(result["data"]["detail"], "certificate not found")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_renewalinfo.py
+++ b/test/test_renewalinfo.py
@@ -208,7 +208,14 @@ class TestRenewalinfo(unittest.TestCase):
         ):
             result = self.renewalinfo.get("/acme/renewal-info/foo")
             self.assertEqual(result["code"], 404)
-            self.assertEqual(result["data"], "malf")
+            self.assertEqual(
+                result["data"],
+                {
+                    "status": 404,
+                    "type": "malf",
+                    "detail": "certificate not found",
+                },
+            )
 
     def test_017_get_returns_400_on_exception(self):
         self.mock_repository.get_housekeeping_param.return_value = True
@@ -220,7 +227,14 @@ class TestRenewalinfo(unittest.TestCase):
         ):
             result = self.renewalinfo.get("/acme/renewal-info/foo")
             self.assertEqual(result["code"], 400)
-            self.assertEqual(result["data"], "malf")
+            self.assertEqual(
+                result["data"],
+                {
+                    "status": 400,
+                    "type": "malf",
+                    "detail": "failed to get renewal information",
+                },
+            )
 
     def test_018_update_success(self):
         self.mock_message.check.return_value = (
@@ -684,7 +698,14 @@ class TestRenewalinfo(unittest.TestCase):
         ):
             result = renewalinfo.get("/acme/renewal-info/foo")
             self.assertEqual(result["code"], 404)
-            self.assertEqual(result["data"], "malf")
+            self.assertEqual(
+                result["data"],
+                {
+                    "status": 404,
+                    "type": "malf",
+                    "detail": "certificate not found",
+                },
+            )
 
     def test_045_get_compat_400(self):
         renewalinfo = self.renewalinfo
@@ -698,7 +719,14 @@ class TestRenewalinfo(unittest.TestCase):
         ):
             result = renewalinfo.get("/acme/renewal-info/foo")
             self.assertEqual(result["code"], 400)
-            self.assertEqual(result["data"], "malf")
+            self.assertEqual(
+                result["data"],
+                {
+                    "status": 400,
+                    "type": "malf",
+                    "detail": "failed to get renewal information",
+                },
+            )
 
     def test_046_update_compat_success(self):
         renewalinfo = self.renewalinfo

--- a/tools/min_sync/sync.py
+++ b/tools/min_sync/sync.py
@@ -546,9 +546,7 @@ def _finalize_sync(
             f"Push and open PR into `{target}` when ready:"
         )
         print(f"  git push -u origin {work_branch}")
-        print(
-            f"  gh pr create --base {target} --head {work_branch} --title '{title}'"
-        )
+        print(f"  gh pr create --base {target} --head {work_branch} --title '{title}'")
     return 0
 
 


### PR DESCRIPTION
- #381 - Extract ARI certid from the URL path (last path segment), so GET /acme/renewal-info/{certid} still works when the request scheme/host does not match server_name (typical reverse-proxy http vs https mismatch).
- #380 - Unknown or empty ARI lookups now return an ACME problem document instead of a bare malformed string.
- CA lookup that returns 2xx with an empty body is treated as certificate not found (404).