### PR TITLE
[min-devel] add Django DB TLS and support for remote MySQL/PostgreSQL instances

### DIFF
--- a/.github/actions/channel_rpm_setup/action.yml
+++ b/.github/actions/channel_rpm_setup/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: "Package name suffix after acme2certifier (empty on full branches, -min on min-*)"
     required: false
     default: ""
+  TLS:
+    description: "Enable TLS on the Django database server"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -86,6 +90,7 @@ runs:
         PYTHON_STACK: ${{ inputs.PYTHON_STACK }}
         DJANGO_DB: ${{ inputs.DJANGO_DB }}
         NAME_SUFFIX: ${{ inputs.NAME_SUFFIX }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Download RPM artifact by name from build run"
       uses: ./.github/actions/download_artifact

--- a/.github/actions/container_prep/action.yml
+++ b/.github/actions/container_prep/action.yml
@@ -24,6 +24,14 @@ inputs:
     description: "IPv6"
     required: true
     default: "false"
+  TLS:
+    description: "Enable TLS on the Django database server"
+    required: false
+    default: "false"
+  XCA_DB:
+    description: "Import XCA schema into a dedicated xca database"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -94,12 +102,16 @@ runs:
       uses: ./.github/actions/mariadb_prep
       with:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        TLS: ${{ inputs.TLS }}
+        XCA_DB: ${{ inputs.XCA_DB }}
 
     - name: "Instanciate Postgres"
       if: inputs.DJANGO_DB == 'psql'
       uses: ./.github/actions/psql_prep
       with:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        TLS: ${{ inputs.TLS }}
+        XCA_DB: ${{ inputs.XCA_DB }}
 
     - name: "Instanciate MSSQL"
       if: inputs.DJANGO_DB == 'mssql'

--- a/.github/actions/deb_prep/action.yml
+++ b/.github/actions/deb_prep/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "systemd Ubuntu image for DEB install tests"
     required: false
     default: "grindsa/systemd-ubuntu:24.04"
+  TLS:
+    description: "Enable TLS on the Django database server"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -90,12 +94,14 @@ runs:
       uses: ./.github/actions/mariadb_prep
       with:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Instanciate Postgres"
       if: inputs.DJANGO_DB == 'psql'
       uses: ./.github/actions/psql_prep
       with:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Prepare addditional environment for MSSQL"
       if: inputs.DJANGO_DB == 'mssql'

--- a/.github/actions/mariadb_prep/action.yml
+++ b/.github/actions/mariadb_prep/action.yml
@@ -56,9 +56,12 @@ runs:
         SSL_DIR=/tmp/data/mariadb/ssl
         sudo mkdir -p "$SSL_DIR"
         sudo chown "$(id -u):$(id -g)" "$SSL_DIR"
+        # OpenSSL 3.x / Python ssl reject CA certs without keyUsage=keyCertSign.
         openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
           -keyout "$SSL_DIR/ca-key.pem" -out "$SSL_DIR/ca.pem" \
-          -subj "/CN=mariadb-test-ca"
+          -subj "/CN=mariadb-test-ca" \
+          -addext "basicConstraints=critical,CA:TRUE" \
+          -addext "keyUsage=critical,keyCertSign,cRLSign"
         openssl req -newkey rsa:2048 -nodes \
           -keyout "$SSL_DIR/server-key.pem" -out "$SSL_DIR/server.csr" \
           -subj "/CN=mariadbsrv" \
@@ -168,20 +171,8 @@ runs:
         set -euo pipefail
         XDB="${GITHUB_WORKSPACE}/test/ca/acme2certifier-clean.xdb"
         test -f "$XDB"
-        RAW=/tmp/xca-raw.sql
-        if ! sqlite3 --escape off "$XDB" .dump > "$RAW" 2>/tmp/sqlite-dump.err; then
-          echo "sqlite3 --escape off failed, retrying without it"
-          cat /tmp/sqlite-dump.err || true
-          sqlite3 "$XDB" .dump > "$RAW"
-        fi
-        {
-          echo "SET SESSION SQL_MODE='ANSI';"
-          grep -v -E '^(PRAGMA |BEGIN TRANSACTION;|CREATE TABLE sqlite_sequence|INSERT INTO sqlite_sequence)' "$RAW"
-        } > /tmp/xca-mariadb.sql
-        if grep -q 'unistr(' /tmp/xca-mariadb.sql; then
-          echo "sqlite dump still contains unistr(); need sqlite3 --escape off" >&2
-          exit 1
-        fi
+        python3 "${GITHUB_WORKSPACE}/.github/scripts/xca_sqlite_dump.py" \
+          --dialect mysql "$XDB" -o /tmp/xca-mariadb.sql
         docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"DROP DATABASE IF EXISTS xca;"
         docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"CREATE DATABASE xca CHARACTER SET UTF8;"
         docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"GRANT ALL PRIVILEGES ON xca.* TO 'acme2certifier'@'%'; FLUSH PRIVILEGES;"

--- a/.github/actions/mariadb_prep/action.yml
+++ b/.github/actions/mariadb_prep/action.yml
@@ -13,6 +13,25 @@ inputs:
     description: "Red Hat version"
     required: false
     default: "9"
+  TLS:
+    description: "Generate a self-signed CA/server cert and enable TLS (not required for clients)"
+    required: false
+    default: "false"
+  XCA_DB:
+    description: "Create database xca and import test/ca/acme2certifier-clean.xdb"
+    required: false
+    default: "false"
+
+outputs:
+  SSL_CA:
+    description: "Host path to the TLS CA certificate (empty unless TLS=true)"
+    value: ${{ steps.gen_tls.outputs.SSL_CA }}
+  SSL_CERT:
+    description: "Host path to the TLS server certificate (empty unless TLS=true)"
+    value: ${{ steps.gen_tls.outputs.SSL_CERT }}
+  SSL_KEY:
+    description: "Host path to the TLS server key (empty unless TLS=true)"
+    value: ${{ steps.gen_tls.outputs.SSL_KEY }}
 
 runs:
   using: "composite"
@@ -23,31 +42,88 @@ runs:
       with:
         IMAGE: mariadb:lts
 
-    - name: "Instanciate Mariadb"
-      if: inputs.INSTANCIATE == 'true' && inputs.RH_VERSION != '8'
-      run: |
-        echo "Instanciate mariadb for RH_VERSION $RH_VERSION"
-        docker run --name mariadbsrv --network acme -e MARIADB_ROOT_PASSWORD=foobar -d mariadb:lts
-      shell: bash
-      env:
-        NAME_SPACE: ${{ inputs.NAME_SPACE }}
-        RH_VERSION: ${{ inputs.RH_VERSION }}
-
     - name: "Pull Mariadb image (RHEL8)"
       if: inputs.INSTANCIATE == 'true' && inputs.RH_VERSION == '8'
       uses: ./.github/actions/docker_pull
       with:
         IMAGE: mariadb:10.6-ubi9
 
-    - name: "Instanciate Mariadb for RHEL8"
-      if: inputs.INSTANCIATE == 'true' && inputs.RH_VERSION == '8'
+    - name: "Generate TLS certificates"
+      id: gen_tls
+      if: inputs.INSTANCIATE == 'true' && inputs.TLS == 'true'
       run: |
-        echo "Instanciate mariadb 10 for RH_VERSION $RH_VERSION"
-        docker run --name mariadbsrv --network acme -e MARIADB_ROOT_PASSWORD=foobar -d mariadb:10.6-ubi9
+        set -euo pipefail
+        SSL_DIR=/tmp/data/mariadb/ssl
+        sudo mkdir -p "$SSL_DIR"
+        sudo chown "$(id -u):$(id -g)" "$SSL_DIR"
+        openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+          -keyout "$SSL_DIR/ca-key.pem" -out "$SSL_DIR/ca.pem" \
+          -subj "/CN=mariadb-test-ca"
+        openssl req -newkey rsa:2048 -nodes \
+          -keyout "$SSL_DIR/server-key.pem" -out "$SSL_DIR/server.csr" \
+          -subj "/CN=mariadbsrv" \
+          -addext "subjectAltName=DNS:mariadbsrv,DNS:mariadbsrv.acme,DNS:localhost,IP:127.0.0.1" \
+          -addext "extendedKeyUsage=serverAuth" \
+          -addext "keyUsage=digitalSignature,keyEncipherment"
+        openssl x509 -req -in "$SSL_DIR/server.csr" \
+          -CA "$SSL_DIR/ca.pem" -CAkey "$SSL_DIR/ca-key.pem" -CAcreateserial \
+          -out "$SSL_DIR/server-cert.pem" -days 30 -sha256 -copy_extensions copy
+        # mysql uid differs across images (999 vs 27); keep the key world-readable.
+        chmod 644 "$SSL_DIR/ca.pem" "$SSL_DIR/server-cert.pem" "$SSL_DIR/server-key.pem"
+        {
+          echo "SSL_CA=$SSL_DIR/ca.pem"
+          echo "SSL_CERT=$SSL_DIR/server-cert.pem"
+          echo "SSL_KEY=$SSL_DIR/server-key.pem"
+        } >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: "Instanciate Mariadb"
+      if: inputs.INSTANCIATE == 'true' && inputs.RH_VERSION != '8'
+      run: |
+        set -euo pipefail
+        echo "Instanciate mariadb for RH_VERSION $RH_VERSION"
+        extra=()
+        ssl_opts=()
+        if [ "$TLS" = "true" ]; then
+          extra+=(-v /tmp/data/mariadb/ssl:/etc/mysql/ssl:ro)
+          ssl_opts+=(
+            --ssl-ca=/etc/mysql/ssl/ca.pem
+            --ssl-cert=/etc/mysql/ssl/server-cert.pem
+            --ssl-key=/etc/mysql/ssl/server-key.pem
+          )
+        fi
+        docker run --name mariadbsrv --network acme --network-alias mariadbsrv.acme \
+          -e MARIADB_ROOT_PASSWORD=foobar \
+          "${extra[@]}" -d mariadb:lts "${ssl_opts[@]}"
       shell: bash
       env:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
         RH_VERSION: ${{ inputs.RH_VERSION }}
+        TLS: ${{ inputs.TLS }}
+
+    - name: "Instanciate Mariadb for RHEL8"
+      if: inputs.INSTANCIATE == 'true' && inputs.RH_VERSION == '8'
+      run: |
+        set -euo pipefail
+        echo "Instanciate mariadb 10 for RH_VERSION $RH_VERSION"
+        extra=()
+        ssl_opts=()
+        if [ "$TLS" = "true" ]; then
+          extra+=(-v /tmp/data/mariadb/ssl:/etc/mysql/ssl:ro)
+          ssl_opts+=(
+            --ssl-ca=/etc/mysql/ssl/ca.pem
+            --ssl-cert=/etc/mysql/ssl/server-cert.pem
+            --ssl-key=/etc/mysql/ssl/server-key.pem
+          )
+        fi
+        docker run --name mariadbsrv --network acme --network-alias mariadbsrv.acme \
+          -e MARIADB_ROOT_PASSWORD=foobar \
+          "${extra[@]}" -d mariadb:10.6-ubi9 "${ssl_opts[@]}"
+      shell: bash
+      env:
+        NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        RH_VERSION: ${{ inputs.RH_VERSION }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Wait for mariadb readiness"
       if: inputs.INSTANCIATE == 'true'
@@ -84,4 +160,30 @@ runs:
         docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"CREATE DATABASE acme2certifier CHARACTER SET UTF8;"
         docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"GRANT ALL PRIVILEGES ON acme2certifier.* TO 'acme2certifier'@'%' IDENTIFIED BY '1mmSvDFl';"
         docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"FLUSH PRIVILEGES;"
+      shell: bash
+
+    - name: "Import XCA schema"
+      if: inputs.INSTANCIATE == 'true' && inputs.XCA_DB == 'true'
+      run: |
+        set -euo pipefail
+        XDB="${GITHUB_WORKSPACE}/test/ca/acme2certifier-clean.xdb"
+        test -f "$XDB"
+        RAW=/tmp/xca-raw.sql
+        if ! sqlite3 --escape off "$XDB" .dump > "$RAW" 2>/tmp/sqlite-dump.err; then
+          echo "sqlite3 --escape off failed, retrying without it"
+          cat /tmp/sqlite-dump.err || true
+          sqlite3 "$XDB" .dump > "$RAW"
+        fi
+        {
+          echo "SET SESSION SQL_MODE='ANSI';"
+          grep -v -E '^(PRAGMA |BEGIN TRANSACTION;|CREATE TABLE sqlite_sequence|INSERT INTO sqlite_sequence)' "$RAW"
+        } > /tmp/xca-mariadb.sql
+        if grep -q 'unistr(' /tmp/xca-mariadb.sql; then
+          echo "sqlite dump still contains unistr(); need sqlite3 --escape off" >&2
+          exit 1
+        fi
+        docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"DROP DATABASE IF EXISTS xca;"
+        docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"CREATE DATABASE xca CHARACTER SET UTF8;"
+        docker exec mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp -e"GRANT ALL PRIVILEGES ON xca.* TO 'acme2certifier'@'%'; FLUSH PRIVILEGES;"
+        docker exec -i mariadbsrv mariadb -h127.0.0.1 -uroot -pfoobar --protocol=tcp xca < /tmp/xca-mariadb.sql
       shell: bash

--- a/.github/actions/psql_prep/action.yml
+++ b/.github/actions/psql_prep/action.yml
@@ -9,6 +9,25 @@ inputs:
     description: "Instanciate mariadb"
     required: true
     default: "true"
+  TLS:
+    description: "Generate a self-signed CA/server cert and enable TLS (not required for clients)"
+    required: false
+    default: "false"
+  XCA_DB:
+    description: "Create database xca and import test/ca/acme2certifier-clean.xdb"
+    required: false
+    default: "false"
+
+outputs:
+  SSL_CA:
+    description: "Host path to the TLS CA certificate (empty unless TLS=true)"
+    value: ${{ steps.gen_tls.outputs.SSL_CA }}
+  SSL_CERT:
+    description: "Host path to the TLS server certificate (empty unless TLS=true)"
+    value: ${{ steps.gen_tls.outputs.SSL_CERT }}
+  SSL_KEY:
+    description: "Host path to the TLS server key (empty unless TLS=true)"
+    value: ${{ steps.gen_tls.outputs.SSL_KEY }}
 
 runs:
   using: "composite"
@@ -29,14 +48,60 @@ runs:
       with:
         IMAGE: postgres
 
+    - name: "Generate TLS certificates"
+      id: gen_tls
+      if: inputs.INSTANCIATE == 'true' && inputs.TLS == 'true'
+      run: |
+        set -euo pipefail
+        SSL_DIR=/tmp/data/pgsql/ssl
+        sudo mkdir -p "$SSL_DIR"
+        sudo chown "$(id -u):$(id -g)" "$SSL_DIR"
+        openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+          -keyout "$SSL_DIR/ca-key.pem" -out "$SSL_DIR/ca.pem" \
+          -subj "/CN=postgres-test-ca"
+        openssl req -newkey rsa:2048 -nodes \
+          -keyout "$SSL_DIR/server-key.pem" -out "$SSL_DIR/server.csr" \
+          -subj "/CN=postgresdbsrv" \
+          -addext "subjectAltName=DNS:postgresdbsrv,DNS:localhost,IP:127.0.0.1" \
+          -addext "extendedKeyUsage=serverAuth" \
+          -addext "keyUsage=digitalSignature,keyEncipherment"
+        openssl x509 -req -in "$SSL_DIR/server.csr" \
+          -CA "$SSL_DIR/ca.pem" -CAkey "$SSL_DIR/ca-key.pem" -CAcreateserial \
+          -out "$SSL_DIR/server-cert.pem" -days 30 -sha256 -copy_extensions copy
+        chmod 644 "$SSL_DIR/ca.pem" "$SSL_DIR/server-cert.pem"
+        # Official postgres image runs as uid 999; world-readable keys are rejected.
+        sudo chown 999:999 "$SSL_DIR/server-key.pem"
+        sudo chmod 600 "$SSL_DIR/server-key.pem"
+        {
+          echo "SSL_CA=$SSL_DIR/ca.pem"
+          echo "SSL_CERT=$SSL_DIR/server-cert.pem"
+          echo "SSL_KEY=$SSL_DIR/server-key.pem"
+        } >> "$GITHUB_OUTPUT"
+      shell: bash
+
     - name: "Install postgres"
       if: inputs.INSTANCIATE == 'true'
       working-directory: /tmp
       run: |
-        docker run --name postgresdbsrv --network $NAME_SPACE -e POSTGRES_PASSWORD=foobar -d postgres
+        set -euo pipefail
+        extra=()
+        ssl_opts=()
+        if [ "$TLS" = "true" ]; then
+          extra+=(-v /tmp/data/pgsql/ssl:/certs:ro)
+          ssl_opts+=(
+            -c ssl=on
+            -c ssl_cert_file=/certs/server-cert.pem
+            -c ssl_key_file=/certs/server-key.pem
+            -c ssl_ca_file=/certs/ca.pem
+          )
+        fi
+        docker run --name postgresdbsrv --network "$NAME_SPACE" \
+          -e POSTGRES_PASSWORD=foobar \
+          "${extra[@]}" -d postgres "${ssl_opts[@]}"
       shell: bash
       env:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Wait for postgres readiness"
       if: inputs.INSTANCIATE == 'true'
@@ -73,3 +138,23 @@ runs:
       shell: bash
       env:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+
+    - name: "Import XCA schema"
+      if: inputs.INSTANCIATE == 'true' && inputs.XCA_DB == 'true'
+      run: |
+        set -euo pipefail
+        XDB="${GITHUB_WORKSPACE}/test/ca/acme2certifier-clean.xdb"
+        test -f "$XDB"
+        RAW=/tmp/xca-raw.sql
+        if ! sqlite3 --escape off "$XDB" .dump > "$RAW" 2>/tmp/sqlite-dump.err; then
+          echo "sqlite3 --escape off failed, retrying without it"
+          cat /tmp/sqlite-dump.err || true
+          sqlite3 "$XDB" .dump > "$RAW"
+        fi
+        grep -v -E '^(PRAGMA |BEGIN TRANSACTION;|CREATE TABLE sqlite_sequence|INSERT INTO sqlite_sequence)' "$RAW" > /tmp/xca-pgsql.sql
+        docker exec postgresdbsrv psql -U postgres -c "DROP DATABASE IF EXISTS xca;"
+        docker exec postgresdbsrv psql -U postgres -c "CREATE DATABASE xca;"
+        docker exec postgresdbsrv psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE xca TO acme2certifier;"
+        docker exec -i postgresdbsrv psql -v ON_ERROR_STOP=1 -U postgres -d xca < /tmp/xca-pgsql.sql
+        docker exec postgresdbsrv psql -U postgres -d xca -c "GRANT ALL ON SCHEMA public TO acme2certifier; GRANT ALL ON ALL TABLES IN SCHEMA public TO acme2certifier; GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO acme2certifier;"
+      shell: bash

--- a/.github/actions/psql_prep/action.yml
+++ b/.github/actions/psql_prep/action.yml
@@ -56,9 +56,12 @@ runs:
         SSL_DIR=/tmp/data/pgsql/ssl
         sudo mkdir -p "$SSL_DIR"
         sudo chown "$(id -u):$(id -g)" "$SSL_DIR"
+        # OpenSSL 3.x / Python ssl reject CA certs without keyUsage=keyCertSign.
         openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
           -keyout "$SSL_DIR/ca-key.pem" -out "$SSL_DIR/ca.pem" \
-          -subj "/CN=postgres-test-ca"
+          -subj "/CN=postgres-test-ca" \
+          -addext "basicConstraints=critical,CA:TRUE" \
+          -addext "keyUsage=critical,keyCertSign,cRLSign"
         openssl req -newkey rsa:2048 -nodes \
           -keyout "$SSL_DIR/server-key.pem" -out "$SSL_DIR/server.csr" \
           -subj "/CN=postgresdbsrv" \
@@ -145,13 +148,8 @@ runs:
         set -euo pipefail
         XDB="${GITHUB_WORKSPACE}/test/ca/acme2certifier-clean.xdb"
         test -f "$XDB"
-        RAW=/tmp/xca-raw.sql
-        if ! sqlite3 --escape off "$XDB" .dump > "$RAW" 2>/tmp/sqlite-dump.err; then
-          echo "sqlite3 --escape off failed, retrying without it"
-          cat /tmp/sqlite-dump.err || true
-          sqlite3 "$XDB" .dump > "$RAW"
-        fi
-        grep -v -E '^(PRAGMA |BEGIN TRANSACTION;|CREATE TABLE sqlite_sequence|INSERT INTO sqlite_sequence)' "$RAW" > /tmp/xca-pgsql.sql
+        python3 "${GITHUB_WORKSPACE}/.github/scripts/xca_sqlite_dump.py" \
+          --dialect postgresql "$XDB" -o /tmp/xca-pgsql.sql
         docker exec postgresdbsrv psql -U postgres -c "DROP DATABASE IF EXISTS xca;"
         docker exec postgresdbsrv psql -U postgres -c "CREATE DATABASE xca;"
         docker exec postgresdbsrv psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE xca TO acme2certifier;"

--- a/.github/actions/rpm_prep/action.yml
+++ b/.github/actions/rpm_prep/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "Package name suffix after acme2certifier (empty on full branches, -min on min-*)"
     required: false
     default: ""
+  TLS:
+    description: "Enable TLS on the Django database server"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -227,12 +231,14 @@ runs:
       with:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
         RH_VERSION: ${{ inputs.RH_VERSION }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Instanciate Postgres"
       if: inputs.DJANGO_DB == 'psql'
       uses: ./.github/actions/psql_prep
       with:
         NAME_SPACE: ${{ inputs.NAME_SPACE }}
+        TLS: ${{ inputs.TLS }}
 
     - name: "Prepare and install MSSQL client stack"
       if: inputs.DJANGO_DB == 'mssql'

--- a/.github/actions/wf_specific/django/django_db_ssl/action.yml
+++ b/.github/actions/wf_specific/django/django_db_ssl/action.yml
@@ -45,6 +45,25 @@ runs:
         sudo mkdir -p "$VOLUME_DIR"
         sudo cp "$SSL_CA" "$VOLUME_DIR/db-ca.pem"
         sudo chmod 644 "$VOLUME_DIR/db-ca.pem"
+        if [ "$DJANGO_DB" = "psql" ]; then
+          # libpq probes $HOME/.postgresql/postgresql.crt unless sslcert/sslkey are
+          # set. After uWSGI setuid that path is /root/... (EACCES). Point both at
+          # readable volume files instead of changing HOME.
+          SSL_DIR=$(dirname "$SSL_CA")
+          test -f "$SSL_DIR/ca-key.pem"
+          openssl req -newkey rsa:2048 -nodes \
+            -keyout /tmp/a2c-db-client-key.pem \
+            -out /tmp/a2c-db-client.csr \
+            -subj "/CN=a2c-django-db-client"
+          openssl x509 -req -in /tmp/a2c-db-client.csr \
+            -CA "$SSL_CA" -CAkey "$SSL_DIR/ca-key.pem" -CAcreateserial \
+            -out /tmp/a2c-db-client-cert.pem -days 30 -sha256
+          sudo cp /tmp/a2c-db-client-cert.pem "$VOLUME_DIR/db-client-cert.pem"
+          sudo cp /tmp/a2c-db-client-key.pem "$VOLUME_DIR/db-client-key.pem"
+          sudo chmod 644 "$VOLUME_DIR/db-client-cert.pem"
+          # libpq refuses a client key with group/world access (644).
+          sudo chmod 600 "$VOLUME_DIR/db-client-key.pem"
+        fi
         # Files were staged with sudo; patch as root.
         # shellcheck disable=SC2086
         sudo python3 "${GITHUB_WORKSPACE}/.github/scripts/patch_django_db_ssl.py" \

--- a/.github/actions/wf_specific/django/django_db_ssl/action.yml
+++ b/.github/actions/wf_specific/django/django_db_ssl/action.yml
@@ -1,0 +1,54 @@
+name: "django_db_ssl"
+description: "Stage DB TLS CA on the a2c volume and patch Django DATABASES OPTIONS"
+inputs:
+  DJANGO_DB:
+    description: "Django database (mariadb or psql)"
+    required: true
+  SETTINGS_FILE:
+    description: "Whitespace-separated path(s) to settings.py to patch"
+    required: true
+  VOLUME_DIR:
+    description: "Host directory mounted as the a2c volume"
+    required: true
+  CA_RUNTIME_PATH:
+    description: "Path Django opens at runtime for the CA PEM"
+    required: true
+  SSL_CA:
+    description: "Host path to the TLS CA certificate (empty uses mariadb/psql default)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Stage DB CA and patch Django TLS OPTIONS"
+      run: |
+        set -euo pipefail
+        DJANGO_DB="${{ inputs.DJANGO_DB }}"
+        case "$DJANGO_DB" in
+          mariadb|psql) ;;
+          *)
+            echo "ERROR: DJANGO_DB must be mariadb or psql (got: $DJANGO_DB)" >&2
+            exit 1
+            ;;
+        esac
+        SSL_CA="${{ inputs.SSL_CA }}"
+        if [ -z "$SSL_CA" ]; then
+          if [ "$DJANGO_DB" = "mariadb" ]; then
+            SSL_CA=/tmp/data/mariadb/ssl/ca.pem
+          else
+            SSL_CA=/tmp/data/pgsql/ssl/ca.pem
+          fi
+        fi
+        test -f "$SSL_CA"
+        VOLUME_DIR="${{ inputs.VOLUME_DIR }}"
+        sudo mkdir -p "$VOLUME_DIR"
+        sudo cp "$SSL_CA" "$VOLUME_DIR/db-ca.pem"
+        sudo chmod 644 "$VOLUME_DIR/db-ca.pem"
+        # Files were staged with sudo; patch as root.
+        # shellcheck disable=SC2086
+        sudo python3 "${GITHUB_WORKSPACE}/.github/scripts/patch_django_db_ssl.py" \
+          --django-db "$DJANGO_DB" \
+          --ca-runtime-path "${{ inputs.CA_RUNTIME_PATH }}" \
+          ${{ inputs.SETTINGS_FILE }}
+      shell: bash

--- a/.github/actions/wf_specific/django/django_db_ssl_verify/action.yml
+++ b/.github/actions/wf_specific/django/django_db_ssl_verify/action.yml
@@ -1,0 +1,62 @@
+name: "django_db_ssl_verify"
+description: "Assert Django's live DATABASES session is TLS-encrypted"
+inputs:
+  CONTAINER:
+    description: "acme2certifier container name"
+    required: false
+    default: "acme-srv"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Verify Django DB session is TLS"
+      run: |
+        set -euo pipefail
+        CONTAINER="${{ inputs.CONTAINER }}"
+        docker cp "${GITHUB_WORKSPACE}/.github/scripts/django_db_ssl_verify.py" \
+          "${CONTAINER}:/tmp/django_db_ssl_verify.py"
+        docker exec "$CONTAINER" bash -c '
+          set -euo pipefail
+          py=""
+          if command -v a2c-manage >/dev/null 2>&1; then
+            shebang=$(head -n1 "$(command -v a2c-manage)")
+            case "$shebang" in
+              "#!"*)
+                rest=${shebang:2}
+                set -- $rest
+                if [[ "${1##*/}" == "env" ]]; then
+                  interp=$2
+                else
+                  interp=$1
+                fi
+                if command -v "$interp" >/dev/null 2>&1; then
+                  interp=$(command -v "$interp")
+                fi
+                if [[ -x "$interp" ]] && "$interp" -c "import django" >/dev/null 2>&1; then
+                  py="$interp"
+                fi
+                ;;
+            esac
+          fi
+          if [[ -z "$py" ]]; then
+            for cand in python3 python3.9 python3.11 python3.12 \
+              /usr/bin/python3 /usr/bin/python3.9 \
+              /opt/acme2certifier/venv/bin/python3 \
+              /var/www/acme2certifier/venv/bin/python3; do
+              if command -v "$cand" >/dev/null 2>&1; then
+                cand=$(command -v "$cand")
+              fi
+              if [[ -x "$cand" ]] && "$cand" -c "import django" >/dev/null 2>&1; then
+                py="$cand"
+                break
+              fi
+            done
+          fi
+          if [[ -z "$py" ]]; then
+            echo "ERROR: no Python interpreter with django found" >&2
+            exit 1
+          fi
+          echo "Using $py for Django TLS session check"
+          "$py" /tmp/django_db_ssl_verify.py
+        '
+      shell: bash

--- a/.github/actions/wf_specific/django/django_db_ssl_verify/action.yml
+++ b/.github/actions/wf_specific/django/django_db_ssl_verify/action.yml
@@ -17,6 +17,18 @@ runs:
           "${CONTAINER}:/tmp/django_db_ssl_verify.py"
         docker exec "$CONTAINER" bash -c '
           set -euo pipefail
+          APP_ROOT=""
+          for cand in /opt/acme2certifier /var/www/acme2certifier; do
+            if [[ -d "$cand/acme2certifier/django_project" ]]; then
+              APP_ROOT="$cand"
+              break
+            fi
+          done
+          if [[ -n "$APP_ROOT" ]]; then
+            export PYTHONPATH="${APP_ROOT}${PYTHONPATH:+:$PYTHONPATH}"
+            export ACME2CERTIFIER_BASE_DIR="${APP_ROOT}"
+            cd "$APP_ROOT"
+          fi
           py=""
           if command -v a2c-manage >/dev/null 2>&1; then
             shebang=$(head -n1 "$(command -v a2c-manage)")
@@ -32,7 +44,7 @@ runs:
                 if command -v "$interp" >/dev/null 2>&1; then
                   interp=$(command -v "$interp")
                 fi
-                if [[ -x "$interp" ]] && "$interp" -c "import django" >/dev/null 2>&1; then
+                if [[ -x "$interp" ]] && "$interp" -c "import django, acme2certifier.django_project" >/dev/null 2>&1; then
                   py="$interp"
                 fi
                 ;;
@@ -46,17 +58,35 @@ runs:
               if command -v "$cand" >/dev/null 2>&1; then
                 cand=$(command -v "$cand")
               fi
-              if [[ -x "$cand" ]] && "$cand" -c "import django" >/dev/null 2>&1; then
+              if [[ -x "$cand" ]] && "$cand" -c "import django, acme2certifier.django_project" >/dev/null 2>&1; then
                 py="$cand"
                 break
               fi
             done
           fi
           if [[ -z "$py" ]]; then
-            echo "ERROR: no Python interpreter with django found" >&2
+            echo "ERROR: no Python interpreter with django + acme2certifier.django_project found" >&2
             exit 1
           fi
           echo "Using $py for Django TLS session check"
+          app_user=""
+          for u in www-data nginx apache; do
+            if getent passwd "$u" >/dev/null 2>&1; then
+              app_user=$u
+              break
+            fi
+          done
+          for key in /opt/acme2certifier/volume/db-client-key.pem \
+            /var/www/acme2certifier/volume/db-client-key.pem; do
+            if [[ -f "$key" ]]; then
+              chmod 600 "$key"
+              if [[ -n "$app_user" ]]; then
+                chown "$app_user:$app_user" "$key"
+              fi
+              echo "PostgreSQL client key $key mode=$(stat -c %a:%U:%G "$key")"
+              break
+            fi
+          done
           "$py" /tmp/django_db_ssl_verify.py
         '
       shell: bash

--- a/.github/actions/wf_specific/vault_ca_handler/vault_prep/action.yml
+++ b/.github/actions/wf_specific/vault_ca_handler/vault_prep/action.yml
@@ -107,6 +107,23 @@ runs:
       docker exec vault vault operator unseal $UNSEAL_KEY_1
       docker exec vault vault operator unseal $UNSEAL_KEY_2
       docker exec vault vault operator unseal $UNSEAL_KEY_3
+
+      # Single-node Raft is unsealed before leader election finishes. Login
+      # against a standby with no active node returns HTTP 500.
+      # `vault status -format=json` has no ha_mode field; parse table output.
+      for i in $(seq 1 30); do
+        if docker exec vault vault status 2>/dev/null \
+          | grep -Eq 'HA Mode[[:space:]]+active'; then
+          break
+        fi
+        if [ "$i" -eq 30 ]; then
+          echo "Vault did not become the active Raft node after unseal"
+          docker exec vault vault status || true
+          exit 1
+        fi
+        sleep 1
+      done
+
       echo $ROOT_TOKEN | docker exec -i vault vault login -
 
       # Create root ca

--- a/.github/scripts/django_db_ssl_verify.py
+++ b/.github/scripts/django_db_ssl_verify.py
@@ -6,11 +6,30 @@ from __future__ import annotations
 import os
 import sys
 
+# RPM/DEB layouts keep the package on PYTHONPATH, not in site-packages.
+_APP_ROOTS = (
+    "/opt/acme2certifier",
+    "/var/www/acme2certifier",
+)
 
-def main() -> int:
+
+def _prepare_runtime() -> None:
+    """Make acme2certifier.django_project importable and set BASE_DIR."""
     os.environ.setdefault(
         "DJANGO_SETTINGS_MODULE", "acme2certifier.django_project.settings"
     )
+    for root in _APP_ROOTS:
+        django_project = os.path.join(root, "acme2certifier", "django_project")
+        if not os.path.isdir(django_project):
+            continue
+        if root not in sys.path:
+            sys.path.insert(0, root)
+        os.environ.setdefault("ACME2CERTIFIER_BASE_DIR", root)
+        return
+
+
+def main() -> int:
+    _prepare_runtime()
     import django
 
     django.setup()

--- a/.github/scripts/django_db_ssl_verify.py
+++ b/.github/scripts/django_db_ssl_verify.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Assert Django's live DATABASES['default'] session is TLS-encrypted."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    os.environ.setdefault(
+        "DJANGO_SETTINGS_MODULE", "acme2certifier.django_project.settings"
+    )
+    import django
+
+    django.setup()
+    from django.db import connection
+
+    vendor = connection.vendor
+    with connection.cursor() as cursor:
+        if vendor == "mysql":
+            cursor.execute("SHOW STATUS LIKE 'Ssl_cipher'")
+            row = cursor.fetchone()
+            cipher = (row[1] if row else "") or ""
+            if not str(cipher).strip():
+                print(
+                    "ERROR: Django MariaDB session is not TLS-encrypted "
+                    "(Ssl_cipher empty)",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"Django MariaDB TLS cipher={cipher}")
+            return 0
+        if vendor == "postgresql":
+            cursor.execute(
+                "SELECT ssl, version, cipher FROM pg_stat_ssl "
+                "WHERE pid = pg_backend_pid()"
+            )
+            row = cursor.fetchone()
+            ssl_on = bool(row[0]) if row else False
+            if not ssl_on:
+                print(
+                    "ERROR: Django PostgreSQL session is not TLS-encrypted "
+                    f"(pg_stat_ssl={row!r})",
+                    file=sys.stderr,
+                )
+                return 1
+            print(
+                f"Django PostgreSQL TLS ssl={row[0]} version={row[1]} "
+                f"cipher={row[2]}"
+            )
+            return 0
+    print(f"ERROR: unsupported Django DB vendor {vendor!r}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/patch_django_db_ssl.py
+++ b/.github/scripts/patch_django_db_ssl.py
@@ -8,6 +8,11 @@ import sys
 from pathlib import Path
 
 
+def _client_material_paths(ca_runtime_path: str) -> tuple[str, str]:
+    parent = Path(ca_runtime_path).parent
+    return str(parent / "db-client-cert.pem"), str(parent / "db-client-key.pem")
+
+
 def _patch_mariadb(text: str, ca_runtime_path: str) -> str:
     ssl_snippet = f'"ssl": {{"ca": "{ca_runtime_path}"}}'
     if ssl_snippet in text:
@@ -25,18 +30,22 @@ def _patch_mariadb(text: str, ca_runtime_path: str) -> str:
 def _patch_psql(text: str, ca_runtime_path: str) -> str:
     if '"sslmode"' in text and "sslrootcert" in text:
         return text
+    sslcert, sslkey = _client_material_paths(ca_runtime_path)
     options = (
         '        "OPTIONS": {\n'
         '            "sslmode": "verify-ca",\n'
         f'            "sslrootcert": "{ca_runtime_path}",\n'
+        f'            "sslcert": "{sslcert}",\n'
+        f'            "sslkey": "{sslkey}",\n'
         "        },\n"
     )
     needle = '"PORT": "",\n'
     if needle in text:
         return text.replace(needle, needle + options, 1)
-    needle_alt = '"PORT": "",'
-    if needle_alt in text:
-        return text.replace(needle_alt, needle_alt + "\n" + options.rstrip("\n"), 1)
+    if '"PORT": "",' in text:
+        return text.replace(
+            '"PORT": "",', '"PORT": "",\n' + options.rstrip("\n"), 1
+        )
     raise SystemExit("PostgreSQL settings: expected PORT key to inject OPTIONS")
 
 

--- a/.github/scripts/patch_django_db_ssl.py
+++ b/.github/scripts/patch_django_db_ssl.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Inject Django DATABASES TLS OPTIONS for CI MariaDB/PostgreSQL settings files."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _patch_mariadb(text: str, ca_runtime_path: str) -> str:
+    ssl_snippet = f'"ssl": {{"ca": "{ca_runtime_path}"}}'
+    if ssl_snippet in text:
+        return text
+    needle = '"use_unicode": True,'
+    if needle not in text:
+        raise SystemExit("MariaDB settings: expected OPTIONS use_unicode key")
+    return text.replace(
+        needle,
+        needle + f"\n            {ssl_snippet},",
+        1,
+    )
+
+
+def _patch_psql(text: str, ca_runtime_path: str) -> str:
+    if '"sslmode"' in text and "sslrootcert" in text:
+        return text
+    options = (
+        '        "OPTIONS": {\n'
+        '            "sslmode": "verify-ca",\n'
+        f'            "sslrootcert": "{ca_runtime_path}",\n'
+        "        },\n"
+    )
+    needle = '"PORT": "",\n'
+    if needle in text:
+        return text.replace(needle, needle + options, 1)
+    needle_alt = '"PORT": "",'
+    if needle_alt in text:
+        return text.replace(needle_alt, needle_alt + "\n" + options.rstrip("\n"), 1)
+    raise SystemExit("PostgreSQL settings: expected PORT key to inject OPTIONS")
+
+
+def patch_file(path: Path, django_db: str, ca_runtime_path: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if django_db == "mariadb":
+        updated = _patch_mariadb(text, ca_runtime_path)
+    elif django_db == "psql":
+        updated = _patch_psql(text, ca_runtime_path)
+    else:
+        raise SystemExit(f"unsupported DJANGO_DB={django_db} (expected mariadb|psql)")
+    if updated == text:
+        print(f"already patched: {path}")
+        return
+    path.write_text(updated, encoding="utf-8")
+    print(f"patched TLS OPTIONS: {path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--django-db",
+        required=True,
+        choices=("mariadb", "psql"),
+    )
+    parser.add_argument(
+        "--ca-runtime-path",
+        required=True,
+        help="Path Django opens at runtime (inside the a2c container/host)",
+    )
+    parser.add_argument(
+        "settings_files",
+        nargs="+",
+        type=Path,
+        help="settings.py file(s) to patch",
+    )
+    args = parser.parse_args()
+    for settings in args.settings_files:
+        if not settings.is_file():
+            raise SystemExit(f"settings file not found: {settings}")
+        patch_file(settings, args.django_db, args.ca_runtime_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/xca_sqlite_dump.py
+++ b/.github/scripts/xca_sqlite_dump.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Dump an XCA SQLite database as MariaDB- or PostgreSQL-compatible SQL.
+
+GitHub-hosted sqlite3 is often 3.45.x: `.dump` emits `unistr()` / `char(10)` and
+has no `--escape off`. Neither MariaDB nor PostgreSQL accept that dump as-is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from typing import Any, Optional, TextIO
+
+
+def sql_literal(value: Any) -> str:
+    """Render a Python value as an SQL literal (UTF-8 strings, hex blobs)."""
+    if value is None:
+        return "NULL"
+    if isinstance(value, bytes):
+        return "X'" + value.hex() + "'"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def dump_xca_sqlite(xdb_path: str, dialect: str, out: TextIO) -> None:
+    """Write CREATE/INSERT/VIEW/INDEX statements for *xdb_path* to *out*."""
+    if dialect not in ("mysql", "postgresql"):
+        raise ValueError(f"unsupported dialect {dialect}")
+
+    con = sqlite3.connect(f"file:{xdb_path}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+    try:
+        if dialect == "mysql":
+            out.write("SET SESSION SQL_MODE='ANSI';\n")
+            out.write("SET NAMES utf8mb4;\n")
+            out.write("SET FOREIGN_KEY_CHECKS=0;\n")
+
+        objects = con.execute(
+            "SELECT type, name, sql FROM sqlite_master "
+            "WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%' "
+            "ORDER BY rowid"
+        ).fetchall()
+        for type_, name, sql in objects:
+            statement = sql.rstrip().rstrip(";") + ";\n"
+            out.write(statement)
+            if type_ != "table":
+                continue
+            col_info = con.execute(f'PRAGMA table_info("{name}")').fetchall()
+            columns = [row["name"] for row in col_info]
+            quoted_cols = ", ".join(f'"{col}"' for col in columns)
+            for row in con.execute(f'SELECT * FROM "{name}"'):
+                values = ", ".join(sql_literal(row[col]) for col in columns)
+                out.write(
+                    f'INSERT INTO "{name}" ({quoted_cols}) VALUES ({values});\n'
+                )
+
+        if dialect == "mysql":
+            out.write("SET FOREIGN_KEY_CHECKS=1;\n")
+    finally:
+        con.close()
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("xdb", help="Path to the XCA SQLite database")
+    parser.add_argument(
+        "--dialect",
+        choices=("mysql", "postgresql"),
+        required=True,
+        help="Target SQL dialect",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="-",
+        help="Output file (default: stdout)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.output == "-":
+        dump_xca_sqlite(args.xdb, args.dialect, sys.stdout)
+        return 0
+    with open(args.output, "w", encoding="utf-8", newline="\n") as handle:
+        dump_xca_sqlite(args.xdb, args.dialect, handle)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ and pick the appropriate release branch.
 **New Features**:
 
 - Options `[Challenge] http_01_support`, `dns_01_support`, and `tls_alpn_01_support` to disable individual RFC 8555 challenge types (enabled by default for backwards compatibility) ([#377](https://github.com/grindsa/acme2certifier/issues/377)); per-account overrides via EAB profile `challenge` section
+- [HARICA CertManager](docs/harica.md) REST CA handler (`harica_ca_handler`) for SSL enrollment against prevalidated domains (login/2FA, poll, optional `auto_approve`, revoke); credentials via `requester_*` / `approver_*` or matching `*_variable` environment variable names
+- [`a2c-harica-totp`](docs/harica.md) CLI to print the current CertManager TOTP code from configured seeds (portal login / troubleshooting)
+- [XCA CA handler](docs/xca.md) can use the same MySQL/MariaDB or PostgreSQL database as the XCA GUI (`xdb_engine`, `xdb_host` / `xdb_name` / `xdb_user` / `xdb_password`, optional table prefix and TLS); SQLite `.xdb` remains the default ([#386](https://github.com/grindsa/acme2certifier/issues/386))
+
+## Changes in 0.45.3
 
 **Bug Fixes and Improvements**:
 

--- a/docs/a2c-alma-loadbalancing.md
+++ b/docs/a2c-alma-loadbalancing.md
@@ -542,7 +542,7 @@ python3 -m acme2certifier.tools.a2c_django_secret_keygen
 - modify `/opt/acme2certifier/acme2certifier/django_project/settings.py` and
   - insert the secret-key created in the previous step
   - update the 'ALLOWED_HOSTS'- section with both ip-address and fqdn of the node
-  - configure a connection to mariadb as shown below
+  - configure a connection to mariadb as shown below. Optional TLS (`ssl` / `sslmode` in `OPTIONS`) is documented in [external database support](external_database_support.md#encrypting-the-django-database-connection-tls).
 
 ```python
 SECRET_KEY = "+%*lei)yj9b841=2d5(u)a&7*uwi@l99$(*&ong@g*p1%q)g$e"
@@ -625,7 +625,7 @@ python3 -m acme2certifier.tools.a2c_django_secret_keygen
 - modify `/opt/acme2certifier/acme2certifier/django_project/settings.py` and
   - insert a secret key created in the previous step
   - update the 'ALLOWED_HOSTS'- section with both IP-Adress and fqdn of the node
-  - configure a connection to mariadb as shown below
+  - configure a connection to mariadb as shown below. Optional TLS (`ssl` / `sslmode` in `OPTIONS`) is documented in [external database support](external_database_support.md#encrypting-the-django-database-connection-tls).
 
 ```python
 SECRET_KEY = "5@@wlvvi!hb(6qc%*77j55@jt8ib4^f1o&+pz-^z*#v3e7u3o!"

--- a/docs/a2c-ubuntu-loadbalancing.md
+++ b/docs/a2c-ubuntu-loadbalancing.md
@@ -541,7 +541,7 @@ python3 -m acme2certifier.tools.a2c_django_secret_keygen
 - modify `/var/www/acme2certifier/acme2certifier/django_project/settings.py` and
   - insert the secret-key created in the previous step
   - update the 'ALLOWED_HOSTS'- section with both ip-address and fqdn of the node
-  - configure a connection to mariadb as shown below
+  - configure a connection to mariadb as shown below. Optional TLS (`ssl` / `sslmode` in `OPTIONS`) is documented in [external database support](external_database_support.md#encrypting-the-django-database-connection-tls).
 
 ```python
 SECRET_KEY = "+%*lei)yj9b841=2d5(u)a&7*uwi@l99$(*&ong@g*p1%q)g$e"
@@ -624,7 +624,7 @@ python3 -m acme2certifier.tools.a2c_django_secret_keygen
 - modify `/var/www/acme2certifier/acme2certifier/django_project/settings.py` and
   - insert a secret key created in the previous step
   - update the 'ALLOWED_HOSTS'- section with both IP-Adress and fqdn of the node
-  - configure a connection to mariadb as shown below
+  - configure a connection to mariadb as shown below. Optional TLS (`ssl` / `sslmode` in `OPTIONS`) is documented in [external database support](external_database_support.md#encrypting-the-django-database-connection-tls).
 
 ```python
 SECRET_KEY = "5@@wlvvi!hb(6qc%*77j55@jt8ib4^f1o&+pz-^z*#v3e7u3o!"

--- a/docs/external_database_support.md
+++ b/docs/external_database_support.md
@@ -186,6 +186,31 @@ DATABASES = {
 }
 ```
 
+### Encrypting the Django database connection (TLS)
+
+Place the database server CA (PEM) on the acme2certifier volume (for example `/var/www/acme2certifier/volume/db-ca.pem` or `/opt/acme2certifier/volume/db-ca.pem` on RPM) and point Django at it. The DB server must present a certificate signed by that CA. There is no `acme_srv.cfg` key for this; it lives in `DATABASES['OPTIONS']` only. Client-certificate (mTLS) authentication is not used.
+
+**MariaDB** — encrypt and verify the server certificate (`verify-ca`; no hostname check). Add `"ssl"` to the existing `OPTIONS` dict:
+
+```python
+"OPTIONS": {
+    "init_command": "SET sql_mode='STRICT_TRANS_TABLES', innodb_strict_mode=1",
+    "charset": "utf8mb4",
+    "use_unicode": True,
+    "ssl": {"ca": "/var/www/acme2certifier/volume/db-ca.pem"},
+    # Optional hostname check (mysqlclient): "ssl_mode": "VERIFY_IDENTITY",
+}
+```
+
+**PostgreSQL** — add `OPTIONS` with `sslmode` `verify-ca` (or `verify-full` to also check the hostname):
+
+```python
+"OPTIONS": {
+    "sslmode": "verify-ca",
+    "sslrootcert": "/var/www/acme2certifier/volume/db-ca.pem",
+}
+```
+
 ## Finalize acme2certifier configuration
 
 - Modify the [configuration file](acme_srv.md) `/var/www/acme2certifier/volume/acme_srv.cfg` according to your needs. If your CA handler needs runtime information (configuration files, keys, certificate bundles, etc.) to be shared between (cluster) nodes, ensure they are loaded from `/var/www/acme2certifier/volume`. Below is an example `[CAhandler]` section for the OpenSSL handler:

--- a/docs/external_database_support.md
+++ b/docs/external_database_support.md
@@ -202,12 +202,26 @@ Place the database server CA (PEM) on the acme2certifier volume (for example `/v
 }
 ```
 
-**PostgreSQL** — add `OPTIONS` with `sslmode` `verify-ca` (or `verify-full` to also check the hostname):
+**PostgreSQL** — add `OPTIONS` with `sslmode` `verify-ca` (or `verify-full` to also check the hostname). Use **absolute** paths only. libpq otherwise probes `$HOME/.postgresql/postgresql.crt`; after Apache/uWSGI `setuid` that is often `/root/.postgresql/postgresql.crt` and fails with `Permission denied`.
+
+On libpq 17+ disable the client-cert probe:
 
 ```python
 "OPTIONS": {
     "sslmode": "verify-ca",
     "sslrootcert": "/var/www/acme2certifier/volume/db-ca.pem",
+    "sslcertmode": "disable",
+}
+```
+
+On older libpq, set `sslcert` and `sslkey` to absolute files so the default `~/.postgresql/` paths are never used (the server does not need to require client certs). libpq rejects a key with group/world access: `chmod 600` the key and make it readable by the Apache/uWSGI user (`www-data` or `nginx`).
+
+```python
+"OPTIONS": {
+    "sslmode": "verify-ca",
+    "sslrootcert": "/var/www/acme2certifier/volume/db-ca.pem",
+    "sslcert": "/var/www/acme2certifier/volume/db-client-cert.pem",
+    "sslkey": "/var/www/acme2certifier/volume/db-client-key.pem",
 }
 ```
 

--- a/docs/xca.md
+++ b/docs/xca.md
@@ -5,15 +5,17 @@
 
 # Support for XCA-Based Certificate Authorities
 
-This handler allows **acme2certifier** to store **certificates** and **requests** in an [XCA](https://github.com/chris2511/xca/) SQLite database.
+This handler allows **acme2certifier** to store **certificates** and **requests** in an [XCA](https://github.com/chris2511/xca/) database — either a local SQLite `.xdb` file or the same [MySQL/MariaDB or PostgreSQL](https://www.hohnstaedt.de/xca/index.php/documentation/remote-databases) database the XCA GUI already uses.
 
 It also supports fetching **enrollment templates** from XCA and applying them to **certificate signing requests (CSRs)**.
+
+This is the **XCA schema** (`items`, `certs`, `view_certs`, …), not Django ACME storage. For ACME account/order data see [External database support](external_database_support.md).
 
 ## Prerequisites
 
 To use this handler, you need:
 
-- A **preconfigured XCA database** with **CA certificates** and **keys** imported.
+- A **preconfigured XCA database** with **CA certificates** and **keys** imported. acme2certifier does **not** create the XCA schema; initialize the store with the XCA GUI or CLI first.
 - The **Internal Name** of the Certificate Authority, as shown in the XCA application.
 
 ![xca-ca-list](xca-ca-list.png)
@@ -31,11 +33,13 @@ handler_module: acme2certifier.cahandlers.xca_ca_handler
 
 See [Upgrading](upgrading.md).
 
-### 2. Ensure Database Accessibility
+### 2. Ensure Database Accessibility (SQLite)
 
 - Place the **XCA database** in a directory accessible to **acme2certifier**.
 - Set ownership to the user running the web services.
 - Restrict permissions to prevent unauthorized access.
+
+For MySQL/MariaDB or PostgreSQL, skip this step and use the [remote database](#remote-database-mysqlmariadb-or-postgresql) settings below.
 
 ### 3. Modify the Server Configuration
 
@@ -55,17 +59,79 @@ template_name: XCA template to be applied to CSRs
 
 ### Parameter Explanations
 
-- **xdb_file** – Path to the **XCA database**.
-- **xdb_permission** *(optional)* – **File permissions** for the XCA database (default: `660`).
+- **xdb_file** – Path to the **XCA SQLite database** (`.xdb`). Mutually exclusive with a remote `xdb_engine`.
+- **xdb_permission** *(optional)* – **File permissions** for the SQLite XCA database (default: `660`). Ignored for remote engines.
 - **issuing_ca_name** – **XCA name** of the CA used for certificate issuance.
 - **issuing_ca_key** – **XCA name** of the key used to sign certificates. If not set, it defaults to the value in `issuing_ca_name`.
-- **passphrase_variable** *(optional)* – Environment variable containing the **passphrase** to decrypt the CA key (overridden if `passphrase` is set).
-- **passphrase** *(optional)* – **Passphrase** to access the database and decrypt the private CA key.
+- **passphrase_variable** *(optional)* – Environment variable containing the **passphrase** to decrypt the CA key (overridden if `passphrase` is set). This is **not** the SQL login password.
+- **passphrase** *(optional)* – **Passphrase** to decrypt the private CA key stored in XCA.
 - **ca_cert_chain_list** *(optional)* – List of **root and intermediate CA certificates** to be included in the bundle returned to an ACME client (**do not include the issuing CA certificate**).
 - **template_name** *(optional)* – Name of the **XCA template** to be applied during certificate issuance.
 - **allowed_domainlist** *(optional)* – List of allowed **domain names** for enrollment (JSON format). Example: `["bar.local", "bar.foo.local"]` (default: `[]`).
 - **enrollment_config_log** *(optional)* – Enable logging of enrollment parameters (default: `False`).
 - **enrollment_config_log_skip_list** *(optional)* – List of **enrollment parameters** to exclude from logs (JSON format). Example: `["parameter1", "parameter2"]` (default: `[]`).
+
+## Remote database (MySQL/MariaDB or PostgreSQL)
+
+Use this when the [XCA GUI runs off-server](https://www.hohnstaedt.de/xca/index.php/documentation/remote-databases) against a shared SQL database. acme2certifier talks to the **same** XCA tables; it does not create them.
+
+Install the matching Python driver if it is not already present (Django PostgreSQL already ships `psycopg2`; Django MySQL/`mysqlclient` is **not** a substitute for PyMySQL):
+
+```bash
+pip install PyMySQL
+# or
+pip install psycopg2-binary
+```
+
+Do **not** set `xdb_file` together with a remote engine.
+
+```ini
+[CAhandler]
+handler_module: acme2certifier.cahandlers.xca_ca_handler
+xdb_engine: mysql
+xdb_host: 10.1.0.1
+xdb_port: 3306
+xdb_name: xca
+xdb_user: youruser
+xdb_password_variable: XCA_DB_PASSWORD
+xdb_table_prefix:
+xdb_ssl_ca: /path/cacert.pem
+xdb_ssl_mode: verify-ca
+issuing_ca_name: sub-ca
+issuing_ca_key: sub-ca-key
+passphrase_variable: XCA_PASSPHRASE
+ca_cert_chain_list: ["root-ca"]
+```
+
+PostgreSQL example (`xdb_engine: postgresql`; `postgres` and `pgsql` are accepted aliases). `mariadb` is treated as `mysql`.
+
+### Remote parameters
+
+- **xdb_engine** – `sqlite` (default), `mysql`, `mariadb`, or `postgresql`.
+- **xdb_host** / **xdb_port** / **xdb_name** / **xdb_user** – SQL connection. Host, database name, and user are required for remote engines.
+- **xdb_password_variable** / **xdb_password** – SQL login password (same `*_variable` overwrite rules as `passphrase`). Distinct from the CA-key **passphrase**.
+- **xdb_table_prefix** *(optional)* – XCA table prefix (`user@host/TYPE:dbname#prefix` in the XCA dialog). Concatenated in front of every XCA table and view (`items` → `prefixitems`, `view_certs` → `prefixview_certs`). Put an underscore in the value if you want one.
+- **xdb_ssl_ca** / **xdb_ssl_mode** *(optional)* – TLS CA file and mode (`verify-ca` / `verify-full` for MySQL hostname checks; PostgreSQL `sslmode` values such as `require`, `verify-ca`, `verify-full`).
+
+XCA connection-dialog mapping: user → `xdb_user`, host → `xdb_host`, `QMYSQL`/`QPSQL` → `mysql`/`postgresql`, database → `xdb_name`, `#prefix` → `xdb_table_prefix`.
+
+Do not store Django ACME tables and an unprefixed XCA schema in the same database; use `xdb_table_prefix` (or a dedicated database) if they share a server.
+
+### Importing an existing SQLite `.xdb`
+
+Follow [XCA Remote Databases](https://www.hohnstaedt.de/xca/index.php/documentation/remote-databases), with one extra step on SQLite 3.44+: `.dump` emits `unistr()`, which MariaDB/MySQL do not implement.
+
+```bash
+sqlite3 --escape off your.xdb .dump > dump.sql
+```
+
+Then apply the XCA MySQL edits (drop `PRAGMA` / `BEGIN TRANSACTION`, add `SET SESSION SQL_MODE='ANSI';`) and import:
+
+```bash
+mariadb -u root -p xca < dump.sql
+```
+
+`--escape off` writes control characters (newlines in item comments) as literal bytes instead of `unistr('\u000a')`. If a dump already contains `unistr()`, replace those calls before import — `\u000a` is a newline (`CHAR(10)`). PostgreSQL provides `unistr()` and does not need this change.
 
 ## Template Support
 

--- a/docs/xca.md
+++ b/docs/xca.md
@@ -119,19 +119,22 @@ Do not store Django ACME tables and an unprefixed XCA schema in the same databas
 
 ### Importing an existing SQLite `.xdb`
 
-Follow [XCA Remote Databases](https://www.hohnstaedt.de/xca/index.php/documentation/remote-databases), with one extra step on SQLite 3.44+: `.dump` emits `unistr()`, which MariaDB/MySQL do not implement.
+Follow [XCA Remote Databases](https://www.hohnstaedt.de/xca/index.php/documentation/remote-databases), with one extra step on SQLite 3.44+: `.dump` emits `unistr()` / `char(10)`, which MariaDB/MySQL and PostgreSQL do not accept as-is.
+
+Prefer a newer sqlite CLI (`sqlite3 --escape off your.xdb .dump`) or dump via Python so strings keep literal newlines:
 
 ```bash
-sqlite3 --escape off your.xdb .dump > dump.sql
+python3 .github/scripts/xca_sqlite_dump.py --dialect mysql your.xdb -o dump.sql
+# or --dialect postgresql
 ```
 
-Then apply the XCA MySQL edits (drop `PRAGMA` / `BEGIN TRANSACTION`, add `SET SESSION SQL_MODE='ANSI';`) and import:
+Then import:
 
 ```bash
 mariadb -u root -p xca < dump.sql
 ```
 
-`--escape off` writes control characters (newlines in item comments) as literal bytes instead of `unistr('\u000a')`. If a dump already contains `unistr()`, replace those calls before import — `\u000a` is a newline (`CHAR(10)`). PostgreSQL provides `unistr()` and does not need this change.
+`--escape off` writes control characters (newlines in item comments) as literal bytes instead of `unistr('\u000a')`. If a dump already contains `unistr()`, replace those calls before import — `\u000a` is a newline (`CHAR(10)` in MariaDB, `chr(10)` in PostgreSQL).
 
 ## Template Support
 

--- a/examples/django/settings.py
+++ b/examples/django/settings.py
@@ -76,6 +76,9 @@ DATABASES = {
             "init_command": "SET sql_mode='STRICT_TRANS_TABLES', innodb_strict_mode=1",
             "charset": "utf8mb4",
             "use_unicode": True,
+            # TLS: place the DB server CA on the volume and uncomment.
+            # "ssl": {"ca": "/var/www/acme2certifier/volume/db-ca.pem"},
+            # Optional hostname check (mysqlclient): "ssl_mode": "VERIFY_IDENTITY",
         },
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ full = [
     "requests_gssapi",
     "requests_ntlm",
     "Django",
+    "PyMySQL",
+    "psycopg2-binary",
 ]
 test = [
     "pytest",

--- a/test/test_django_db_ssl_verify.py
+++ b/test/test_django_db_ssl_verify.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""tests for .github/scripts/django_db_ssl_verify.py"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".github", "scripts"))
+
+import django_db_ssl_verify  # noqa: E402
+
+
+def _run_with_connection(vendor: str, fetchone) -> int:
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetchone
+    ctx = MagicMock()
+    ctx.__enter__.return_value = cursor
+    ctx.__exit__.return_value = False
+    connection = SimpleNamespace(vendor=vendor, cursor=lambda: ctx)
+    django_mock = MagicMock()
+    db_mod = SimpleNamespace(connection=connection)
+    with (
+        patch.dict("sys.modules", {"django": django_mock, "django.db": db_mod}),
+        patch.object(django_mock, "setup"),
+    ):
+        return django_db_ssl_verify.main()
+
+
+def test_mysql_cipher_ok() -> None:
+    """Non-empty Ssl_cipher is success."""
+    assert _run_with_connection("mysql", ("Ssl_cipher", "TLS_AES_256_GCM_SHA384")) == 0
+
+
+def test_mysql_empty_cipher_fails() -> None:
+    """Empty Ssl_cipher fails the check."""
+    assert _run_with_connection("mysql", ("Ssl_cipher", "")) == 1
+
+
+def test_postgresql_ssl_true() -> None:
+    """pg_stat_ssl ssl=true is success."""
+    assert (
+        _run_with_connection("postgresql", (True, "TLSv1.3", "TLS_AES_256_GCM_SHA384"))
+        == 0
+    )
+
+
+def test_postgresql_ssl_false_fails() -> None:
+    """pg_stat_ssl ssl=false fails the check."""
+    assert _run_with_connection("postgresql", (False, None, None)) == 1
+
+
+def test_unsupported_vendor_fails() -> None:
+    """Unknown Django vendor fails closed."""
+    assert _run_with_connection("sqlite", None) == 1

--- a/test/test_django_db_ssl_verify.py
+++ b/test/test_django_db_ssl_verify.py
@@ -25,6 +25,7 @@ def _run_with_connection(vendor: str, fetchone) -> int:
     with (
         patch.dict("sys.modules", {"django": django_mock, "django.db": db_mod}),
         patch.object(django_mock, "setup"),
+        patch.object(django_db_ssl_verify, "_prepare_runtime"),
     ):
         return django_db_ssl_verify.main()
 
@@ -55,3 +56,21 @@ def test_postgresql_ssl_false_fails() -> None:
 def test_unsupported_vendor_fails() -> None:
     """Unknown Django vendor fails closed."""
     assert _run_with_connection("sqlite", None) == 1
+
+
+def test_prepare_runtime_adds_app_root(tmp_path, monkeypatch) -> None:
+    """RPM/DEB APP_ROOT is prepended so django_project can be imported."""
+    root = tmp_path / "opt" / "acme2certifier"
+    (root / "acme2certifier" / "django_project").mkdir(parents=True)
+    monkeypatch.setattr(
+        django_db_ssl_verify, "_APP_ROOTS", (str(root), "/no/such/root")
+    )
+    monkeypatch.delenv("ACME2CERTIFIER_BASE_DIR", raising=False)
+    monkeypatch.delenv("DJANGO_SETTINGS_MODULE", raising=False)
+    django_db_ssl_verify._prepare_runtime()
+    assert sys.path[0] == str(root)
+    assert os.environ["ACME2CERTIFIER_BASE_DIR"] == str(root)
+    assert (
+        os.environ["DJANGO_SETTINGS_MODULE"]
+        == "acme2certifier.django_project.settings"
+    )

--- a/test/test_patch_django_db_ssl.py
+++ b/test/test_patch_django_db_ssl.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""tests for .github/scripts/patch_django_db_ssl.py"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".github", "scripts"))
+
+from patch_django_db_ssl import patch_file  # noqa: E402
+
+_CA = "/var/www/acme2certifier/volume/db-ca.pem"
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def test_patch_mariadb_injects_ssl(tmp_path: Path) -> None:
+    """MariaDB OPTIONS gain ssl.ca pointing at the runtime CA path."""
+    src = _REPO / ".github" / "django_settings_mariadb.py"
+    dest = tmp_path / "settings.py"
+    dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    patch_file(dest, "mariadb", _CA)
+    text = dest.read_text(encoding="utf-8")
+    assert f'"ssl": {{"ca": "{_CA}"}}' in text
+    patch_file(dest, "mariadb", _CA)
+    assert text.count('"ssl"') == dest.read_text(encoding="utf-8").count('"ssl"')
+
+
+def test_patch_psql_injects_sslmode(tmp_path: Path) -> None:
+    """PostgreSQL DATABASES gain sslmode verify-ca and sslrootcert."""
+    src = _REPO / ".github" / "django_settings_psql.py"
+    dest = tmp_path / "settings.py"
+    dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    patch_file(dest, "psql", _CA)
+    text = dest.read_text(encoding="utf-8")
+    assert '"sslmode": "verify-ca"' in text
+    assert f'"sslrootcert": "{_CA}"' in text
+    patch_file(dest, "psql", _CA)
+    assert text.count("sslrootcert") == dest.read_text(encoding="utf-8").count(
+        "sslrootcert"
+    )
+
+
+def test_patch_rejects_unknown_engine(tmp_path: Path) -> None:
+    """Unsupported DJANGO_DB values fail closed."""
+    dest = tmp_path / "settings.py"
+    dest.write_text("DATABASES = {}\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        patch_file(dest, "mssql", _CA)

--- a/test/test_patch_django_db_ssl.py
+++ b/test/test_patch_django_db_ssl.py
@@ -38,10 +38,12 @@ def test_patch_psql_injects_sslmode(tmp_path: Path) -> None:
     text = dest.read_text(encoding="utf-8")
     assert '"sslmode": "verify-ca"' in text
     assert f'"sslrootcert": "{_CA}"' in text
+    assert '"sslcert": "/var/www/acme2certifier/volume/db-client-cert.pem"' in text
+    assert '"sslkey": "/var/www/acme2certifier/volume/db-client-key.pem"' in text
+    assert "HOME" not in text
     patch_file(dest, "psql", _CA)
-    assert text.count("sslrootcert") == dest.read_text(encoding="utf-8").count(
-        "sslrootcert"
-    )
+    twice = dest.read_text(encoding="utf-8")
+    assert twice.count("sslrootcert") == text.count("sslrootcert")
 
 
 def test_patch_rejects_unknown_engine(tmp_path: Path) -> None:

--- a/test/test_xca_sqlite_dump.py
+++ b/test/test_xca_sqlite_dump.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""tests for .github/scripts/xca_sqlite_dump.py"""
+
+import io
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".github", "scripts"))
+
+from xca_sqlite_dump import dump_xca_sqlite  # noqa: E402
+
+
+def _xdb_path() -> str:
+    return os.path.join(os.path.dirname(__file__), "ca", "acme2certifier-clean.xdb")
+
+
+class TestXcaSqliteDump(unittest.TestCase):
+    """CI import helper must not emit sqlite-only dump functions."""
+
+    def test_001_mysql_dump_has_no_unistr(self):
+        """mysql dump uses literal newlines instead of unistr()/char()"""
+        buf = io.StringIO()
+        dump_xca_sqlite(_xdb_path(), "mysql", buf)
+        sql = buf.getvalue()
+        self.assertIn("SET SESSION SQL_MODE='ANSI';", sql)
+        self.assertNotIn("unistr(", sql)
+        self.assertNotIn("char(10)", sql.lower())
+        self.assertIn("INSERT INTO \"items\"", sql)
+        self.assertIn("wurde neu erstellt", sql)
+        self.assertIn("\n", sql)
+
+    def test_002_postgresql_dump_has_no_unistr(self):
+        """postgresql dump is free of sqlite dump helpers"""
+        buf = io.StringIO()
+        dump_xca_sqlite(_xdb_path(), "postgresql", buf)
+        sql = buf.getvalue()
+        self.assertNotIn("SET SESSION SQL_MODE", sql)
+        self.assertNotIn("unistr(", sql)
+        self.assertIn("CREATE TABLE items", sql)
+        self.assertIn("CREATE VIEW view_certs", sql)
+        self.assertGreater(sql.count("INSERT INTO"), 10)
+
+    def test_003_item_comment_keeps_newline(self):
+        """item comments retain the newline that sqlite dumps as unistr"""
+        buf = io.StringIO()
+        dump_xca_sqlite(_xdb_path(), "postgresql", buf)
+        self.assertRegex(
+            buf.getvalue(),
+            r"angewendet\)\n\(Der Schlüssel",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Django can encrypt MariaDB/PostgreSQL connections via DATABASES['OPTIONS'] (server CA verify; no acme_srv.cfg key, no mTLS).